### PR TITLE
Add CI-gated auto-deploy to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,3 +59,24 @@ jobs:
       - name: Build
         run: npm run build
         working-directory: dashboard
+
+  deploy:
+    needs: [public-content-scan, secret-scan, backend, dashboard]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: production
+    concurrency:
+      group: deploy-production
+      cancel-in-progress: false
+    steps:
+      - name: Deploy over SSH
+        env:
+          SSH_HOST: ${{ secrets.DEPLOY_SSH_HOST }}
+          SSH_USER: ${{ secrets.DEPLOY_SSH_USER }}
+          SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+        run: |
+          install -m 600 /dev/null key
+          printf '%s' "$SSH_KEY" > key
+          ssh -i key -o StrictHostKeyChecking=accept-new -o ConnectTimeout=20 \
+            "$SSH_USER@$SSH_HOST" \
+            'set -e; cd ~/loma; git fetch origin --prune; git reset --hard origin/main; bash scripts/deploy.sh'

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Build and (re)start the Loma stack, then verify both services respond.
+# Generic by design: contains no host/URL/secrets. Invoked by CI after the repo
+# has been fast-forwarded to origin/main on the server.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+echo "Deploying $(git rev-parse --short HEAD)"
+
+docker compose up -d --build
+
+# Liveness: backend (:3000, any HTTP code proves the aiohttp server is up) and
+# dashboard (:3001) must respond. 000 means no connection.
+ok=0
+for _ in $(seq 1 40); do
+  b=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 http://localhost:3000/ || echo 000)
+  d=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 http://localhost:3001/ || echo 000)
+  if [ "$b" != "000" ] && [ "$d" != "000" ]; then ok=1; break; fi
+  sleep 3
+done
+
+if [ "$ok" != 1 ]; then
+  echo "health check failed (backend=$b dashboard=$d)"
+  docker compose ps
+  exit 1
+fi
+echo "healthy (backend=$b dashboard=$d)"


### PR DESCRIPTION
## What
Adds a `deploy` job to `ci.yml` and a generic `scripts/deploy.sh`.

## Behavior
- Runs **only** on push to `main`, and only after `public-content-scan`, `secret-scan`, `backend`, `dashboard` all pass (`needs:` = CI gate).
- SSHes to the deploy host (from `production` environment secrets — `DEPLOY_SSH_HOST/USER/KEY`) and runs `git reset --hard origin/main` + `scripts/deploy.sh` (build + health check).
- `concurrency` prevents overlapping deploys; fork PRs can't trigger it and never receive secrets.

## Privacy
Server URL lives only in a masked secret; no host/IP in the workflow or script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)