### PR TITLE
CI(notify): wait for stack restart before posting deploy notification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,11 @@ jobs:
           if [ -n "$WEBHOOK_TOKEN" ]; then
             auth=(-H "Authorization: Bearer $WEBHOOK_TOKEN")
           fi
+          # The deploy restarts the stack, so the webhook host is briefly down.
+          # Wait for it to come back, then retry to ride out any remaining blip.
+          sleep 30
           curl -sS --fail-with-body -X POST "$WEBHOOK_URL" \
+            --retry 5 --retry-delay 10 --retry-connrefused --retry-all-errors \
             -H "Content-Type: application/json" \
             "${auth[@]}" \
             -d "$payload"


### PR DESCRIPTION
Follow-up to #26. The `notify` job fired while the deploy was still restarting the stack, so the POST to the webhook host (app.lomahq.com) failed with a connection error.

Fix: `sleep 30` for the restart, then `curl --retry 5 --retry-delay 10 --retry-connrefused --retry-all-errors` to ride out any remaining blip. Mirrors the original repo's `sleep 30` before notifying.

YAML + `bash -n` + OSS content/secret guards pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)