### PR TITLE
Open self-signup + admin approval auth flow

### DIFF
--- a/api/auth_middleware.py
+++ b/api/auth_middleware.py
@@ -71,17 +71,24 @@ async def auth_middleware(request, handler):
 
         # Look up user from DB to get system role
         db = get_db()
-        if db is not None:
-            user = await db.users.find_one({"email": user_email})
-            request["user"] = user
-            if using_preview_fallback:
-                request["system_role"] = _DEFAULT_ROLE
-            else:
-                request["system_role"] = (
-                    user.get("system_role", _DEFAULT_ROLE) if user else _DEFAULT_ROLE
-                )
-        else:
-            request["user"] = None
+        user = await db.users.find_one({"email": user_email}) if db is not None else None
+        request["user"] = user
+        if using_preview_fallback or db is None:
             request["system_role"] = _DEFAULT_ROLE
+            request["user_status"] = "active"
+        else:
+            request["system_role"] = (
+                user.get("system_role", _DEFAULT_ROLE) if user else _DEFAULT_ROLE
+            )
+            # Legacy users (no status field) are treated as active.
+            request["user_status"] = user.get("status", "active") if user else "active"
+
+        # Gate users awaiting admin approval: they may only read their own profile
+        # (/api/governance/me, so the dashboard can show the pending screen). Every
+        # other API call is denied until an admin approves them.
+        if request.get("user_status") == "pending" and request.path != "/api/governance/me":
+            return web.json_response(
+                {"error": "Account pending admin approval"}, status=403,
+            )
 
     return await handler(request)

--- a/api/governance_routes.py
+++ b/api/governance_routes.py
@@ -85,6 +85,8 @@ async def handle_get_me(request: web.Request) -> web.Response:
             "name": email.split("@")[0].replace(".", " ").title(),
             "avatar": email[0].upper(),
             "system_role": "admin" if count == 0 else _DEFAULT_ROLE,
+            # First user ever is auto-approved; everyone else awaits admin approval.
+            "status": "active" if count == 0 else "pending",
             "tool_assignments": {},
             "theme_preference": "light",
             "claude_pool_enabled": True,
@@ -92,9 +94,14 @@ async def handle_get_me(request: web.Request) -> web.Response:
             "updated_at": datetime.now(timezone.utc),
         }
         await db.users.insert_one(user)
-        logger.info("Auto-provisioned user %s with role %s", email, user["system_role"])
+        logger.info(
+            "Auto-provisioned user %s with role %s (status %s)",
+            email, user["system_role"], user["status"],
+        )
 
     serialized_user = _serialize(user)
+    # Legacy users created before the approval flow are treated as active.
+    serialized_user.setdefault("status", "active")
     if request.get("preview_fallback_user"):
         serialized_user["system_role"] = _DEFAULT_ROLE
 
@@ -145,6 +152,8 @@ async def handle_list_users(request: web.Request) -> web.Response:
     # Enrich with Claude auth status per user
     claude_users_dir = Path(os.environ.get("CLAUDE_USERS_DIR", "/opt/claude-users"))
     for user in serialized:
+        # Legacy users created before the approval flow are treated as active.
+        user.setdefault("status", "active")
         email = user.get("email", "")
         config_file = claude_users_dir / email / ".claude.json"
         if config_file.exists():
@@ -206,6 +215,15 @@ async def handle_update_user(request: web.Request) -> web.Response:
                 status=400,
             )
         updates["system_role"] = role
+
+    if "status" in body:
+        status = body["status"]
+        if status not in ("active", "pending", "rejected"):
+            return web.json_response(
+                {"error": "Invalid status. Must be one of: active, pending, rejected"},
+                status=400,
+            )
+        updates["status"] = status
 
     if "tool_assignments" in body:
         updates["tool_assignments"] = body["tool_assignments"]

