### PR TITLE
Resolve /api identity via nginx auth_request (fixes role behind proxy)

### DIFF
--- a/dashboard/src/app/api/whoami/route.ts
+++ b/dashboard/src/app/api/whoami/route.ts
@@ -1,0 +1,23 @@
+import { auth } from "@/auth";
+
+export const runtime = "nodejs";
+
+// Used by the nginx `auth_request` subrequest: returns the caller's email (from
+// the verified NextAuth session) in the X-Auth-Email response header so nginx can
+// inject a trusted X-User-Email when proxying /api/* to the Python backend.
+// Returns 401 when there is no valid session, which makes nginx reject the call.
+//
+// This exists because Next.js does not forward middleware-injected request headers
+// through next.config rewrites() to an external backend, so the proxy (nginx) must
+// resolve identity out-of-band instead.
+export async function GET() {
+  const session = await auth();
+  const email = session?.user?.email;
+  if (!email) {
+    return new Response(null, { status: 401 });
+  }
+  return new Response(null, {
+    status: 200,
+    headers: { "X-Auth-Email": email },
+  });
+}

--- a/dashboard/src/middleware.ts
+++ b/dashboard/src/middleware.ts
@@ -2,7 +2,8 @@ import { auth } from "./auth";
 import { NextResponse } from "next/server";
 
 // Paths under /api that must NOT require auth or get the X-User-Email header.
-const PUBLIC_API_PREFIXES = ["/api/auth", "/api/signup"];
+// /api/whoami is the nginx auth_request target; its own handler reads the session.
+const PUBLIC_API_PREFIXES = ["/api/auth", "/api/signup", "/api/whoami"];
 // Backend-only paths the dashboard never needs to gate (also routed straight to
 // the backend by the reverse proxy).
 const BYPASS_PREFIXES = ["/webhook", "/metrics"];

