### PR TITLE
Fix middleware not running for /api (role lost behind proxy)

### DIFF
--- a/api/governance_routes.py
+++ b/api/governance_routes.py
@@ -75,6 +75,10 @@ async def handle_get_me(request: web.Request) -> web.Response:
         return web.json_response({"error": "DB not configured"}, status=503)
 
     email = get_user_email(request)
+    if not email:
+        # No identity on the request (e.g. proxy did not forward X-User-Email).
+        # Don't auto-provision a blank user or crash on email[0]; report unauthenticated.
+        return web.json_response({"error": "Authentication required"}, status=401)
     user = await db.users.find_one({"email": email})
 
     if user is None:

--- a/dashboard/src/middleware.ts
+++ b/dashboard/src/middleware.ts
@@ -1,28 +1,48 @@
 import { auth } from "./auth";
 import { NextResponse } from "next/server";
 
-export default auth((req) => {
-  // Redirect unauthenticated users to login
-  if (!req.auth?.user) {
-    return NextResponse.redirect(new URL("/login", req.url));
-  }
+// Paths under /api that must NOT require auth or get the X-User-Email header.
+const PUBLIC_API_PREFIXES = ["/api/auth", "/api/signup"];
+// Backend-only paths the dashboard never needs to gate (also routed straight to
+// the backend by the reverse proxy).
+const BYPASS_PREFIXES = ["/webhook", "/metrics"];
 
+export default auth((req) => {
   const { pathname } = req.nextUrl;
 
-  // For API calls (except NextAuth), inject X-User-Email header.
-  // The actual proxying to the Python backend is handled by rewrites() in next.config.ts,
-  // which reliably supports POST bodies and SSE streaming.
-  if (pathname.startsWith("/api/") && !pathname.startsWith("/api/auth")) {
+  if (
+    BYPASS_PREFIXES.some((p) => pathname.startsWith(p)) ||
+    PUBLIC_API_PREFIXES.some((p) => pathname.startsWith(p))
+  ) {
+    return NextResponse.next();
+  }
+
+  const isApi = pathname.startsWith("/api/");
+
+  if (!req.auth?.user) {
+    // API calls get 401 (don't redirect XHR/fetch to the HTML login page);
+    // page navigations go to /login.
+    return isApi
+      ? NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+      : NextResponse.redirect(new URL("/login", req.url));
+  }
+
+  // Authenticated /api/* calls: inject the user's email so the Python backend
+  // (which rewrites() forwards to) can resolve the caller's role.
+  if (isApi) {
     const headers = new Headers(req.headers);
     headers.set("X-User-Email", req.auth?.user?.email || "");
     return NextResponse.next({ request: { headers } });
   }
 
-  // All other routes: NextAuth's authorized callback handles redirect to /login
+  return NextResponse.next();
 });
 
+// Keep the matcher simple: run middleware on everything except static assets and
+// the login page. The per-path exclusions above are handled in code, because a
+// multi-segment negative-lookahead matcher (e.g. "api/auth") was excluding all of
+// /api under Next.js 16, so the middleware never ran for API routes and the
+// X-User-Email header was never injected.
 export const config = {
-  matcher: [
-    "/((?!login|webhook|metrics|api/auth|api/signup|_next/static|_next/image|favicon.ico).*)",
-  ],
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|login).*)"],
 };


### PR DESCRIPTION
## Problem
Users showed up as `chatter` (admin/maintainer features hidden), and `/api/governance/me` returned 500.

## Cause
`middleware.ts`'s matcher used multi-segment negative-lookahead exclusions (`api/auth`, `api/signup`). Under **Next.js 16** this excludes **all** of `/api`, so the middleware never ran for API routes and never injected the `X-User-Email` header. The backend then couldn't identify the caller → defaulted to the production role `chatter`, and `governance_routes.py` crashed on `email[0]` with the empty email (500).

Confirmed on the box: unauthenticated `/skills`→307 `/login` (middleware runs), but `/api/governance/me`→500 and `/api/skills`→403 reach the backend with no auth (middleware did **not** run).

## Fix
- Simple matcher (`/((?!_next/static|_next/image|favicon.ico|login).*)`); handle `/api/auth`, `/api/signup`, `/webhook`, `/metrics` exclusions and the `X-User-Email` injection in the function.
- Unauthenticated `/api/*` → 401 (don't redirect fetch to HTML login); pages → `/login`.
- Guard `/api/governance/me` against an empty email (401) instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)