### PR TITLE
Allow unauthenticated access to /api/signup

### DIFF
--- a/dashboard/src/middleware.ts
+++ b/dashboard/src/middleware.ts
@@ -23,6 +23,6 @@ export default auth((req) => {
 
 export const config = {
   matcher: [
-    "/((?!login|webhook|metrics|api/auth|_next/static|_next/image|favicon.ico).*)",
+    "/((?!login|webhook|metrics|api/auth|api/signup|_next/static|_next/image|favicon.ico).*)",
   ],
 };


### PR DESCRIPTION
## Bug
Self-signup failed on the deployed dashboard with "Unable to create account." The `/api/signup` POST returned **307 → /login**: the NextAuth middleware (`dashboard/src/middleware.ts`) matcher didn't exclude `api/signup`, so it redirected the (intentionally unauthenticated) signup request before the route handler ran.

## Fix
Add `api/signup` to the middleware matcher exclusion list, next to `api/auth`. One line.

## Test
After deploy: `POST /api/signup` with a new email returns 201 (or 400/409 on bad/dup input) instead of a 307 to /login; the "Create account" form on /login then works.