--- a/deploy/nginx/conf.d/loma-ssl.conf.example
+++ b/deploy/nginx/conf.d/loma-ssl.conf.example
@@ -54,8 +54,21 @@ server {
     proxy_read_timeout 3600s;
     proxy_buffering off;
 
-    # Webhooks → backend; everything else (incl. /api/*) → dashboard, which injects
-    # X-User-Email before proxying /api to the backend. See loma.conf for why.
+    # Identity for /api via an auth_request to the dashboard. See loma.conf.
+    location = /_whoami {
+        internal;
+        proxy_pass http://loma_dashboard/api/whoami;
+        proxy_pass_request_body off;
+        proxy_set_header Content-Length "";
+    }
+    location /api/auth/  { proxy_pass http://loma_dashboard; }
+    location /api/signup { proxy_pass http://loma_dashboard; }
+    location /api/ {
+        auth_request /_whoami;
+        auth_request_set $auth_email $upstream_http_x_auth_email;
+        proxy_set_header X-User-Email $auth_email;
+        proxy_pass http://loma_backend;
+    }
     location /webhooks/ { proxy_pass http://loma_backend; }
     location = /webhook { proxy_pass http://loma_backend; }
     location /          { proxy_pass http://loma_dashboard; }

--- a/deploy/nginx/conf.d/loma.conf
+++ b/deploy/nginx/conf.d/loma.conf
@@ -1,6 +1,12 @@
 # Loma reverse proxy — single external origin on :80.
-# Routes /api (+ OAuth callbacks, SSE, WebSocket) and webhooks to the backend,
-# and everything else to the dashboard, over the internal Docker network.
+#
+# Identity: Next.js does not forward middleware-injected request headers through
+# its rewrites() to an external backend, so we resolve the caller out-of-band:
+# for every /api/* call nginx makes an auth_request to the dashboard's
+# /api/whoami (which reads the NextAuth session) and injects a trusted
+# X-User-Email before proxying to the backend. Any client-sent X-User-Email is
+# overwritten, so it cannot be spoofed.
+#
 # For HTTPS on :443, see ../README.md (swap in loma-ssl.conf.example).
 
 map $http_upgrade $connection_upgrade {
@@ -34,15 +40,34 @@ server {
     proxy_read_timeout 3600s;                               # long-lived SSE / WS
     proxy_buffering off;                                    # stream SSE immediately
 
+    # Internal identity subrequest: ask the dashboard who owns this session.
+    # Returns 200 + X-Auth-Email when authenticated, 401 otherwise.
+    location = /_whoami {
+        internal;
+        proxy_pass http://loma_dashboard/api/whoami;
+        proxy_pass_request_body off;
+        proxy_set_header Content-Length "";
+        # Cookie + Host are forwarded from the original request so NextAuth can
+        # validate the session.
+    }
+
+    # NextAuth and self-signup are served by the dashboard (no identity needed).
+    location /api/auth/  { proxy_pass http://loma_dashboard; }
+    location /api/signup { proxy_pass http://loma_dashboard; }
+
+    # All other /api/* → backend, with a trusted X-User-Email resolved via the
+    # auth_request. nginx handles POST bodies, SSE streaming, and WebSocket here.
+    location /api/ {
+        auth_request /_whoami;
+        auth_request_set $auth_email $upstream_http_x_auth_email;
+        proxy_set_header X-User-Email $auth_email;   # overwrites any client value
+        proxy_pass http://loma_backend;
+    }
+
     # Third-party webhooks (HMAC-authenticated; no user identity needed) → backend.
     location /webhooks/ { proxy_pass http://loma_backend; }
     location = /webhook { proxy_pass http://loma_backend; }
 
-    # Everything else — including /api/* — goes to the dashboard. The dashboard's
-    # Next.js middleware injects the X-User-Email header (from the session) before
-    # its own rewrites forward /api/* to the backend, so the backend can resolve
-    # the user's role. Routing /api straight to the backend would bypass that and
-    # drop every request to the default role. NextAuth (/api/auth/*) and chat SSE /
-    # terminal WebSocket are also handled here, exactly as on the direct :3001 path.
+    # Dashboard UI and everything else.
     location / { proxy_pass http://loma_dashboard; }
 }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -9,6 +9,12 @@ echo "Deploying $(git rev-parse --short HEAD)"
 
 docker compose up -d --build
 
+# The nginx reverse-proxy config is bind-mounted, so `up` may not reload it on a
+# config-only change. Reload it explicitly (no-op if nginx was just recreated).
+if docker compose exec -T nginx nginx -t >/dev/null 2>&1; then
+  docker compose exec -T nginx nginx -s reload || true
+fi
+
 # Liveness through the nginx proxy (:80): the dashboard ("/") and the backend
 # (a webhook path, which nginx routes straight to the backend) must both respond.
 # Any non-000 code proves the path is routed and the upstream is up. We probe a


### PR DESCRIPTION
## Problem
Behind the proxy, every user resolved to the `chatter` role (admin/maintainer features hidden). Confirmed via backend logs: authenticated `/api/governance/me` requests reached the backend with an **empty** `X-User-Email`.

## Cause
Next.js does not forward middleware-injected request headers through `next.config` `rewrites()` to an external backend. So the `X-User-Email` the dashboard middleware sets is dropped at the rewrite, and the backend can't identify the caller.

## Fix
Resolve identity at the nginx layer:
- New dashboard route `GET /api/whoami` returns the caller's email (from the verified NextAuth session) in `X-Auth-Email`, or 401.
- nginx issues an `auth_request` to `/api/whoami` for every `/api/*` call, sets a trusted `X-User-Email` from the result (overwriting any client value — no spoofing), and proxies straight to the backend. nginx handles POST/SSE/WebSocket natively.
- `/api/auth`, `/api/signup` still go to the dashboard.
- `deploy.sh` now reloads nginx so bind-mounted proxy config changes take effect.

## Test
After deploy: authenticated dashboard shows the correct (admin) role; `/api/governance/me` returns the user; unauthenticated `/api/*` → 401; chat (SSE) and terminal (WS) work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)