--- a/dashboard/src/app/admin/page.tsx
+++ b/dashboard/src/app/admin/page.tsx
@@ -639,6 +639,9 @@ export default function AdminPage() {
                   <th className="py-3 px-2 text-center text-[11px] font-semibold text-gray-400 uppercase tracking-wider min-w-[100px]">
                     Role
                   </th>
+                  <th className="py-3 px-2 text-center text-[11px] font-semibold text-gray-400 uppercase tracking-wider min-w-[160px]">
+                    Status
+                  </th>
                   <th className="py-3 px-2 text-center min-w-[80px]">
                     <div className="inline-flex flex-col items-center gap-1">
                       <div className="w-6 h-6 rounded-md flex items-center justify-center bg-amber-50">
@@ -720,6 +723,48 @@ export default function AdminPage() {
                         <option value="analyst">Analyst</option>
                         <option value="chatter">Chatter</option>
                       </select>
+                    </td>
+                    {/* Approval status */}
+                    <td className="py-3 px-2 text-center">
+                      {(user.status ?? "active") === "pending" ? (
+                        <div className="flex items-center justify-center gap-1.5">
+                          <span className="text-[10px] px-2 py-0.5 rounded-full bg-amber-50 text-amber-600 font-medium">Pending</span>
+                          <button
+                            onClick={async () => {
+                              const prev = user.status ?? "active";
+                              setUsers((us) => us.map((u) => (u.email === user.email ? { ...u, status: "active" } : u)));
+                              try {
+                                await updateUser(user.email, { status: "active" });
+                              } catch (err) {
+                                console.error("Failed to approve user:", err);
+                                setUsers((us) => us.map((u) => (u.email === user.email ? { ...u, status: prev } : u)));
+                              }
+                            }}
+                            className="text-[10px] px-2 py-0.5 rounded-full bg-emerald-600 text-white font-medium hover:bg-emerald-700 transition-colors"
+                          >
+                            Approve
+                          </button>
+                          <button
+                            onClick={async () => {
+                              const prev = user.status ?? "active";
+                              setUsers((us) => us.map((u) => (u.email === user.email ? { ...u, status: "rejected" } : u)));
+                              try {
+                                await updateUser(user.email, { status: "rejected" });
+                              } catch (err) {
+                                console.error("Failed to reject user:", err);
+                                setUsers((us) => us.map((u) => (u.email === user.email ? { ...u, status: prev } : u)));
+                              }
+                            }}
+                            className="text-[10px] px-2 py-0.5 rounded-full bg-red-50 text-red-600 font-medium hover:bg-red-100 transition-colors"
+                          >
+                            Reject
+                          </button>
+                        </div>
+                      ) : (user.status ?? "active") === "rejected" ? (
+                        <span className="text-[10px] px-2 py-0.5 rounded-full bg-red-50 text-red-500 font-medium">Rejected</span>
+                      ) : (
+                        <span className="text-[10px] px-2 py-0.5 rounded-full bg-gray-100 text-gray-400 font-medium">Active</span>
+                      )}
                     </td>
                     {/* Claude connection + pool toggle */}
                     <td className="py-3 px-2 text-center">

--- a/dashboard/src/app/api/signup/route.ts
+++ b/dashboard/src/app/api/signup/route.ts
@@ -1,0 +1,62 @@
+import { hashPassword, normalizeEmail, getUsersCollection } from "@/auth-node";
+
+export const runtime = "nodejs";
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json().catch(() => ({}));
+    const email = normalizeEmail(body?.email);
+    const password = String(body?.password || "");
+    const name = typeof body?.name === "string" ? body.name : "";
+
+    if (!EMAIL_RE.test(email)) {
+      return Response.json({ error: "Enter a valid email address." }, { status: 400 });
+    }
+    if (password.length < 8) {
+      return Response.json(
+        { error: "Password must be at least 8 characters." },
+        { status: 400 },
+      );
+    }
+
+    const users = await getUsersCollection();
+
+    // The first account must be the admin, created via the setup token on the
+    // sign-in screen — this avoids a public visitor grabbing admin / a no-admin deadlock.
+    const count = await users.countDocuments({});
+    if (count === 0) {
+      return Response.json(
+        { error: "The first admin must be created with the setup token on the sign-in screen." },
+        { status: 403 },
+      );
+    }
+
+    if (await users.findOne({ email })) {
+      return Response.json(
+        { error: "An account with this email already exists." },
+        { status: 409 },
+      );
+    }
+
+    const now = new Date();
+    await users.insertOne({
+      email,
+      name: name.trim() || email.split("@")[0] || email,
+      avatar: email[0].toUpperCase(),
+      system_role: "chatter",
+      status: "pending",
+      tool_assignments: {},
+      theme_preference: "system",
+      claude_pool_enabled: true,
+      local_auth: hashPassword(password),
+      created_at: now,
+      updated_at: now,
+    });
+
+    return Response.json({ ok: true }, { status: 201 });
+  } catch {
+    return Response.json({ error: "Signup failed" }, { status: 500 });
+  }
+}

