### PR TITLE
Install Claude Code CLI in backend image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends nodejs npm git 
     && OPENCODE_INSTALL_DIR=/usr/local/bin sh -c 'curl -fsSL https://opencode.ai/install | bash' \
     && ln -sf /root/.opencode/bin/opencode /usr/local/bin/opencode \
     && opencode --version \
+    && npm install -g @anthropic-ai/claude-code \
+    && claude --version \
     && rm -rf /var/lib/apt/lists/* /root/.npm
 
 COPY requirements.txt .


### PR DESCRIPTION
## What
Adds `npm install -g @anthropic-ai/claude-code` to the backend Dockerfile (npm is already installed for the OpenCode setup) and verifies `claude --version` at build time.

## Why
`agent/pool.py` drives the `claude` CLI via `claude_agent_sdk`, and the dashboard's "Claude Code" connect card runs `CLAUDE_CONFIG_DIR=/opt/claude-users/<email> claude login` inside the container. The image shipped OpenCode but never the `claude` binary, so that flow failed with `bash: claude: command not found`.

## Test
Rebuild backend image; `claude --version` runs during build, and the dashboard `claude login` OAuth flow then proceeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)