### PR TITLE
Support Google SSO as a per-deployment option (local stays default)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,11 @@ PUBLIC_BASE_URL=http://localhost
 # Internal backend port — behind the proxy, not exposed externally by default.
 WEBHOOK_PORT=3000
 
+# Login methods the dashboard UI shows: local | google | local,google. BUILD-TIME
+# (passed as a docker build arg), so set it here and `docker compose up -d --build`.
+# Keep it equal to AUTH_PROVIDER in dashboard/.env. See dashboard/.env.example.
+NEXT_PUBLIC_AUTH_PROVIDER=local
+
 # --- HTTPS (optional) ---
 # Default is HTTP on :80. To serve HTTPS on :443, get a cert and set these (see
 # deploy/nginx/README.md), then `docker compose up -d`:

--- a/dashboard/.env.example
+++ b/dashboard/.env.example
@@ -1,16 +1,28 @@
 # Auth.js / NextAuth
 AUTH_SECRET=generate-with-npx-auth-secret
+# Runtime login methods enabled: local | google | local,google. Default "local"
+# works locally and on an IP without HTTPS (email/password + first-admin setup token).
 AUTH_PROVIDER=local
-NEXT_PUBLIC_AUTH_PROVIDER=local
+# UI flag for which buttons the login page shows. This is BUILD-TIME (NEXT_PUBLIC_*),
+# so it is NOT read from this file — set NEXT_PUBLIC_AUTH_PROVIDER in the project-root
+# .env (it is passed as a docker build arg) and rebuild. Keep it equal to AUTH_PROVIDER.
 LOMA_SETUP_TOKEN=your-first-admin-setup-token
 
 # Required for local dashboard auth and user provisioning
 OBSERVABILITY_MONGODB_URI=mongodb+srv://user:pass@cluster.example.com/loma
 OBSERVABILITY_DB_NAME=loma_observability
 
-# Optional Google dashboard login. Set AUTH_PROVIDER=google or AUTH_PROVIDER=local,google to use it.
+# Optional Google SSO (requires HTTPS — Google won't redirect to a bare IP).
+#   1. Set AUTH_PROVIDER=google (or local,google) above, and NEXT_PUBLIC_AUTH_PROVIDER
+#      to the same value in the project-root .env, then rebuild.
+#   2. Create a Google OAuth Web client; authorized redirect URI:
+#      https://your-domain/api/auth/callback/google  (AUTH_URL must be https://your-domain).
+#   3. Restrict who can sign in with ALLOWED_EMAIL_DOMAINS. When set, matching Google
+#      users are auto-provisioned ACTIVE (first user becomes admin); without it, new
+#      Google users land in pending/admin-approval.
 AUTH_GOOGLE_ID=your-google-client-id.apps.googleusercontent.com
 AUTH_GOOGLE_SECRET=your-google-client-secret
+ALLOWED_EMAIL_DOMAINS=your-company.com
 # NextAuth external origin. Behind the nginx proxy (docker compose) set this to the
 # proxy address: http://<your-ip> (Phase 1) or https://<your-domain> (Phase 2).
 # Local dev without Docker: http://localhost:3001.

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -7,6 +7,11 @@ FROM node:20-slim AS build
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+# Which login methods the UI shows. NEXT_PUBLIC_* is inlined at build time, so it
+# must be a build arg (default "local"); set to "google" or "local,google" to show
+# the Google button. Passed via docker-compose build.args from the project .env.
+ARG NEXT_PUBLIC_AUTH_PROVIDER=local
+ENV NEXT_PUBLIC_AUTH_PROVIDER=$NEXT_PUBLIC_AUTH_PROVIDER
 RUN npm run build
 
 FROM node:20-slim

--- a/dashboard/src/auth-node.ts
+++ b/dashboard/src/auth-node.ts
@@ -175,12 +175,44 @@ export const { handlers } = NextAuth({
       if (account?.provider !== "google") {
         return true;
       }
-      const email = (user.email ?? "").toLowerCase();
+      const email = normalizeEmail(user.email);
       const configuredDomains = await readAllowedEmailDomains();
-      if (configuredDomains.length === 0) {
-        return true;
+
+      // Domain gate: when ALLOWED_EMAIL_DOMAINS is set, only matching emails may sign in.
+      if (
+        configuredDomains.length > 0 &&
+        !configuredDomains.some((domain) => email.endsWith(`@${domain}`))
+      ) {
+        return false;
       }
-      return configuredDomains.some((domain) => email.endsWith(`@${domain}`));
+
+      // Auto-provision allowed-domain Google users as ACTIVE — the domain restriction is
+      // the gate, so no separate admin approval is needed. The first user ever becomes
+      // admin, so a fresh google-only deployment can bootstrap without the local setup
+      // token. Existing records are left untouched (so roles set in the admin page stick).
+      // With no domain restriction (open Google) we do NOT auto-activate — the backend's
+      // pending/admin-approval flow still applies.
+      if (configuredDomains.length > 0 && email) {
+        const users = await getUsersCollection();
+        const existing = await users.findOne({ email });
+        if (!existing) {
+          const count = await users.countDocuments({});
+          const now = new Date();
+          await users.insertOne({
+            email,
+            name: user.name || email.split("@")[0] || email,
+            avatar: null,
+            system_role: count === 0 ? "admin" : "chatter",
+            status: "active",
+            tool_assignments: {},
+            theme_preference: "system",
+            claude_pool_enabled: true,
+            created_at: now,
+            updated_at: now,
+          });
+        }
+      }
+      return true;
     },
     jwt({ token, user }) {
       if (user?.email) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,11 @@ services:
     build:
       context: ./dashboard
       dockerfile: Dockerfile
+      args:
+        # Login UI: "local" (default), "google", or "local,google". Build-time
+        # (NEXT_PUBLIC_*); set NEXT_PUBLIC_AUTH_PROVIDER in the project .env and
+        # rebuild. The runtime AUTH_PROVIDER lives in dashboard/.env.
+        NEXT_PUBLIC_AUTH_PROVIDER: ${NEXT_PUBLIC_AUTH_PROVIDER:-local}
     env_file: ./dashboard/.env
     environment:
       BACKEND_URL: http://loma-backend:3000


### PR DESCRIPTION
## What
Makes Google SSO a usable per-deployment option while keeping **local email/password as the default** (OSS / no-HTTPS installs unchanged).

- **Login UI build arg** — `NEXT_PUBLIC_AUTH_PROVIDER` is build-time (inlined into the Next.js bundle), so the Google button requires it as a docker `ARG` (default `local`) + compose `build.args` from the project `.env`. Set to `google`/`local,google` to show it.
- **Auto-provision allowed-domain Google users as active** — `signIn` callback upserts a record with `status:"active"` and `system_role: count===0 ? "admin" : "chatter"` when the email matches `ALLOWED_EMAIL_DOMAINS` (first user → admin, so a google-only deployment bootstraps without the local setup token). Existing records untouched. No domain set → open Google still uses the backend's pending/admin-approval flow.
- `.env.example` / `dashboard/.env.example` document the setup (HTTPS requirement, redirect URI, the build-arg/two-file note).

Inert by default (`NEXT_PUBLIC_AUTH_PROVIDER`/`AUTH_PROVIDER` default `local`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)