### PR TITLE
Install uv in backend image for the ClickHouse MCP server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends nodejs npm git 
     && opencode --version \
     && npm install -g @anthropic-ai/claude-code \
     && claude --version \
+    && pip install --no-cache-dir uv \
+    && uv --version \
     && rm -rf /var/lib/apt/lists/* /root/.npm
 
 COPY requirements.txt .


### PR DESCRIPTION
## What
Add `pip install uv` to the backend Dockerfile (verified with `uv --version` at build time).

## Why
The ClickHouse integration's MCP server launches via `uv run --with mcp-clickhouse --python 3.10 mcp-clickhouse`. `uv` was missing from the image, so the server failed to start and the agent reported no ClickHouse access even though the integration was connected and present in the OpenCode config.

## Test
After rebuild: `uv --version` runs; a fresh chat session can start the ClickHouse MCP server (first run downloads Python 3.10 + mcp-clickhouse via uv, then cached).

🤖 Generated with [Claude Code](https://claude.com/claude-code)