### PR TITLE
Add Loma logo to README hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <div align="center">
 
+<img src="https://www.lomahq.com/loma-logo.svg" alt="Loma" width="72" height="72" />
+
 # Loma
 
 **An AI Agents Factory for your whole team.**


### PR DESCRIPTION
Adds the hosted Loma logo (lomahq.com/loma-logo.svg) to the top of the README hero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)