### PR TITLE
Add opt-in HTTPS via env-driven TLS overlay

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,18 @@
 # Loma backend
 APP_NAME=Loma
 # External origin users hit. With the bundled nginx proxy (docker compose) this is
-# the proxy address: http://<your-ip> (Phase 1) or https://<your-domain> (Phase 2).
-# For local dev without Docker (dashboard on :3001) use http://localhost:3001.
+# the proxy address: http://<your-ip> over HTTP, or https://<your-domain> once you
+# enable TLS. For local dev without Docker (dashboard on :3001) use http://localhost:3001.
 PUBLIC_BASE_URL=http://localhost
 # Internal backend port — behind the proxy, not exposed externally by default.
 WEBHOOK_PORT=3000
+
+# --- HTTPS (optional) ---
+# Default is HTTP on :80. To serve HTTPS on :443, get a cert and set these (see
+# deploy/nginx/README.md), then `docker compose up -d`:
+# LOMA_DOMAIN=loma.example.com
+# COMPOSE_FILE=docker-compose.yml:docker-compose.tls.yml
+# (and set PUBLIC_BASE_URL=https://loma.example.com above + AUTH_URL in dashboard/.env)
 ENV=PROD
 LOMA_SETUP_TOKEN=your-first-admin-setup-token
 

