### PR TITLE
nginx: route /api through the dashboard so X-User-Email is injected

### DIFF
--- a/deploy/nginx/conf.d/loma-ssl.conf.example
+++ b/deploy/nginx/conf.d/loma-ssl.conf.example
@@ -54,8 +54,8 @@ server {
     proxy_read_timeout 3600s;
     proxy_buffering off;
 
-    location /api/auth/ { proxy_pass http://loma_dashboard; }
-    location /api/      { proxy_pass http://loma_backend; }
+    # Webhooks → backend; everything else (incl. /api/*) → dashboard, which injects
+    # X-User-Email before proxying /api to the backend. See loma.conf for why.
     location /webhooks/ { proxy_pass http://loma_backend; }
     location = /webhook { proxy_pass http://loma_backend; }
     location /          { proxy_pass http://loma_dashboard; }

--- a/deploy/nginx/conf.d/loma.conf
+++ b/deploy/nginx/conf.d/loma.conf
@@ -34,17 +34,15 @@ server {
     proxy_read_timeout 3600s;                               # long-lived SSE / WS
     proxy_buffering off;                                    # stream SSE immediately
 
-    # NextAuth routes stay on the dashboard.
-    location /api/auth/ { proxy_pass http://loma_dashboard; }
-
-    # Everything else under /api goes straight to the backend (API, OAuth
-    # callbacks, chat SSE, terminal WebSocket).
-    location /api/      { proxy_pass http://loma_backend; }
-
-    # Third-party webhooks → backend.
+    # Third-party webhooks (HMAC-authenticated; no user identity needed) → backend.
     location /webhooks/ { proxy_pass http://loma_backend; }
     location = /webhook { proxy_pass http://loma_backend; }
 
-    # Dashboard UI and all other routes.
+    # Everything else — including /api/* — goes to the dashboard. The dashboard's
+    # Next.js middleware injects the X-User-Email header (from the session) before
+    # its own rewrites forward /api/* to the backend, so the backend can resolve
+    # the user's role. Routing /api straight to the backend would bypass that and
+    # drop every request to the default role. NextAuth (/api/auth/*) and chat SSE /
+    # terminal WebSocket are also handled here, exactly as on the direct :3001 path.
     location / { proxy_pass http://loma_dashboard; }
 }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -10,12 +10,13 @@ echo "Deploying $(git rev-parse --short HEAD)"
 docker compose up -d --build
 
 # Liveness through the nginx proxy (:80): the dashboard ("/") and the backend
-# ("/api/...") must both respond. Any non-000 code proves the path is routed and
-# the upstream is up. This also validates the reverse-proxy routing itself.
+# (a webhook path, which nginx routes straight to the backend) must both respond.
+# Any non-000 code proves the path is routed and the upstream is up. We probe a
+# backend-routed path rather than /api/* (which now goes via the dashboard).
 ok=0
 for _ in $(seq 1 40); do
   d=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 http://localhost/ || echo 000)
-  b=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 http://localhost/api/skills || echo 000)
+  b=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 -X POST http://localhost/webhooks/github || echo 000)
   if [ "$d" != "000" ] && [ "$b" != "000" ]; then ok=1; break; fi
   sleep 3
 done


### PR DESCRIPTION
## Problem
Accessing via the nginx proxy (:80), a maintainer/admin lost their role (fell back to `chatter`), hiding admin features.

## Cause
The dashboard's Next.js `middleware.ts` injects the `X-User-Email` header (from the session) on `/api/*` before its rewrites forward them to the backend. The proxy routed `/api/*` **straight to the backend**, bypassing that middleware, so `auth_middleware` saw no identity and used the default role.

## Fix
Route `/api/*` (and everything except `/webhooks`) to the **dashboard**, matching the direct `:3001` path. Webhooks stay direct-to-backend (HMAC, no user header). Also probe a backend-routed path in the deploy health check, since `/api` no longer hits the backend directly.

Verified on the box (transient nginx): `/api/auth/session`→200 (NextAuth via dashboard), `/`→307, `/webhooks/github`→401 (backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)