--- a/dashboard/src/app/login/page.tsx
+++ b/dashboard/src/app/login/page.tsx
@@ -19,11 +19,18 @@ function LoginContent() {
   );
   const showLocal = authProviders.includes("all") || authProviders.includes("local");
   const showGoogle = authProviders.includes("all") || authProviders.includes("google");
+  const [mode, setMode] = useState<"signin" | "signup">("signin");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [name, setName] = useState("");
   const [setupToken, setSetupToken] = useState("");
   const [localError, setLocalError] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const switchMode = (next: "signin" | "signup") => {
+    setMode(next);
+    setLocalError("");
+  };
 
   const submitLocalLogin = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -45,6 +52,44 @@ function LoginContent() {
     }
 
     setLocalError("Unable to sign in. Check your email, password, and setup token.");
+  };
+
+  const submitSignup = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setLocalError("");
+    setIsSubmitting(true);
+    try {
+      const res = await fetch("/api/signup", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password, name }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setIsSubmitting(false);
+        setLocalError(data?.error || "Unable to create account.");
+        return;
+      }
+      // Account created (pending approval) — sign in so the app can show the
+      // "awaiting approval" screen.
+      const result = await signIn("credentials", {
+        email,
+        password,
+        redirect: false,
+        callbackUrl: "/",
+      });
+      setIsSubmitting(false);
+      if (result?.ok) {
+        router.push("/");
+        router.refresh();
+        return;
+      }
+      setLocalError("Account created. Please sign in.");
+      setMode("signin");
+    } catch {
+      setIsSubmitting(false);
+      setLocalError("Unable to create account.");
+    }
   };
 
   return (
@@ -72,7 +117,7 @@ function LoginContent() {
           </div>
         )}
 
