### PR TITLE
Add Slack-triggered flow type

### DIFF
--- a/api/flow_routes.py
+++ b/api/flow_routes.py
@@ -145,8 +145,24 @@ async def handle_get_flow(request: web.Request) -> web.Response:
     return web.json_response({"flow": _serialize(flow)})
 
 
+async def _slack_channel_taken(db, channel_id: str, exclude_flow_id: str | None = None) -> bool:
+    """Return True if an active Slack-triggered flow already watches this channel.
+
+    Enforces the "one active Slack flow per channel" rule so a top-level message
+    maps to exactly one flow/prompt.
+    """
+    query: dict = {
+        "trigger_type": "slack",
+        "status": "active",
+        "channel_id": channel_id,
+    }
+    if exclude_flow_id:
+        query["flow_id"] = {"$ne": exclude_flow_id}
+    return await db.flows.find_one(query) is not None
+
+
 async def handle_create_flow(request: web.Request) -> web.Response:
-    """POST /api/flows — create a new flow (scheduled or webhook-triggered)."""
+    """POST /api/flows — create a new flow (scheduled, webhook, or Slack-triggered)."""
     require_operator_or_above(request)
     db = get_db()
     if db is None:
@@ -166,6 +182,17 @@ async def handle_create_flow(request: web.Request) -> web.Response:
                 return web.json_response(
                     {"error": f"Missing required field: {field}"}, status=400,
                 )
+    elif trigger_type == "slack":
+        for field in ("name", "prompt", "channel_id"):
+            if field not in body:
+                return web.json_response(
+                    {"error": f"Missing required field: {field}"}, status=400,
+                )
+        if await _slack_channel_taken(db, body["channel_id"]):
+            return web.json_response(
+                {"error": "Another active Slack-triggered flow already watches this channel"},
+                status=409,
+            )
     else:
         for field in ("name", "prompt", "schedule_type"):
             if field not in body:
@@ -197,8 +224,8 @@ async def handle_create_flow(request: web.Request) -> web.Response:
 
     flow = await create_flow(db, body)
 
-    # Add to live scheduler if active (scheduled flows only)
-    if flow["status"] == "active" and trigger_type != "webhook":
+    # Add to live scheduler if active (scheduled flows only — webhook/slack are event-driven)
+    if flow["status"] == "active" and trigger_type == "scheduled":
         await add_flow_to_scheduler(flow)
         next_run = get_next_run_time(flow["flow_id"])
         if next_run:
@@ -243,6 +270,18 @@ async def handle_update_flow(request: web.Request) -> web.Response:
     if model_error is not None:
         return model_error
 
+    # Enforce "one active Slack flow per channel" if the watched channel is changing.
+    target_trigger = body.get("trigger_type", existing.get("trigger_type", "scheduled"))
+    if target_trigger == "slack" and "channel_id" in body:
+        target_status = body.get("status", existing.get("status"))
+        if target_status == "active" and await _slack_channel_taken(
+            db, body["channel_id"], exclude_flow_id=flow_id,
+        ):
+            return web.json_response(
+                {"error": "Another active Slack-triggered flow already watches this channel"},
+                status=409,
+            )
+
     # Parse datetime fields if present
     if "start_time" in body:
         body["start_time"] = _parse_datetime(body["start_time"])
@@ -254,7 +293,7 @@ async def handle_update_flow(request: web.Request) -> web.Response:
         return web.json_response({"error": "Flow not found"}, status=404)
 
     # Re-schedule if schedule-related fields changed (scheduled flows only)
-    if flow.get("trigger_type", "scheduled") != "webhook":
+    if flow.get("trigger_type", "scheduled") == "scheduled":
         schedule_fields = {"schedule_type", "cron", "timezone", "start_time", "end_time"}
         if schedule_fields & body.keys():
             await remove_flow_from_scheduler(flow_id)
@@ -317,10 +356,19 @@ async def handle_resume_flow(request: web.Request) -> web.Response:
     if existing is None or not _check_flow_access(existing, request):
         return web.json_response({"error": "Flow not found"}, status=404)
 
