### PR TITLE
Front the stack with nginx: single origin on :80, backend not exposed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,10 @@
 # Loma backend
 APP_NAME=Loma
-PUBLIC_BASE_URL=http://localhost:3001
+# External origin users hit. With the bundled nginx proxy (docker compose) this is
+# the proxy address: http://<your-ip> (Phase 1) or https://<your-domain> (Phase 2).
+# For local dev without Docker (dashboard on :3001) use http://localhost:3001.
+PUBLIC_BASE_URL=http://localhost
+# Internal backend port — behind the proxy, not exposed externally by default.
 WEBHOOK_PORT=3000
 ENV=PROD
 LOMA_SETUP_TOKEN=your-first-admin-setup-token

--- a/dashboard/.env.example
+++ b/dashboard/.env.example
@@ -11,10 +11,13 @@ OBSERVABILITY_DB_NAME=loma_observability
 # Optional Google dashboard login. Set AUTH_PROVIDER=google or AUTH_PROVIDER=local,google to use it.
 AUTH_GOOGLE_ID=your-google-client-id.apps.googleusercontent.com
 AUTH_GOOGLE_SECRET=your-google-client-secret
-AUTH_URL=http://localhost:3001
+# NextAuth external origin. Behind the nginx proxy (docker compose) set this to the
+# proxy address: http://<your-ip> (Phase 1) or https://<your-domain> (Phase 2).
+# Local dev without Docker: http://localhost:3001.
+AUTH_URL=http://localhost
 
-# Python backend URL used by Next.js server rewrites
-BACKEND_URL=http://localhost:3000
+# Python backend URL used by Next.js server rewrites (internal Docker network).
+BACKEND_URL=http://loma-backend:3000
 
 # Browser API calls use same-origin /api/* rewrites by default.
 # Leave this blank unless you intentionally expose the backend directly.

