### PR TITLE
Pre-install npx-based MCP servers in the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends nodejs npm git 
     && claude --version \
     && pip install --no-cache-dir uv \
     && uv --version \
+    && npm install -g \
+        mongodb-mcp-server \
+        @notionhq/notion-mcp-server \
+        @hubspot/mcp-server \
+        @sentry/mcp-server \
+        @lishenxydlgzs/aws-athena-mcp \
     && rm -rf /var/lib/apt/lists/* /root/.npm
 
 COPY requirements.txt .


### PR DESCRIPTION
## What
Globally install the registry's npx-based MCP servers in the backend Dockerfile: `mongodb-mcp-server`, `@notionhq/notion-mcp-server`, `@hubspot/mcp-server`, `@sentry/mcp-server`, `@lishenxydlgzs/aws-athena-mcp`.

## Why
OpenCode launches MCP servers with `npx -y <bare-name>`. On a cold npx cache (every container rebuild), npm 9.x fails to install-and-run some packages by bare name — `npx -y mongodb-mcp-server` returns `sh: 1: mongodb-mcp-server: not found`, while `npx -y mongodb-mcp-server@1.13.0` works. So the MongoDB MCP server never spawned, `mongodb_find` was unavailable, and OpenCode stalled session warmup waiting on it ("loads forever").

Pre-installing globally makes `npx` resolve the bins from PATH instantly and reliably, and removes first-run download latency for the other servers too.

## Test
After rebuild: `npx -y mongodb-mcp-server --version` works on a cold cache; a fresh chat session can call `mongodb_find` and answer DB questions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)