+    # A Slack flow can't be resumed if another active flow took its channel while paused.
+    if existing.get("trigger_type") == "slack" and await _slack_channel_taken(
+        db, existing.get("channel_id", ""), exclude_flow_id=flow_id,
+    ):
+        return web.json_response(
+            {"error": "Another active Slack-triggered flow already watches this channel"},
+            status=409,
+        )
+
     flow = await update_flow(db, flow_id, {"status": "active"})
 
     # Only register with APScheduler for scheduled flows
-    if flow.get("trigger_type", "scheduled") != "webhook":
+    if flow.get("trigger_type", "scheduled") == "scheduled":
         await add_flow_to_scheduler(flow)
         next_run = get_next_run_time(flow_id)
         if next_run:
@@ -348,6 +396,11 @@ async def handle_run_now(request: web.Request) -> web.Response:
     if flow.get("trigger_type") == "webhook":
         return web.json_response(
             {"error": "Webhook flows cannot be triggered manually — they require event data"},
+            status=400,
+        )
+    if flow.get("trigger_type") == "slack":
+        return web.json_response(
+            {"error": "Slack-triggered flows run when a message is posted in their channel"},
             status=400,
         )
 

--- a/dashboard/src/app/flows/[id]/page.tsx
+++ b/dashboard/src/app/flows/[id]/page.tsx
@@ -545,6 +545,8 @@ export default function FlowDetailPage() {
   }
 
   const isWebhook = flow.trigger_type === "webhook";
+  const isSlack = flow.trigger_type === "slack";
+  const isScheduled = (flow.trigger_type || "scheduled") === "scheduled";
   const webhookUrl = `${window.location.origin}/webhook?flowId=${flow.flow_id}`;
 
   return (
@@ -658,7 +660,7 @@ export default function FlowDetailPage() {
               {flow.status === "active" ? "Pause" : "Resume"}
             </button>
           )}