--- a/deploy/nginx/README.md
+++ b/deploy/nginx/README.md
@@ -1,0 +1,67 @@
+# Reverse proxy (nginx)
+
+The `nginx` service in `docker-compose.yml` is the single external entrypoint. It serves the
+dashboard and routes traffic over the internal Docker network, so the backend (`3000`) and
+dashboard (`3001`) containers are bound to `127.0.0.1` only and never need to be exposed.
+
+```
+client ──▶ :80 nginx ──┬─ /api/auth/*          ─▶ dashboard (NextAuth)
+                       ├─ /api/*               ─▶ backend  (API, OAuth cb, chat SSE, terminal WS)
+                       ├─ /webhooks/* , /webhook ─▶ backend  (third-party webhooks)
+                       └─ everything else      ─▶ dashboard (UI)
+```
+
+## Phase 1 — HTTP on an IP (default)
+
+Active config: `conf.d/loma.conf` (listens on `:80`, `server_name _`).
+
+Open inbound **80** in your firewall / cloud security group and **close 3000/3001**. Set, in
+the relevant env files:
+
+- `.env`: `PUBLIC_BASE_URL=http://<your-ip>`
+- `dashboard/.env`: `AUTH_URL=http://<your-ip>`
+
+Then `docker compose up -d` and browse to `http://<your-ip>`.
+
+## Phase 2 — Domain + HTTPS on :443
+
+Prereqs: a DNS A record pointing your domain at the server, and inbound **443** open.
+
+1. **Serve the ACME challenge over HTTP.** The active `loma.conf` already serves
+   `/.well-known/acme-challenge/` from `/var/www/certbot`, so just make sure the stack is up.
+
+2. **Obtain the certificate** (webroot challenge — no downtime):
+
+   ```bash
+   docker compose run --rm certbot certonly \
+     --webroot -w /var/www/certbot \
+     -d your.domain.com \
+     --email you@example.com --agree-tos --no-eff-email
+   ```
+
+   The cert lands in `deploy/nginx/certbot/conf/live/your.domain.com/` (mounted into nginx at
+   `/etc/letsencrypt`).
+
+3. **Switch nginx to HTTPS:**
+   - In `docker-compose.yml`, add `"443:443"` to the `nginx` service `ports`.
+   - Copy `conf.d/loma-ssl.conf.example` → `conf.d/loma.conf`, replacing `YOUR_DOMAIN` with
+     your domain (this replaces the HTTP-only server with the redirect + TLS server).
+   - `docker compose up -d` (recreates nginx with the new port + config).
+
+4. **Update the app's external URL** (and re-register OAuth redirect URIs with the providers):
+   - `.env`: `PUBLIC_BASE_URL=https://your.domain.com`,
+     `GOOGLE_OAUTH_REDIRECT_URI=https://your.domain.com/api/oauth/google/callback`,
+     `SLACK_OAUTH_REDIRECT_URI=https://your.domain.com/api/oauth/slack/callback`
+   - `dashboard/.env`: `AUTH_URL=https://your.domain.com`
+   - Recreate so the values are picked up: `docker compose up -d --force-recreate loma-backend loma-dashboard`.
+
+   nginx forwards `X-Forwarded-Proto: https`, so backend-built webhook URLs become `https://…`
+   automatically.
+
+5. **Auto-renew.** Run a periodic renewal that reloads nginx on success — e.g. a host cron:
+
+   ```cron
+   0 3 * * * cd /home/ubuntu/loma && docker compose run --rm certbot renew --webroot -w /var/www/certbot && docker compose exec nginx nginx -s reload
+   ```
+
+   (Let's Encrypt certs last 90 days; renewal is a no-op until ~30 days before expiry.)

--- a/deploy/nginx/certbot/conf/.gitkeep
+++ b/deploy/nginx/certbot/conf/.gitkeep
@@ -1,0 +1,1 @@
+# Keeps the Let's Encrypt config/cert dir in git (populated by certbot in Phase 2).

--- a/deploy/nginx/certbot/www/.gitkeep
+++ b/deploy/nginx/certbot/www/.gitkeep
@@ -1,0 +1,1 @@
+# Keeps the ACME webroot dir in git (Phase 2 cert challenges land here).

--- a/deploy/nginx/conf.d/loma-ssl.conf.example
+++ b/deploy/nginx/conf.d/loma-ssl.conf.example
@@ -1,0 +1,62 @@
+# Loma reverse proxy — HTTPS variant (Phase 2).
+#
+# To enable HTTPS:
+#   1. Obtain a cert (see ../README.md), then
+#   2. replace YOUR_DOMAIN below with your domain,
+#   3. rename this file to loma.conf (replacing the HTTP-only one),
+#   4. add "443:443" to the nginx service ports in docker-compose.yml,
+#   5. `docker compose up -d` (or `docker compose exec nginx nginx -s reload`).
+
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+upstream loma_backend   { server loma-backend:3000; }
+upstream loma_dashboard { server loma-dashboard:3001; }
+
+# Port 80: serve the ACME challenge, redirect everything else to HTTPS.
+server {
+    listen 80;
+    server_name YOUR_DOMAIN;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name YOUR_DOMAIN;
+
+    ssl_certificate     /etc/letsencrypt/live/YOUR_DOMAIN/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/YOUR_DOMAIN/privkey.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+
+    client_max_body_size 110m;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    proxy_http_version 1.1;
+    proxy_set_header Host              $host;
+    proxy_set_header X-Real-IP         $remote_addr;
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;       # = https here
+    proxy_set_header X-Forwarded-Host  $host;
+    proxy_set_header Upgrade           $http_upgrade;
+    proxy_set_header Connection        $connection_upgrade;
+    proxy_read_timeout 3600s;
+    proxy_buffering off;
+
+    location /api/auth/ { proxy_pass http://loma_dashboard; }
+    location /api/      { proxy_pass http://loma_backend; }
+    location /webhooks/ { proxy_pass http://loma_backend; }
+    location = /webhook { proxy_pass http://loma_backend; }
+    location /          { proxy_pass http://loma_dashboard; }
+}

--- a/deploy/nginx/conf.d/loma.conf
+++ b/deploy/nginx/conf.d/loma.conf
@@ -1,0 +1,50 @@
+# Loma reverse proxy — single external origin on :80.
+# Routes /api (+ OAuth callbacks, SSE, WebSocket) and webhooks to the backend,
+# and everything else to the dashboard, over the internal Docker network.
+# For HTTPS on :443, see ../README.md (swap in loma-ssl.conf.example).
+
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+upstream loma_backend   { server loma-backend:3000; }
+upstream loma_dashboard { server loma-dashboard:3001; }
+
+server {
+    listen 80;
+    server_name _;
+
+    client_max_body_size 110m;          # matches backend skill-asset limit
+
+    # Let's Encrypt HTTP-01 challenge (used in Phase 2). Harmless before then.
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    # Shared upstream proxy settings (inherited by the locations below).
+    proxy_http_version 1.1;
+    proxy_set_header Host              $host;
+    proxy_set_header X-Real-IP         $remote_addr;
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host  $host;
+    proxy_set_header Upgrade           $http_upgrade;       # WebSocket (terminal)
+    proxy_set_header Connection        $connection_upgrade;
+    proxy_read_timeout 3600s;                               # long-lived SSE / WS
+    proxy_buffering off;                                    # stream SSE immediately
+
+    # NextAuth routes stay on the dashboard.
+    location /api/auth/ { proxy_pass http://loma_dashboard; }
+
+    # Everything else under /api goes straight to the backend (API, OAuth
+    # callbacks, chat SSE, terminal WebSocket).
+    location /api/      { proxy_pass http://loma_backend; }
+
+    # Third-party webhooks → backend.
+    location /webhooks/ { proxy_pass http://loma_backend; }
+    location = /webhook { proxy_pass http://loma_backend; }
+
+    # Dashboard UI and all other routes.
+    location / { proxy_pass http://loma_dashboard; }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,9 @@ services:
       context: .
       dockerfile: Dockerfile
     env_file: .env
+    # Loopback only — reached externally through the nginx proxy, not directly.
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
     volumes:
       - loma-skill-assets:/var/lib/loma/skill-assets
       # Mount the real .env so the dashboard Environment admin (/api/env) can read & edit it.
@@ -23,11 +24,37 @@ services:
     env_file: ./dashboard/.env
     environment:
       BACKEND_URL: http://loma-backend:3000
+    # Loopback only — reached externally through the nginx proxy, not directly.
     ports:
-      - "3001:3001"
+      - "127.0.0.1:3001:3001"
     depends_on:
       - loma-backend
     restart: unless-stopped
+
+  # Single external entrypoint. Serves the dashboard on :80 and routes /api +
+  # webhooks to the backend over the internal network, so :3000/:3001 need not
+  # be exposed. For HTTPS on :443 see deploy/nginx/README.md.
+  nginx:
+    image: nginx:1.27-alpine
+    ports:
+      - "80:80"
+    volumes:
+      - ./deploy/nginx/conf.d:/etc/nginx/conf.d:ro
+      - ./deploy/nginx/certbot/www:/var/www/certbot:ro
+      - ./deploy/nginx/certbot/conf:/etc/letsencrypt:ro
+    depends_on:
+      - loma-backend
+      - loma-dashboard
+    restart: unless-stopped
+
+  # Phase 2 (HTTPS): obtain/renew Let's Encrypt certs via the webroot challenge.
+  # Disabled by default (only runs with `--profile certbot`). See deploy/nginx/README.md.
+  certbot:
+    image: certbot/certbot
+    profiles: ["certbot"]
+    volumes:
+      - ./deploy/nginx/certbot/conf:/etc/letsencrypt
+      - ./deploy/nginx/certbot/www:/var/www/certbot
 
 volumes:
   loma-skill-assets:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -9,19 +9,20 @@ echo "Deploying $(git rev-parse --short HEAD)"
 
 docker compose up -d --build
 
-# Liveness: backend (:3000, any HTTP code proves the aiohttp server is up) and
-# dashboard (:3001) must respond. 000 means no connection.
+# Liveness through the nginx proxy (:80): the dashboard ("/") and the backend
+# ("/api/...") must both respond. Any non-000 code proves the path is routed and
+# the upstream is up. This also validates the reverse-proxy routing itself.
 ok=0
 for _ in $(seq 1 40); do
-  b=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 http://localhost:3000/ || echo 000)
-  d=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 http://localhost:3001/ || echo 000)
-  if [ "$b" != "000" ] && [ "$d" != "000" ]; then ok=1; break; fi
+  d=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 http://localhost/ || echo 000)
+  b=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 http://localhost/api/skills || echo 000)
+  if [ "$d" != "000" ] && [ "$b" != "000" ]; then ok=1; break; fi
   sleep 3
 done
 
 if [ "$ok" != 1 ]; then
-  echo "health check failed (backend=$b dashboard=$d)"
+  echo "health check failed (dashboard=$d backend=$b)"
   docker compose ps
   exit 1
 fi
-echo "healthy (backend=$b dashboard=$d)"
+echo "healthy (dashboard=$d backend=$b via :80)"


### PR DESCRIPTION
## What
Adds an **nginx** reverse proxy as the single external entrypoint on **:80**. It routes over the internal Docker network:
- `/api/auth/*` → dashboard (NextAuth)
- `/api/*` → backend (API, OAuth callbacks, chat SSE, terminal WebSocket)
- `/webhooks/*`, `/webhook` → backend
- everything else → dashboard

`loma-backend`/`loma-dashboard` are now bound to `127.0.0.1` only, so **:3000/:3001 no longer need to be exposed**.

## HTTPS path (Phase 2)
Ships `deploy/nginx/conf.d/loma-ssl.conf.example`, a profile-gated `certbot` service, and `deploy/nginx/README.md` documenting the domain + Let's Encrypt switch to **:443** (no code change — obtain cert, swap config, flip env to `https://`).

## Validated on the deployment (non-disruptively)
A throwaway nginx on the live `loma_default` network (loopback test port) confirmed routing while `:3001` stayed up:
`/`→307, `/login`→200, `/api/skills`→200 (count 55, backend via nginx), `/webhooks/github`→401 (backend handler).

## Cutover (after merge/deploy — requires ops)
- Open inbound **80** (and close **3001**) in the security group.
- Set `PUBLIC_BASE_URL=http://<ip>` (`.env`) and `AUTH_URL=http://<ip>` (`dashboard/.env`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)