### PR TITLE
Fix deploy SSH key trailing newline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
           SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
         run: |
           install -m 600 /dev/null key
-          printf '%s' "$SSH_KEY" > key
+          printf '%s\n' "$SSH_KEY" > key
           ssh -i key -o StrictHostKeyChecking=accept-new -o ConnectTimeout=20 \
             "$SSH_USER@$SSH_HOST" \
             'set -e; cd ~/loma; git fetch origin --prune; git reset --hard origin/main; bash scripts/deploy.sh'


### PR DESCRIPTION
OpenSSH private keys need a trailing newline; `printf '%s'` dropped it ("invalid format / Permission denied"). Use `printf '%s\n'`. Verified locally that the key loads and authenticates with the newline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)