### PR TITLE
Persist connected Claude Code accounts across container recreation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,9 @@ services:
       # Mount the real .env so the dashboard Environment admin (/api/env) can read & edit it.
       # env_file injects values into the process env, but does not place a file at /app/.env.
       - ./.env:/app/.env
+      # Persist connected Claude Code accounts (CLAUDE_USERS_DIR) across container
+      # recreation — otherwise `claude login` creds are lost on every rebuild/redeploy.
+      - loma-claude-users:/opt/claude-users
     restart: unless-stopped
 
   loma-dashboard:
@@ -28,3 +31,4 @@ services:
 
 volumes:
   loma-skill-assets:
+  loma-claude-users:


### PR DESCRIPTION
## What
Add a named volume `loma-claude-users` mounted at `/opt/claude-users` for the backend.

## Why
`claude login` (the dashboard "Login with Claude" flow) writes OAuth creds to `/opt/claude-users/<email>` (`CLAUDE_USERS_DIR`, read by `agent/pool.py`). That path was on the container's ephemeral writable layer with no volume, so every `docker compose up -d --build` / redeploy discarded it — connected accounts vanished and the round-robin pool went empty on each restart.

## Test
After deploy: connect an account via "Login with Claude", then `docker compose up -d --build` again; the account remains connected (`/opt/claude-users/<email>/.claude.json` persists on the volume).

🤖 Generated with [Claude Code](https://claude.com/claude-code)