-          {flow.status === "active" && !isWebhook && (
+          {flow.status === "active" && isScheduled && (
             <button
               onClick={handleRunNow}
               className="px-3 py-1.5 text-sm font-medium rounded-lg border border-gray-200 text-gray-700 hover:bg-gray-50 transition-colors"
@@ -732,7 +734,7 @@ export default function FlowDetailPage() {
             <div className="flex justify-between">
               <span className="text-gray-500">Trigger</span>
               <span className="text-gray-900 font-medium">
-                {isWebhook ? "Webhook" : "Scheduled"}
+                {isWebhook ? "Webhook" : isSlack ? "Slack" : "Scheduled"}
               </span>
             </div>
             {isWebhook ? (
@@ -749,6 +751,23 @@ export default function FlowDetailPage() {
                     </code>
                   </div>
                 )}
+              </>
+            ) : isSlack ? (
+              <>
+                <div className="flex justify-between">
+                  <span className="text-gray-500">Channel</span>
+                  <span className="text-gray-900">{flow.channel_name || flow.channel_id}</span>
+                </div>
+                {flow.slack_config?.allow_bot_messages && (
+                  <div className="flex justify-between">
+                    <span className="text-gray-500">Bot messages</span>
+                    <span className="text-gray-900">Enabled</span>
+                  </div>
+                )}
+                <p className="text-xs text-gray-400 pt-1">
+                  Responds to new top-level messages in this channel and replies in-thread.
+                  @mention the bot to reply inside a thread.
+                </p>
               </>
             ) : (
               <>
@@ -801,7 +820,7 @@ export default function FlowDetailPage() {
               <span className="text-gray-500">Last run</span>
               <ClientTimestamp iso={flow.last_run_at} variant="full" className="text-gray-900" />
             </div>
-            {!isWebhook && (
+            {isScheduled && (
               <div className="flex justify-between">
                 <span className="text-gray-500">Next run</span>
                 {flow.status === "active" ? (

--- a/dashboard/src/app/flows/page.tsx
+++ b/dashboard/src/app/flows/page.tsx
@@ -11,7 +11,7 @@ import ClientTimestamp from "../../components/ClientTimestamp";
 type FlowTab = "all" | "drafts" | "disabled";
 
 const STATUS_FILTERS = ["all", "active", "paused", "completed"] as const;
-const TRIGGER_TYPE_FILTERS = ["all", "scheduled", "webhook"] as const;
+const TRIGGER_TYPE_FILTERS = ["all", "scheduled", "webhook", "slack"] as const;
 
 const LABEL_COLORS = [
   { bg: "bg-blue-50", text: "text-blue-700", border: "border-blue-200" },
@@ -334,6 +334,11 @@ export default function FlowsPage() {
                         <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m13.35-.622 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244" /></svg>
                         Webhook{flow.webhook_config?.auth_method ? ` \u00b7 ${flow.webhook_config.auth_method}` : ""}
                       </span>
+                    ) : flow.trigger_type === "slack" ? (
+                      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs font-medium bg-emerald-50 text-emerald-700 border border-emerald-200">
+                        <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M5.25 8.25h15m-16.5 7.5h15m-1.8-13.5-3.9 19.5m-2.1-19.5-3.9 19.5" /></svg>
+                        Slack{flow.channel_name ? ` \u00b7 ${flow.channel_name}` : (flow.channel_id ? ` \u00b7 ${flow.channel_id}` : "")}
+                      </span>
                     ) : (
                       <>
                         <span className="flex items-center gap-1">
@@ -359,7 +364,7 @@ export default function FlowsPage() {
                       )}
                     </button>
                   )}
-                  {flow.status === "active" && flow.trigger_type !== "webhook" && (
+                  {flow.status === "active" && (flow.trigger_type || "scheduled") === "scheduled" && (
                     <button onClick={() => handleRunNow(flow)} className="p-1.5 rounded-lg text-gray-400 hover:text-brand-700 hover:bg-brand-50 transition-colors press-scale" title="Run now">
                       <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" d="M3 8.689c0-.864.933-1.406 1.683-.977l7.108 4.061a1.125 1.125 0 0 1 0 1.954l-7.108 4.061A1.125 1.125 0 0 1 3 16.811V8.69ZM12.75 8.689c0-.864.933-1.406 1.683-.977l7.108 4.061a1.125 1.125 0 0 1 0 1.954l-7.108 4.061a1.125 1.125 0 0 1-1.683-.977V8.69Z" /></svg>
                     </button>

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -418,13 +418,17 @@ export interface WebhookConfig {
   signature_header?: string;
 }
 
+export interface SlackConfig {
+  allow_bot_messages?: boolean;
+}
+
 export interface Flow {
   flow_id: string;
   name: string;
   description: string;
   prompt: string;
   model?: string | null;
-  trigger_type?: "scheduled" | "webhook";
+  trigger_type?: "scheduled" | "webhook" | "slack";
   schedule_type: "once" | "recurring";
   frequency: string;
   cron: string | null;
@@ -435,6 +439,7 @@ export interface Flow {
   channel_name: string;
   prompt_template?: string;
   webhook_config?: WebhookConfig;
+  slack_config?: SlackConfig;
   status: "active" | "paused" | "completed";
   labels: string[];
   visibility?: "private" | "shared";

--- a/scheduler/models.py
+++ b/scheduler/models.py
@@ -19,7 +19,8 @@ async def create_flow(db, data: dict) -> dict:
         "prompt": data.get("prompt", ""),
         "model": data.get("model"),
 
-        # Trigger type: "scheduled" (cron/one-time) or "webhook" (event-driven)
+        # Trigger type: "scheduled" (cron/one-time), "webhook" (event-driven),
+        # or "slack" (responds to top-level messages in a Slack channel)
         "trigger_type": trigger_type,
 
         # Schedule (used by scheduled flows)
@@ -30,13 +31,18 @@ async def create_flow(db, data: dict) -> dict:
         "start_time": data.get("start_time"),
         "end_time": data.get("end_time"),
 
-        # Channel (used by scheduled flows for Slack posting)
+        # Channel — used by scheduled flows for Slack posting, and by Slack-triggered
+        # flows as the channel whose top-level messages the agent responds to.
         "channel_id": data.get("channel_id", ""),
         "channel_name": data.get("channel_name", ""),
 
         # Webhook config (used by webhook flows)
         "prompt_template": data.get("prompt_template", ""),
         "webhook_config": data.get("webhook_config", {}),
+
+        # Slack-triggered config (used by slack flows). allow_bot_messages lets the
+        # flow respond to messages from bots/automations (e.g. alert channels).
+        "slack_config": data.get("slack_config", {}),
 
         # Status
         "status": data.get("status", "active"),

--- a/slack_app/channels.py
+++ b/slack_app/channels.py
@@ -1,12 +1,78 @@
-"""Optional Slack channel workflow registry.
+"""Slack channel workflow registry.
 
-The first OSS release keeps channel-specific automations disabled by default.
-A later release will move these workflows into dashboard-managed database records.
+Two sources feed the per-channel agent automations:
+
+1. A static, env/code-defined ``CHANNEL_CONFIGS`` map (empty by default in OSS).
+2. **Slack-triggered flows** stored in MongoDB — a flow with ``trigger_type: "slack"``
+   watches a channel and replies to each new top-level message in its thread.
+
+``get_channel_config`` resolves both; the static map takes precedence.
 """
+
+import logging
+
+from observability.db import get_db
+
+logger = logging.getLogger(__name__)
 
 CHANNEL_CONFIGS: dict[str, dict] = {}
 
+# Prepended to a Slack-triggered flow's prompt. The agent's final text reply is
+# posted back into the message's thread automatically (see _stream_response).
+SLACK_FLOW_PREAMBLE = (
+    "{flow_prompt}\n\n"
+    "---\n"
+    "A new message was just posted in the Slack channel #{channel_name}. Your text "
+    "reply will be posted back into that message's thread automatically — output only "
+    "the reply content (no preamble or commentary).\n\n"
+    "Message:\n"
+)
 
-def get_channel_config(channel_id: str) -> dict | None:
-    """Return config for a monitored channel, or None if not monitored."""
-    return CHANNEL_CONFIGS.get(channel_id)
+
+def _config_from_slack_flow(flow: dict) -> dict:
+    """Build a channel config dict from a Slack-triggered flow document."""
+    channel_name = flow.get("channel_name") or flow.get("channel_id", "")
+    return {
+        "name": channel_name.lstrip("#") or flow.get("channel_id", ""),
+        "source": "slack_flow",
+        "flow_id": flow["flow_id"],
+        "prompt_prefix": SLACK_FLOW_PREAMBLE.format(
+            flow_prompt=flow.get("prompt", ""),
+            channel_name=channel_name.lstrip("#"),
+        ),
+        "allow_bot_messages": bool(
+            (flow.get("slack_config") or {}).get("allow_bot_messages", False)
+        ),
+    }
+
+
+async def get_channel_config(channel_id: str) -> dict | None:
+    """Return the agent config for a monitored channel, or None if not monitored.
+
+    Checks the static ``CHANNEL_CONFIGS`` first, then an active Slack-triggered
+    flow watching this channel (at most one — enforced at flow creation).
+    """
+    if not channel_id:
+        return None
+
+    static = CHANNEL_CONFIGS.get(channel_id)
+    if static is not None:
+        return static
+
+    db = get_db()
+    if db is None:
+        return None
+
+    try:
+        flow = await db.flows.find_one({
+            "trigger_type": "slack",
+            "status": "active",
+            "channel_id": channel_id,
+        })
+    except Exception:
+        logger.exception("[SLACK] Failed to look up Slack flow for channel %s", channel_id)
+        return None
+
+    if flow is None:
+        return None
+    return _config_from_slack_flow(flow)

--- a/slack_app/handlers.py
+++ b/slack_app/handlers.py
@@ -84,12 +84,33 @@ async def _stream_response(client, channel, thread_ts, react_ts, agent_stream):
     )
 
 
+async def _record_flow_run(db, flow_id, conversation_id):
+    """Record a run on a Slack-triggered flow so the dashboard shows run stats/history."""
+    from datetime import datetime, timezone
+    try:
+        await db.flows.update_one(
+            {"flow_id": flow_id},
+            {
+                "$set": {
+                    "last_run_at": datetime.now(timezone.utc),
+                    "last_run_conversation_id": conversation_id,
+                    "last_error": None,
+                },
+                "$inc": {"run_count": 1},
+            },
+        )
+    except Exception:
+        logger.exception("[SLACK] Failed to record flow run for %s", flow_id)
+
+
 async def _handle_agent_request(
     client, channel, thread_ts, event_ts, prompt, context, files, source, user_id,
+    flow_id=None,
 ):
     """Common flow: hourglass \u2192 observer \u2192 stream agent \u2192 post responses.
 
-    Used by app_mention, DM, and monitored channel handlers to avoid duplication.
+    Used by app_mention, DM, monitored-channel, and Slack-flow handlers to avoid
+    duplication. When ``flow_id`` is set, the run is attributed to that flow.
     """
     # Add hourglass reaction as acknowledgement
     logger.info("[SLACK] Adding hourglass reaction to message...")
@@ -131,6 +152,8 @@ async def _handle_agent_request(
                 "slack_thread_ts": thread_ts,
                 "user_name": user_email or user_id,
             }
+            if flow_id:
+                metadata["flow_id"] = flow_id
             if existing_convo:
                 observer = ConversationObserver(
                     db, metadata=metadata,
@@ -170,6 +193,11 @@ async def _handle_agent_request(
             asyncio.create_task(ingest_dashboard_chat(
                 observer.conversation_id, prompt, user_email or "",
             ))
+            # Attribute the run to its Slack-triggered flow (run stats + history).
+            if flow_id and db is not None:
+                asyncio.create_task(
+                    _record_flow_run(db, flow_id, observer.conversation_id)
+                )
 
     except Exception as e:
         logger.exception("Error in agent request")
@@ -231,7 +259,7 @@ def register_handlers(app):
             files = await download_slack_files(client.token, all_raw_files)
 
         # Check if this is a monitored channel — prepend channel context if so
-        channel_config = get_channel_config(channel)
+        channel_config = await get_channel_config(channel)
         if channel_config:
             prompt = channel_config["prompt_prefix"] + user_message
             source = channel_config["source"]
@@ -242,6 +270,7 @@ def register_handlers(app):
 
         await _handle_agent_request(
             client, channel, thread_ts, event_ts, prompt, context, files, source, user,
+            flow_id=channel_config.get("flow_id") if channel_config else None,
         )
 
     @app.event("message")
@@ -253,7 +282,7 @@ def register_handlers(app):
         subtype = event.get("subtype")
         is_bot = bool(event.get("bot_id"))
         if is_bot:
-            channel_cfg = get_channel_config(event.get("channel", ""))
+            channel_cfg = await get_channel_config(event.get("channel", ""))
             if not (channel_cfg and channel_cfg.get("allow_bot_messages")):
                 return
         if subtype and subtype not in ("file_share", "bot_message"):
@@ -267,7 +296,7 @@ def register_handlers(app):
         has_files = bool(event.get("files"))
 
         # --- Monitored channels (e.g., #bugs, #feature-requests-clients) ---
-        channel_config = get_channel_config(channel)
+        channel_config = await get_channel_config(channel)
         if channel_config:
             # Skip messages that contain a bot @mention — those are handled by app_mention
             if BOT_MENTION_RE.search(text):
@@ -298,6 +327,7 @@ def register_handlers(app):
             await _handle_agent_request(
                 client, channel, thread_ts, event_ts, prompt, "", files,
                 channel_config["source"], user,
+                flow_id=channel_config.get("flow_id"),
             )
             return
 

--- a/tests/test_slack_flow.py
+++ b/tests/test_slack_flow.py
@@ -1,0 +1,141 @@
+"""Tests for Slack-triggered flows.
+
+Covers the new logic introduced for ``trigger_type: "slack"`` flows:
+- slack_app.channels.get_channel_config: DB-driven channel → flow resolution
+- slack_app.channels._config_from_slack_flow: flow doc → channel config mapping
+- api.flow_routes._slack_channel_taken: one-active-flow-per-channel guard
+
+The message-handler top-level/thread/@mention/bot filtering is pre-existing Loma
+code reused unchanged, so it is not re-tested here.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from slack_app.channels import (
+    get_channel_config,
+    _config_from_slack_flow,
+    CHANNEL_CONFIGS,
+)
+from api.flow_routes import _slack_channel_taken
+
+
+def _slack_flow(**overrides):
+    flow = {
+        "flow_id": "flow-123",
+        "name": "Bug triage",
+        "trigger_type": "slack",
+        "status": "active",
+        "channel_id": "C0001",
+        "channel_name": "#bugs",
+        "prompt": "Triage the bug.",
+        "slack_config": {},
+    }
+    flow.update(overrides)
+    return flow
+
+
+# ---------------------------------------------------------------------------
+# _config_from_slack_flow
+# ---------------------------------------------------------------------------
+
+
+class TestConfigFromSlackFlow:
+    def test_basic_mapping(self):
+        cfg = _config_from_slack_flow(_slack_flow())
+        assert cfg["source"] == "slack_flow"
+        assert cfg["flow_id"] == "flow-123"
+        assert cfg["name"] == "bugs"  # leading '#' stripped
+        assert cfg["allow_bot_messages"] is False
+        # The flow prompt is embedded in the prefix, and the user message is appended after.
+        assert "Triage the bug." in cfg["prompt_prefix"]
+        assert cfg["prompt_prefix"].endswith("Message:\n")
+
+    def test_allow_bot_messages_toggle(self):
+        cfg = _config_from_slack_flow(_slack_flow(slack_config={"allow_bot_messages": True}))
+        assert cfg["allow_bot_messages"] is True
+
+    def test_missing_channel_name_falls_back_to_id(self):
+        cfg = _config_from_slack_flow(_slack_flow(channel_name="", channel_id="C0009"))
+        assert cfg["name"] == "C0009"
+
+
+# ---------------------------------------------------------------------------
+# get_channel_config
+# ---------------------------------------------------------------------------
+
+
+class TestGetChannelConfig:
+    @pytest.mark.asyncio
+    async def test_empty_channel_id_returns_none(self):
+        assert await get_channel_config("") is None
+
+    @pytest.mark.asyncio
+    async def test_no_db_returns_none(self):
+        with patch("slack_app.channels.get_db", return_value=None):
+            assert await get_channel_config("C0001") is None
+
+    @pytest.mark.asyncio
+    async def test_resolves_active_slack_flow(self):
+        db = MagicMock()
+        db.flows.find_one = AsyncMock(return_value=_slack_flow())
+        with patch("slack_app.channels.get_db", return_value=db):
+            cfg = await get_channel_config("C0001")
+        assert cfg is not None
+        assert cfg["flow_id"] == "flow-123"
+        # Query is scoped to active slack flows on this channel — paused/other-type are ignored.
+        db.flows.find_one.assert_awaited_once_with({
+            "trigger_type": "slack",
+            "status": "active",
+            "channel_id": "C0001",
+        })
+
+    @pytest.mark.asyncio
+    async def test_no_matching_flow_returns_none(self):
+        db = MagicMock()
+        db.flows.find_one = AsyncMock(return_value=None)
+        with patch("slack_app.channels.get_db", return_value=db):
+            assert await get_channel_config("C0404") is None
+
+    @pytest.mark.asyncio
+    async def test_static_config_takes_precedence(self):
+        CHANNEL_CONFIGS["C0001"] = {"name": "static", "source": "env", "prompt_prefix": "x"}
+        try:
+            db = MagicMock()
+            db.flows.find_one = AsyncMock(return_value=_slack_flow())
+            with patch("slack_app.channels.get_db", return_value=db):
+                cfg = await get_channel_config("C0001")
+            assert cfg["source"] == "env"
+            db.flows.find_one.assert_not_awaited()
+        finally:
+            CHANNEL_CONFIGS.pop("C0001", None)
+
+
+# ---------------------------------------------------------------------------
+# _slack_channel_taken (one active flow per channel)
+# ---------------------------------------------------------------------------
+
+
+class TestSlackChannelTaken:
+    @pytest.mark.asyncio
+    async def test_taken_when_active_flow_exists(self):
+        db = MagicMock()
+        db.flows.find_one = AsyncMock(return_value=_slack_flow())
+        assert await _slack_channel_taken(db, "C0001") is True
+
+    @pytest.mark.asyncio
+    async def test_free_when_no_flow(self):
+        db = MagicMock()
+        db.flows.find_one = AsyncMock(return_value=None)
+        assert await _slack_channel_taken(db, "C0001") is False
+
+    @pytest.mark.asyncio
+    async def test_excludes_self(self):
+        db = MagicMock()
+        db.flows.find_one = AsyncMock(return_value=None)
+        await _slack_channel_taken(db, "C0001", exclude_flow_id="flow-123")
+        args, _ = db.flows.find_one.call_args
+        assert args[0]["flow_id"] == {"$ne": "flow-123"}
+        assert args[0]["trigger_type"] == "slack"
+        assert args[0]["status"] == "active"


### PR DESCRIPTION
## What

Adds a **third flow `trigger_type`: `slack`**, generalizing the old `plotline-ie-slackbot` per-channel hardcoded agent execution into a configurable flow.

A **Slack-triggered flow** takes a **channel + prompt** and:
- replies, in the message's **thread**, to each new **top-level** message in that channel;
- **ignores thread replies** unless the bot is **@mentioned** (then it replies in-thread and continues the same conversation);
- responds to **humans only** by default, with an optional `slack_config.allow_bot_messages` toggle for alert-style channels (the old `#alerts` case);
- enforces **one active Slack flow per channel**.

## How — reuse, not rebuild

Loma already ships the entire Slack stack the old repo used: `handle_message` already does the top-level/thread/@mention/bot filtering and dispatches via `get_channel_config(channel)`, and `_handle_agent_request` already resumes per-thread conversations and posts in-thread. It was dormant only because `CHANNEL_CONFIGS` is an empty static dict.

This PR:
- Makes `get_channel_config` **async + DB-driven** — it resolves an active `trigger_type:"slack"` flow for the channel and builds the prompt prefix (the agent's reply is auto-posted to the thread by the existing `_stream_response`).
- Threads `flow_id` through `_handle_agent_request` → `metadata.flow_id`, so each run shows up in the flow's run history (`GET /api/flows/{id}/runs`) and updates `run_count`/`last_run_at` (`_record_flow_run`).

## Changes

**Backend**
- `scheduler/models.py`: `trigger_type ∈ {scheduled, webhook, slack}`; add `slack_config`.
- `api/flow_routes.py`: validate slack flows (`name`/`prompt`/`channel_id`); **one-active-flow-per-channel** (409) on create/update/resume; reject `run-now`; keep slack/webhook out of APScheduler (tightened guards to `== "scheduled"`).
- `slack_app/channels.py`: async, DB-backed `get_channel_config` + prompt-prefix builder.
- `slack_app/handlers.py`: await the now-async lookup; attribute runs via `flow_id` + `_record_flow_run`.

**Dashboard**
- `lib/api.ts`: `trigger_type` includes `"slack"`; add `SlackConfig`.
- `flows/page.tsx`: `slack` filter + green badge (channel name).
- `flows/[id]/page.tsx`: slack branch in Details (channel + helper text), no webhook URL/logs, Run-now hidden; Execution History works.

**Tests**
- `tests/test_slack_flow.py` (11 tests): channel→flow resolution (incl. static precedence, no-db, query scoping), config mapping (incl. `allow_bot_messages`), and the one-active-per-channel guard.

## Test
- `pytest tests/test_slack_flow.py tests/test_webhook_executor.py tests/test_scheduled_executor.py tests/test_slack_utils.py` → 73 passed.
- `tsc --noEmit` clean; Python imports clean.

## Follow-ups (separate, not in this PR)
- Update the **`flows` skill in MongoDB** to document the new type (server-side data).
- Add a **gogo-website** marketing card for the third flow type.