-        {showLocal && (
+        {showLocal && mode === "signin" && (
           <form className="space-y-4" onSubmit={submitLocalLogin}>
             <label className="block">
               <span className="text-sm font-medium text-gray-700">Email</span>
@@ -96,19 +141,6 @@ function LoginContent() {
                 className="mt-1 w-full rounded-xl border border-gray-200 px-3 py-2.5 text-sm text-gray-900 outline-none transition-colors focus:border-gray-400"
               />
             </label>
-            <label className="block">
-              <span className="text-sm font-medium text-gray-700">Setup token</span>
-              <input
-                type="password"
-                value={setupToken}
-                onChange={(event) => setSetupToken(event.target.value)}
-                autoComplete="one-time-code"
-                className="mt-1 w-full rounded-xl border border-gray-200 px-3 py-2.5 text-sm text-gray-900 outline-none transition-colors focus:border-gray-400"
-              />
-              <span className="mt-1 block text-xs text-gray-400">
-                Required only when creating the first admin account.
-              </span>
-            </label>
             <button
               type="submit"
               disabled={isSubmitting}
@@ -116,6 +148,86 @@ function LoginContent() {
             >
               {isSubmitting ? "Signing in..." : "Sign in"}
             </button>
+            <label className="block">
+              <span className="text-xs text-gray-400">
+                First admin setup token (leave blank otherwise)
+              </span>
+              <input
+                type="password"
+                value={setupToken}
+                onChange={(event) => setSetupToken(event.target.value)}
+                autoComplete="one-time-code"
+                className="mt-1 w-full rounded-lg border border-gray-100 bg-gray-50 px-3 py-2 text-xs text-gray-600 outline-none transition-colors focus:border-gray-300"
+              />
+            </label>
+            <p className="text-center text-sm text-gray-500">
+              Need an account?{" "}
+              <button
+                type="button"
+                onClick={() => switchMode("signup")}
+                className="font-medium text-gray-900 underline-offset-2 hover:underline"
+              >
+                Create one
+              </button>
+            </p>
+          </form>
+        )}
+
+        {showLocal && mode === "signup" && (
+          <form className="space-y-4" onSubmit={submitSignup}>
+            <label className="block">
+              <span className="text-sm font-medium text-gray-700">Name</span>
+              <input
+                type="text"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                autoComplete="name"
+                className="mt-1 w-full rounded-xl border border-gray-200 px-3 py-2.5 text-sm text-gray-900 outline-none transition-colors focus:border-gray-400"
+              />
+            </label>
+            <label className="block">
+              <span className="text-sm font-medium text-gray-700">Email</span>
+              <input
+                type="email"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                autoComplete="email"
+                required
+                className="mt-1 w-full rounded-xl border border-gray-200 px-3 py-2.5 text-sm text-gray-900 outline-none transition-colors focus:border-gray-400"
+              />
+            </label>
+            <label className="block">
+              <span className="text-sm font-medium text-gray-700">Password</span>
+              <input
+                type="password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                autoComplete="new-password"
+                required
+                minLength={8}
+                className="mt-1 w-full rounded-xl border border-gray-200 px-3 py-2.5 text-sm text-gray-900 outline-none transition-colors focus:border-gray-400"
+              />
+              <span className="mt-1 block text-xs text-gray-400">
+                At least 8 characters. New accounts require admin approval before access.
+              </span>
+            </label>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="w-full rounded-xl bg-gray-900 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isSubmitting ? "Creating account..." : "Create account"}
+            </button>
+            <p className="text-center text-sm text-gray-500">
+              Have an account?{" "}
+              <button
+                type="button"
+                onClick={() => switchMode("signin")}
+                className="font-medium text-gray-900 underline-offset-2 hover:underline"
+              >
+                Sign in
+              </button>
+            </p>
           </form>
         )}
 

--- a/dashboard/src/auth-node.ts
+++ b/dashboard/src/auth-node.ts
@@ -55,17 +55,17 @@ function getMongoClient(): Promise<MongoClient> {
   return mongoClientPromise;
 }
 
-async function getUsersCollection() {
+export async function getUsersCollection() {
   const client = await getMongoClient();
   const dbName = process.env.OBSERVABILITY_DB_NAME || "loma_observability";
   return client.db(dbName).collection("users");
 }
 
-function normalizeEmail(value: unknown): string {
+export function normalizeEmail(value: unknown): string {
   return String(value || "").trim().toLowerCase();
 }
 
-function hashPassword(password: string): LocalAuth {
+export function hashPassword(password: string): LocalAuth {
   const salt = randomBytes(16).toString("base64url");
   const passwordHash = scryptSync(password, salt, 64).toString("base64url");
   return {
@@ -128,6 +128,7 @@ async function authorizeLocal(credentials: Partial<Record<string, unknown>> | un
     name: email.split("@")[0] || email,
     avatar: null,
     system_role: "admin",
+    status: "active",
     tool_assignments: [],
     theme_preference: "system",
     claude_pool_enabled: true,

--- a/dashboard/src/components/LayoutShell.tsx
+++ b/dashboard/src/components/LayoutShell.tsx
@@ -2,12 +2,15 @@
 
 import { useState, useCallback, Suspense } from "react";
 import { usePathname } from "next/navigation";
+import { signOut } from "next-auth/react";
 import Sidebar from "./Sidebar";
 import CrosscutIcon from "./CrosscutIcon";
+import { useUser } from "../lib/UserContext";
 
 export default function LayoutShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const isLogin = pathname === "/login";
+  const { user, loading } = useUser();
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
   const toggleSidebar = useCallback(() => setSidebarOpen((prev) => !prev), []);
@@ -15,6 +18,30 @@ export default function LayoutShell({ children }: { children: React.ReactNode })
 
   if (isLogin) {
     return <>{children}</>;
+  }
+
+  // Users awaiting admin approval can't access the app yet.
+  if (!loading && user?.status === "pending") {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 p-4">
+        <div className="bg-surface border border-gray-200 rounded-2xl p-8 max-w-sm w-full text-center shadow-sm">
+          <div className="mb-4 flex justify-center">
+            <CrosscutIcon size={36} />
+          </div>
+          <h1 className="text-xl font-semibold text-gray-900 mb-2">Awaiting approval</h1>
+          <p className="text-sm text-gray-500 mb-6">
+            Your account is pending admin approval. You&apos;ll get access once an admin
+            approves you.
+          </p>
+          <button
+            onClick={() => signOut({ callbackUrl: "/login" })}
+            className="w-full rounded-xl bg-gray-900 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-gray-800"
+          >
+            Sign out
+          </button>
+        </div>
+      </div>
+    );
   }
 
   return (

--- a/dashboard/src/lib/governance-api.ts
+++ b/dashboard/src/lib/governance-api.ts
@@ -13,6 +13,7 @@ export interface User {
   name: string;
   avatar: string;
   system_role: SystemRole;
+  status?: "active" | "pending" | "rejected";
   tool_assignments: Record<string, ToolAssignment>;
   theme_preference?: "light" | "dark" | "system";
   pinned_conversations?: Array<{ conversation_id: string; pinned_at: string }>;
@@ -86,7 +87,7 @@ export async function fetchUser(email: string): Promise<{ user: User; teams: Tea
 
 export async function updateUser(
   email: string,
-  updates: Partial<Pick<User, "system_role" | "tool_assignments" | "name" | "claude_pool_enabled">>,
+  updates: Partial<Pick<User, "system_role" | "tool_assignments" | "name" | "claude_pool_enabled" | "status">>,
 ): Promise<User> {
   const res = await fetch(`${API_BASE}/api/governance/users/${encodeURIComponent(email)}`, {
     method: "PATCH",


### PR DESCRIPTION
## Problem
Loma could only bootstrap the **first** admin (via `LOMA_SETUP_TOKEN`); `authorizeLocal()` blocked every subsequent new user, there was **no add-user UI**, and `admin` sees all conversations. So additional people shared the admin login and saw everyone's data.

## What this does — open self-signup + admin approval
- **Self-signup (no token):** new `dashboard/src/app/api/signup/route.ts` + a "Create account" mode on `/login` create a **pending**, `chatter`-role user (reusing the existing scrypt `hashPassword`). The first account still must use the setup token on the sign-in screen (prevents a public visitor grabbing admin / a no-admin deadlock).
- **Approval gate:** `db.users` gains `status` (`active|pending|rejected`). `api/auth_middleware.py` **403s pending users** on every `/api/*` except `/api/governance/me`; `LayoutShell` shows an "Awaiting approval" screen for them. Legacy users (no `status`) are treated as `active`.
- **Admin approval:** the admin Users tab gets a **Status** column with **Approve**/**Reject**, reusing the admin-only `PATCH /api/governance/users/{email}` (now accepts `status`).

Each approved user gets their own identity + role-scoped visibility, so users stop sharing admin (fixes the "everyone sees everything" issue).

## Files
Backend: `api/auth_middleware.py`, `api/governance_routes.py`.
Dashboard: `auth-node.ts` (export helpers, status on first admin), new `app/api/signup/route.ts`, `app/login/page.tsx`, `components/LayoutShell.tsx`, `lib/governance-api.ts`, `app/admin/page.tsx`.

## Verification
- `python3 -m py_compile` on both backend files ✓
- Dashboard `tsc --noEmit` clean ✓; `eslint` 0 errors (4 pre-existing warnings) ✓
- Manual e2e to run after deploy: first admin via setup token → active/admin; second user self-signs-up → "Awaiting approval" + `/me` shows `status: pending` + direct `/api/conversations` is 403; admin Approves → user gets scoped access; two users see disjoint conversation lists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)