### PR TITLE
Restore operator gate on flow creation

### DIFF
--- a/api/flow_routes.py
+++ b/api/flow_routes.py
@@ -147,9 +147,7 @@ async def handle_get_flow(request: web.Request) -> web.Response:
 
 async def handle_create_flow(request: web.Request) -> web.Response:
     """POST /api/flows — create a new flow (scheduled or webhook-triggered)."""
-    # Flow creation is intentionally open: the dashboard chat agent creates flows
-    # via a local curl that bypasses the Next.js auth layer (no X-User-Email), so an
-    # operator gate blocked legitimate maintainers. No auth check here by design.
+    require_operator_or_above(request)
     db = get_db()
     if db is None:
         return web.json_response({"error": "DB not configured"}, status=503)


### PR DESCRIPTION
## What
Re-adds `require_operator_or_above(request)` to `handle_create_flow` in `api/flow_routes.py`.

## Why
PR #5 (the `.env` in-place write fix) unintentionally bundled a second change that removed the operator auth gate on `POST /api/flows` — it rode in via the branch's base. This restores the gate so `main` contains only the intended env fix.

The flow-creation auth change itself is preserved on branch `fix/open-flow-creation` for a separate, deliberate review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)