--- a/deploy/nginx/README.md
+++ b/deploy/nginx/README.md
@@ -5,32 +5,40 @@ dashboard and routes traffic over the internal Docker network, so the backend (`
 dashboard (`3001`) containers are bound to `127.0.0.1` only and never need to be exposed.
 
 ```
-client ──▶ :80 nginx ──┬─ /api/auth/*          ─▶ dashboard (NextAuth)
-                       ├─ /api/*               ─▶ backend  (API, OAuth cb, chat SSE, terminal WS)
-                       ├─ /webhooks/* , /webhook ─▶ backend  (third-party webhooks)
-                       └─ everything else      ─▶ dashboard (UI)
+client ──▶ nginx ──┬─ /api/auth/* , /api/signup ─▶ dashboard (NextAuth, signup)
+                   ├─ /api/*                    ─▶ backend  (auth_request injects X-User-Email)
+                   ├─ /webhooks/* , /webhook    ─▶ backend  (third-party webhooks, HMAC)
+                   └─ everything else           ─▶ dashboard (UI)
 ```
 
-## Phase 1 — HTTP on an IP (default)
+Identity: Next.js drops middleware-injected headers through its rewrites, so for every `/api/*`
+call nginx makes an `auth_request` to the dashboard's `/api/whoami` (which reads the NextAuth
+session) and injects a **trusted** `X-User-Email` before proxying to the backend. Any
+client-sent `X-User-Email` is overwritten, so it can't be spoofed.
 
-Active config: `conf.d/loma.conf` (listens on `:80`, `server_name _`).
+## HTTP on an IP (default)
 
-Open inbound **80** in your firewall / cloud security group and **close 3000/3001**. Set, in
-the relevant env files:
+Active config: `conf.d/loma.conf` (listens on `:80`, `server_name _`). Works locally and on a
+bare IP — no domain needed.
+
+Open inbound **80** in your firewall / security group (and don't expose 3000/3001). Set:
 
 - `.env`: `PUBLIC_BASE_URL=http://<your-ip>`
 - `dashboard/.env`: `AUTH_URL=http://<your-ip>`
 
 Then `docker compose up -d` and browse to `http://<your-ip>`.
 
-## Phase 2 — Domain + HTTPS on :443
+## HTTPS on :443 (a few steps)
 
-Prereqs: a DNS A record pointing your domain at the server, and inbound **443** open.
+HTTPS is opt-in via the committed `docker-compose.tls.yml` overlay, which renders
+`templates/loma-tls.conf.template` for your domain (from `${LOMA_DOMAIN}`). The repo default
+stays HTTP, so nothing changes until you set the env vars below.
 
-1. **Serve the ACME challenge over HTTP.** The active `loma.conf` already serves
-   `/.well-known/acme-challenge/` from `/var/www/certbot`, so just make sure the stack is up.
+Prereqs: a DNS **A record** for your domain → the server's (ideally static / Elastic) IP, and
+inbound **443** open.
 
-2. **Obtain the certificate** (webroot challenge — no downtime):
+1. **Get the certificate** while the default HTTP stack is running (it already serves the ACME
+   challenge on :80, no downtime):
 
    ```bash
    docker compose run --rm certbot certonly \
@@ -39,29 +47,44 @@ Prereqs: a DNS A record pointing your domain at the server, and inbound **443** 
      --email you@example.com --agree-tos --no-eff-email
    ```
 
-   The cert lands in `deploy/nginx/certbot/conf/live/your.domain.com/` (mounted into nginx at
-   `/etc/letsencrypt`).
+   The cert lands in `deploy/nginx/certbot/conf/live/your.domain.com/`.
 
-3. **Switch nginx to HTTPS:**
-   - In `docker-compose.yml`, add `"443:443"` to the `nginx` service `ports`.
-   - Copy `conf.d/loma-ssl.conf.example` → `conf.d/loma.conf`, replacing `YOUR_DOMAIN` with
-     your domain (this replaces the HTTP-only server with the redirect + TLS server).
-   - `docker compose up -d` (recreates nginx with the new port + config).
+2. **Enable HTTPS** — in `.env`:
 
-4. **Update the app's external URL** (and re-register OAuth redirect URIs with the providers):
-   - `.env`: `PUBLIC_BASE_URL=https://your.domain.com`,
-     `GOOGLE_OAUTH_REDIRECT_URI=https://your.domain.com/api/oauth/google/callback`,
-     `SLACK_OAUTH_REDIRECT_URI=https://your.domain.com/api/oauth/slack/callback`
-   - `dashboard/.env`: `AUTH_URL=https://your.domain.com`
-   - Recreate so the values are picked up: `docker compose up -d --force-recreate loma-backend loma-dashboard`.
+   ```
+   LOMA_DOMAIN=your.domain.com
+   COMPOSE_FILE=docker-compose.yml:docker-compose.tls.yml
+   PUBLIC_BASE_URL=https://your.domain.com
+   ```
 
-   nginx forwards `X-Forwarded-Proto: https`, so backend-built webhook URLs become `https://…`
-   automatically.
+   and in `dashboard/.env`: `AUTH_URL=https://your.domain.com`.
 
-5. **Auto-renew.** Run a periodic renewal that reloads nginx on success — e.g. a host cron:
+   *(Only if you use Google/Slack OAuth login: also set `GOOGLE_OAUTH_REDIRECT_URI` /
+   `SLACK_OAUTH_REDIRECT_URI` to `https://your.domain.com/...` and re-register them with the
+   provider. The default local-credentials login needs no OAuth config.)*
+
+3. **Apply:**
+
+   ```bash
+   docker compose up -d
+   ```
+
+   nginx now renders the TLS template, serves `:443`, and redirects `:80 → :443`. The
+   `auth_request` identity flow and chat/terminal streaming work exactly as on HTTP.
+   `X-Forwarded-Proto: https` is set, so backend-built webhook URLs become `https://…`.
+
+4. **Auto-renew** — a host cron that renews and reloads nginx:
 
    ```cron
    0 3 * * * cd /home/ubuntu/loma && docker compose run --rm certbot renew --webroot -w /var/www/certbot && docker compose exec nginx nginx -s reload
    ```
 
-   (Let's Encrypt certs last 90 days; renewal is a no-op until ~30 days before expiry.)
+   (Let's Encrypt certs last 90 days; `renew` is a no-op until ~30 days before expiry.)
+
+### Notes
+
+- `LOMA_DOMAIN` and `COMPOSE_FILE` live in your **untracked** `.env`, and certs in the untracked
+  `deploy/nginx/certbot/conf` volume, so HTTPS survives a `git pull` / CI redeploy that runs
+  `git reset --hard` — the committed repo stays generic/HTTP-by-default.
+- If you change `templates/loma-tls.conf.template` itself, recreate nginx so it re-renders:
+  `docker compose up -d --force-recreate nginx`.

--- a/deploy/nginx/templates/loma-tls.conf.template
+++ b/deploy/nginx/templates/loma-tls.conf.template
@@ -1,11 +1,11 @@
-# Loma reverse proxy — HTTPS variant (Phase 2).
+# Loma reverse proxy — HTTPS (rendered by the nginx image's envsubst from
+# ${LOMA_DOMAIN}). Enabled via the docker-compose.tls.yml overlay; see
+# ../README.md. Mirrors conf.d/loma.conf exactly, plus TLS termination and an
+# HTTP→HTTPS redirect. Identity is resolved with an auth_request to the
+# dashboard's /api/whoami, so roles work the same as on plain HTTP.
 #
-# To enable HTTPS:
-#   1. Obtain a cert (see ../README.md), then
-#   2. replace YOUR_DOMAIN below with your domain,
-#   3. rename this file to loma.conf (replacing the HTTP-only one),
-#   4. add "443:443" to the nginx service ports in docker-compose.yml,
-#   5. `docker compose up -d` (or `docker compose exec nginx nginx -s reload`).
+# Only ${LOMA_DOMAIN} is substituted (NGINX_ENVSUBST_FILTER=LOMA_); nginx's own
+# $host / $http_upgrade / etc. are left intact.
 
 map $http_upgrade $connection_upgrade {
     default upgrade;
@@ -18,31 +18,26 @@ upstream loma_dashboard { server loma-dashboard:3001; }
 # Port 80: serve the ACME challenge, redirect everything else to HTTPS.
 server {
     listen 80;
-    server_name YOUR_DOMAIN;
+    server_name ${LOMA_DOMAIN};
 
-    location /.well-known/acme-challenge/ {
-        root /var/www/certbot;
-    }
-    location / {
-        return 301 https://$host$request_uri;
-    }
+    location /.well-known/acme-challenge/ { root /var/www/certbot; }
+    location / { return 301 https://$host$request_uri; }
 }
 
 server {
     listen 443 ssl;
     http2 on;
-    server_name YOUR_DOMAIN;
+    server_name ${LOMA_DOMAIN};
 
-    ssl_certificate     /etc/letsencrypt/live/YOUR_DOMAIN/fullchain.pem;
-    ssl_certificate_key /etc/letsencrypt/live/YOUR_DOMAIN/privkey.pem;
+    ssl_certificate     /etc/letsencrypt/live/${LOMA_DOMAIN}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${LOMA_DOMAIN}/privkey.pem;
     ssl_protocols TLSv1.2 TLSv1.3;
 
     client_max_body_size 110m;
 
-    location /.well-known/acme-challenge/ {
-        root /var/www/certbot;
-    }
+    location /.well-known/acme-challenge/ { root /var/www/certbot; }
 
+    # Shared upstream proxy settings (inherited by the locations below).
     proxy_http_version 1.1;
     proxy_set_header Host              $host;
     proxy_set_header X-Real-IP         $remote_addr;
@@ -54,22 +49,30 @@ server {
     proxy_read_timeout 3600s;
     proxy_buffering off;
 
-    # Identity for /api via an auth_request to the dashboard. See loma.conf.
+    # Internal identity subrequest: ask the dashboard who owns this session.
     location = /_whoami {
         internal;
         proxy_pass http://loma_dashboard/api/whoami;
         proxy_pass_request_body off;
         proxy_set_header Content-Length "";
     }
+
+    # NextAuth and self-signup are served by the dashboard (no identity needed).
     location /api/auth/  { proxy_pass http://loma_dashboard; }
     location /api/signup { proxy_pass http://loma_dashboard; }
+
+    # All other /api/* → backend, with a trusted X-User-Email from the auth_request.
     location /api/ {
         auth_request /_whoami;
         auth_request_set $auth_email $upstream_http_x_auth_email;
-        proxy_set_header X-User-Email $auth_email;
+        proxy_set_header X-User-Email $auth_email;   # overwrites any client value
         proxy_pass http://loma_backend;
     }
+
+    # Third-party webhooks (HMAC-authenticated) → backend.
     location /webhooks/ { proxy_pass http://loma_backend; }
     location = /webhook { proxy_pass http://loma_backend; }
-    location /          { proxy_pass http://loma_dashboard; }
+
+    # Dashboard UI and everything else.
+    location / { proxy_pass http://loma_dashboard; }
 }

--- a/docker-compose.tls.yml
+++ b/docker-compose.tls.yml
@@ -1,0 +1,25 @@
+# HTTPS overlay — enable with COMPOSE_FILE in your .env:
+#
+#   LOMA_DOMAIN=your.domain
+#   COMPOSE_FILE=docker-compose.yml:docker-compose.tls.yml
+#
+# Then obtain a cert and `docker compose up -d`. See deploy/nginx/README.md.
+# Without these env vars the base docker-compose.yml runs HTTP-only on :80.
+#
+# `!override` replaces the base nginx ports/volumes so the nginx image renders
+# deploy/nginx/templates/loma-tls.conf.template into conf.d at startup (the base's
+# read-only conf.d bind mount is dropped). NGINX_ENVSUBST_FILTER limits envsubst
+# to LOMA_* vars so nginx's own $variables are left intact.
+
+services:
+  nginx:
+    ports: !override
+      - "80:80"
+      - "443:443"
+    volumes: !override
+      - ./deploy/nginx/templates:/etc/nginx/templates:ro
+      - ./deploy/nginx/certbot/www:/var/www/certbot:ro
+      - ./deploy/nginx/certbot/conf:/etc/letsencrypt:ro
+    environment:
+      LOMA_DOMAIN: ${LOMA_DOMAIN:?set LOMA_DOMAIN in your .env to enable HTTPS}
+      NGINX_ENVSUBST_FILTER: "LOMA_"


### PR DESCRIPTION
## What
An opt-in HTTPS path for self-hosters. **Default is unchanged — HTTP on :80** (local + bare IP). HTTPS is enabled in a few steps via a committed, env-driven overlay (no hardcoded domain, no tracked-file edits).

- `deploy/nginx/templates/loma-tls.conf.template` — HTTPS server rendered by the nginx image from `${LOMA_DOMAIN}` (`NGINX_ENVSUBST_FILTER=LOMA_` keeps nginx `$vars` intact). Mirrors `loma.conf` including the `auth_request` identity injection, plus TLS + HTTP→HTTPS redirect.
- `docker-compose.tls.yml` — overlay adding `:443` and rendering the template (`!override` replaces base nginx ports/volumes). Inert unless `COMPOSE_FILE` + `LOMA_DOMAIN` are set.
- Removed the stale `loma-ssl.conf.example` (had the pre-auth_request routing that would re-break roles).
- `.env.example` + `deploy/nginx/README.md`: the few-step runbook.

Survives CI `git reset --hard` because `COMPOSE_FILE`/`LOMA_DOMAIN` live in the untracked `.env` and certs in an untracked volume.

## Validated on the box
nginx image renders the template (`${LOMA_DOMAIN}` filled, `$host`/`$auth_email` literal); overlay merges ports `80`+`443` and errors clearly if `LOMA_DOMAIN` is unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)