### PR TITLE
Admin: remove users from the workspace

### DIFF
--- a/api/governance_routes.py
+++ b/api/governance_routes.py
@@ -257,6 +257,40 @@ async def handle_update_user(request: web.Request) -> web.Response:
     return web.json_response({"user": _serialize(user)})
 
 
+async def handle_delete_user(request: web.Request) -> web.Response:
+    """DELETE /api/governance/users/{email} — remove a user from the workspace."""
+    require_admin(request)
+    db = get_db()
+    if db is None:
+        return web.json_response({"error": "DB not configured"}, status=503)
+
+    email = request.match_info["email"]
+
+    if email == get_user_email(request):
+        return web.json_response({"error": "You cannot remove yourself."}, status=400)
+
+    target = await db.users.find_one({"email": email})
+    if target is None:
+        return web.json_response({"error": "User not found"}, status=404)
+
+    # Never leave the workspace without an admin.
+    if target.get("system_role") == "admin":
+        admin_count = await db.users.count_documents({"system_role": "admin"})
+        if admin_count <= 1:
+            return web.json_response({"error": "Cannot remove the last admin."}, status=400)
+
+    await db.users.delete_one({"email": email})
+
+    # The removed user may have been a Claude pool account — refresh the list.
+    try:
+        from agent.pool import get_pool
+        get_pool().refresh_accounts()
+    except RuntimeError:
+        pass
+
+    return web.json_response({"deleted": True})
+
+
 # ── Teams CRUD (admin only) ───────────────────────────────────────────────
 
 
@@ -434,6 +468,7 @@ def setup_governance_routes(app: web.Application):
     app.router.add_get("/api/governance/users", handle_list_users)
     app.router.add_get("/api/governance/users/{email}", handle_get_user)
     app.router.add_patch("/api/governance/users/{email}", handle_update_user)
+    app.router.add_delete("/api/governance/users/{email}", handle_delete_user)
 
     # Teams (admin only)
     app.router.add_get("/api/governance/teams", handle_list_teams)

--- a/dashboard/src/app/admin/page.tsx
+++ b/dashboard/src/app/admin/page.tsx
@@ -10,6 +10,7 @@ import {
   fetchTeams,
   fetchToolConfigs,
   updateUser,
+  deleteUser,
   getEffectiveRole,
   type User,
   type Team,
@@ -115,7 +116,7 @@ function StatusCell({ role, source, oauthStatus, authMode }: {
 /* ── Page ─────────────────────────────────────────────────────────── */
 
 export default function AdminPage() {
-  const { isAdmin, hasRole, loading: userLoading } = useUser();
+  const { user: currentUser, isAdmin, hasRole, loading: userLoading } = useUser();
   const isMaintainerOrAbove = hasRole("maintainer");
   const router = useRouter();
   const [tab, setTab] = useState<"users" | "teams" | "environment" | "settings" | "usage">("teams");
@@ -676,6 +677,9 @@ export default function AdminPage() {
                       <span className="text-[9px] text-gray-400 font-medium leading-tight">Slack</span>
                     </div>
                   </th>
+                  <th className="py-3 px-2 text-center text-[11px] font-semibold text-gray-400 uppercase tracking-wider min-w-[90px]">
+                    Actions
+                  </th>
                 </tr>
               </thead>
               <tbody>
@@ -817,6 +821,34 @@ export default function AdminPage() {
                         oauthStatus={user.tool_assignments?.["slack-personal"]?.oauth_status ?? "not_connected"}
                         authMode="tool-managed"
                       />
+                    </td>
+                    {/* Actions */}
+                    <td className="py-3 px-2 text-center">
+                      {currentUser?.email === user.email ? (
+                        <span className="text-[10px] text-gray-300">You</span>
+                      ) : (
+                        <button
+                          onClick={async () => {
+                            if (
+                              !confirm(
+                                `Remove ${user.name || user.email} from the workspace? They will lose access immediately. This cannot be undone.`
+                              )
+                            )
+                              return;
+                            const prev = users;
+                            setUsers((us) => us.filter((u) => u.email !== user.email));
+                            try {
+                              await deleteUser(user.email);
+                            } catch (e) {
+                              setUsers(prev);
+                              alert(e instanceof Error ? e.message : "Failed to remove user");
+                            }
+                          }}
+                          className="text-[11px] font-medium text-red-600 hover:text-red-700 hover:underline"
+                        >
+                          Remove
+                        </button>
+                      )}
                     </td>
                   </tr>
                 ))}

--- a/dashboard/src/lib/governance-api.ts
+++ b/dashboard/src/lib/governance-api.ts
@@ -99,6 +99,16 @@ export async function updateUser(
   return data.user;
 }
 
+export async function deleteUser(email: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/governance/users/${encodeURIComponent(email)}`, {
+    method: "DELETE",
+  });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error(data.error || `Failed to remove user: ${res.status}`);
+  }
+}
+
 export async function fetchTeams(): Promise<Team[]> {
   const res = await fetch(`${API_BASE}/api/governance/teams`);
   if (!res.ok) throw new Error(`Failed to fetch teams: ${res.status}`);


### PR DESCRIPTION
## What

Adds an admin-only ability to **remove a user from the workspace** from the Users admin table — fulfilling "provide admin the option to remove users from Team."

## Changes

- **Backend** — `DELETE /api/governance/users/{email}` (`require_admin`), mirroring `handle_delete_team`. Guards:
  - You cannot remove yourself (`400`).
  - You cannot remove the last admin (`400`) — the workspace always keeps at least one admin.
  - Refreshes the Claude pool after deletion (the removed user may have been a pool account).
- **Frontend client** — `deleteUser(email)` in `governance-api.ts`, surfacing the backend's error message.
- **Admin UI** — a new "Actions" column with a red **Remove** button per row: `confirm()` dialog, optimistic row removal with rollback + `alert()` on failure. The current user's own row shows "You" instead of a button.

## Note on durability

Removing a user **deletes** their governance record. On a Google-SSO deployment with an allowed domain, a still-eligible user would be **re-provisioned on their next Google login** (the `signIn` auto-provision path). To durably block someone, use **Reject** (sets `status: "rejected"`) instead of Remove. Remove is the right action for fully offboarding someone who no longer has domain access (or on local-auth deployments).

## Test

- `tsc --noEmit` clean; Python parses.
- Verify in-app: as admin, Users tab shows a Remove button on other users; removing one drops the row and revokes access; attempting to remove yourself / the last admin is blocked with a clear message.