### PR TITLE
Mount .env into backend so Environment admin can read it

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,9 @@ services:
       - "3000:3000"
     volumes:
       - loma-skill-assets:/var/lib/loma/skill-assets
+      # Mount the real .env so the dashboard Environment admin (/api/env) can read & edit it.
+      # env_file injects values into the process env, but does not place a file at /app/.env.
+      - ./.env:/app/.env
     restart: unless-stopped
 
   loma-dashboard:


### PR DESCRIPTION
## What
Bind-mount the host `.env` to `/app/.env` for `loma-backend` in `docker-compose.yml`.

## Why
The dashboard **Environment Variables** page (`GET /api/env`, `api/env_routes.py`) reads vars from a `.env` file at `/app/.env` via `dotenv_values()`. But `.env` is in `.dockerignore`, so it's never baked into the image, and `env_file:` only injects values into the *process environment* — it does not create a file at `/app/.env`. So the page showed **0 variables** even though the service was fully configured.

## Test
After `docker compose up -d`: `GET /api/env` returns the configured variables (sensitive ones masked), and the admin page populates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)