### PR TITLE
Admin-added custom remote MCP connectors

### DIFF
--- a/agent/client.py
+++ b/agent/client.py
@@ -125,6 +125,23 @@ async def merge_db_integrations(config: dict) -> dict:
         mcp_servers = config.get("mcp_servers", {})
         async for integration in db.integrations.find({"status": "active"}):
             provider = integration["provider"]
+
+            # Custom connectors carry their own inline remote MCP config (no
+            # catalog entry). Added by admins from the Integrations page.
+            if integration.get("is_custom"):
+                try:
+                    cfg = {"type": "http", "url": integration["mcp_url"]}
+                    if integration.get("api_key_encrypted"):
+                        header = integration.get("auth_header") or "Authorization"
+                        cfg["headers"] = {
+                            header: decrypt_token(integration["api_key_encrypted"]),
+                        }
+                    mcp_servers[provider] = cfg
+                    logger.info("Loaded custom MCP connector '%s' from DB", provider)
+                except Exception:
+                    logger.exception("Failed to load custom MCP connector %s", provider)
+                continue
+
             catalog_entry = PROVIDER_CATALOG.get(provider)
             if not catalog_entry:
                 continue

--- a/api/integration_routes.py
+++ b/api/integration_routes.py
@@ -7,16 +7,28 @@ in MongoDB and trigger MCP pool reload when integrations change.
 
 import logging
 import os
+import re
 import uuid
 from datetime import datetime, timezone
 
 from aiohttp import web
 
+from api.auth_helpers import require_admin, get_user_email
 from api.oauth_helpers import encrypt_token, decrypt_token
 from integrations.registry import PROVIDER_CATALOG, list_providers, get_provider
 from observability.db import get_db
 
 logger = logging.getLogger(__name__)
+
+
+def _slugify(name: str) -> str:
+    """Derive a stable MCP server key from a connector name.
+
+    Lowercased, non-alphanumerics collapsed to underscores. The slug becomes
+    the MCP server name, so the agent exposes its tools as ``mcp__<slug>``.
+    """
+    slug = re.sub(r"[^a-z0-9]+", "_", name.strip().lower()).strip("_")
+    return slug
 
 
 async def _list_integrations(request: web.Request) -> web.Response:
@@ -59,6 +71,27 @@ async def _list_integrations(request: web.Request) -> web.Response:
         if provider in connected:
             item.update(connected[provider])
         result.append(item)
+
+    # Append admin-added custom MCP connectors (not in the static catalog).
+    if db is not None:
+        async for doc in db.integrations.find({"is_custom": True, "status": "active"}):
+            result.append({
+                "provider": doc["provider"],
+                "display_name": doc.get("display_name", doc["provider"]),
+                "description": "Custom MCP server",
+                "auth_type": "custom",
+                "auth_label": "Access token",
+                "auth_help_url": "",
+                "has_webhook": False,
+                "webhook_secret_label": None,
+                "extra_fields": [],
+                "status": "connected",
+                "is_custom": True,
+                "url": doc.get("mcp_url", ""),
+                "has_token": bool(doc.get("api_key_encrypted")),
+                "connected_by": doc.get("connected_by"),
+                "connected_at": doc.get("connected_at").isoformat() if doc.get("connected_at") else None,
+            })
 
     return web.json_response(result)
 
@@ -136,6 +169,85 @@ async def _disconnect_integration(request: web.Request) -> web.Response:
     return web.json_response({"status": "disconnected", "provider": provider})
 
 
+async def _add_custom_connector(request: web.Request) -> web.Response:
+    """POST /api/integrations/custom — register a custom remote MCP server.
+
+    Admin-only. The connector's tools become available to every user's agent.
+    """
+    require_admin(request)
+    db = get_db()
+    if db is None:
+        return web.json_response({"error": "Database not available"}, status=503)
+
+    body = await request.json()
+    name = (body.get("name") or "").strip()
+    url = (body.get("url") or "").strip()
+    token = (body.get("token") or "").strip()
+    auth_header = (body.get("auth_header") or "Authorization").strip() or "Authorization"
+
+    if not name or not url:
+        return web.json_response({"error": "name and url are required"}, status=400)
+    if not re.match(r"^https?://", url):
+        return web.json_response({"error": "url must start with http:// or https://"}, status=400)
+
+    slug = _slugify(name)
+    if not slug:
+        return web.json_response(
+            {"error": "name must contain letters or numbers"}, status=400,
+        )
+    if slug in PROVIDER_CATALOG:
+        return web.json_response(
+            {"error": f"'{slug}' collides with a built-in integration; choose another name"},
+            status=409,
+        )
+    existing = await db.integrations.find_one({"provider": slug})
+    if existing is not None:
+        return web.json_response(
+            {"error": f"A connector named '{slug}' already exists"}, status=409,
+        )
+
+    user_email = get_user_email(request) or "unknown"
+    now = datetime.now(timezone.utc)
+    doc = {
+        "integration_id": str(uuid.uuid4()),
+        "provider": slug,
+        "is_custom": True,
+        "status": "active",
+        "display_name": name,
+        "mcp_url": url,
+        "auth_header": auth_header,
+        "api_key_encrypted": encrypt_token(token) if token else None,
+        "connected_by": user_email,
+        "connected_at": now,
+        "updated_at": now,
+    }
+    await db.integrations.insert_one(doc)
+    logger.info("[INTEGRATIONS] Added custom MCP connector '%s' (by %s)", slug, user_email)
+
+    await _reload_pool()
+
+    return web.json_response({"status": "connected", "provider": slug}, status=201)
+
+
+async def _remove_custom_connector(request: web.Request) -> web.Response:
+    """DELETE /api/integrations/custom/{provider} — remove a custom MCP connector."""
+    require_admin(request)
+    db = get_db()
+    if db is None:
+        return web.json_response({"error": "Database not available"}, status=503)
+
+    provider = request.match_info["provider"]
+    result = await db.integrations.delete_one({"provider": provider, "is_custom": True})
+    if result.deleted_count == 0:
+        return web.json_response({"error": "Custom connector not found"}, status=404)
+
+    logger.info("[INTEGRATIONS] Removed custom MCP connector '%s'", provider)
+
+    await _reload_pool()
+
+    return web.json_response({"status": "disconnected", "provider": provider})
+
+
 async def _get_webhook_url(request: web.Request) -> web.Response:
     """GET /api/integrations/{provider}/webhook-url — return the webhook URL."""
     provider = request.match_info["provider"]
@@ -182,5 +294,7 @@ def setup_integration_routes(app: web.Application):
     """Register integration API routes."""
     app.router.add_get("/api/integrations", _list_integrations)
     app.router.add_post("/api/integrations/connect", _connect_integration)
+    app.router.add_post("/api/integrations/custom", _add_custom_connector)
+    app.router.add_delete("/api/integrations/custom/{provider}", _remove_custom_connector)
     app.router.add_delete("/api/integrations/{provider}", _disconnect_integration)
     app.router.add_get("/api/integrations/{provider}/webhook-url", _get_webhook_url)

--- a/dashboard/src/app/integrations/manage/page.tsx
+++ b/dashboard/src/app/integrations/manage/page.tsx
@@ -19,6 +19,8 @@ import {
   fetchIntegrations,
   connectIntegration,
   disconnectIntegration,
+  addCustomConnector,
+  removeCustomConnector,
   getWebhookUrl,
   type Integration,
 } from "../../../lib/integration-api";
@@ -303,8 +305,15 @@ export default function IntegrationsPage() {
   const [webhookUrls, setWebhookUrls] = useState<Record<string, string>>({});
 
   // Role check — only maintainers+ can see org integrations
-  const { hasRole } = useUser();
+  const { hasRole, isAdmin } = useUser();
   const canManageOrgIntegrations = hasRole("maintainer");
+
+  // Custom MCP connector modal state (admin only)
+  const [showCustomModal, setShowCustomModal] = useState(false);
+  const [customForm, setCustomForm] = useState({ name: "", url: "", token: "", authHeader: "" });
+  const [customAdvanced, setCustomAdvanced] = useState(false);
+  const [addingCustom, setAddingCustom] = useState(false);
+  const [removingCustom, setRemovingCustom] = useState<string | null>(null);
 
   // Claude Code integration state
   const [claudeAuth, setClaudeAuth] = useState<ClaudeAuthStatus | null>(null);
@@ -501,6 +510,42 @@ export default function IntegrationsPage() {
     await loadConnections();
   };
 
+  const handleAddCustomConnector = async () => {
+    if (!customForm.name.trim() || !customForm.url.trim()) return;
+    setAddingCustom(true);
+    setError(null);
+    try {
+      await addCustomConnector({
+        name: customForm.name.trim(),
+        url: customForm.url.trim(),
+        token: customForm.token.trim() || undefined,
+        authHeader: customForm.authHeader.trim() || undefined,
+      });
+      setShowCustomModal(false);
+      setCustomForm({ name: "", url: "", token: "", authHeader: "" });
+      setCustomAdvanced(false);
+      await loadConnections();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to add connector");
+    } finally {
+      setAddingCustom(false);
+    }
+  };
+
+  const handleRemoveCustomConnector = async (provider: string, displayName: string) => {
+    if (!confirm(`Remove ${displayName}? Its MCP tools will no longer be available to any user.`)) return;
+    setRemovingCustom(provider);
+    setError(null);
+    try {
+      await removeCustomConnector(provider);
+      await loadConnections();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : `Failed to remove ${displayName}`);
+    } finally {
+      setRemovingCustom(null);
+    }
+  };
+
   const copyWebhookUrl = (url: string) => {
     navigator.clipboard.writeText(url);
   };
@@ -531,9 +576,10 @@ export default function IntegrationsPage() {
   const isSlackConnected = slackConn?.status === "connected";
   const isSlackExpired = slackConn?.status === "expired";
 
-  // Split org integrations into user-managed and system-managed
-  const userManagedIntegrations = orgIntegrations.filter((i) => i.status !== "system_managed");
-  const systemManagedIntegrations = orgIntegrations.filter((i) => i.status === "system_managed");
+  // Split org integrations into user-managed, system-managed, and custom connectors
+  const userManagedIntegrations = orgIntegrations.filter((i) => !i.is_custom && i.status !== "system_managed");
+  const systemManagedIntegrations = orgIntegrations.filter((i) => !i.is_custom && i.status === "system_managed");
+  const customConnectors = orgIntegrations.filter((i) => i.is_custom);
 
   return (
     <div className="space-y-6 animate-fade-in-up">
@@ -558,6 +604,106 @@ export default function IntegrationsPage() {
           onClose={() => setConnectModalTarget(null)}
           onConnected={handleOrgConnected}
         />
+      )}
+
+      {/* Add Custom Connector Modal — admin only */}
+      {showCustomModal && isAdmin && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+          <div className="bg-surface rounded-2xl border border-gray-200 w-full max-w-lg p-6 shadow-xl">
+            <div className="flex items-start justify-between mb-1">
+              <h2 className="text-lg font-semibold text-gray-900">Add custom connector</h2>
+              <button
+                onClick={() => setShowCustomModal(false)}
+                className="text-gray-400 hover:text-gray-600 text-xl leading-none"
+                aria-label="Close"
+              >
+                ×
+              </button>
+            </div>
+            <p className="text-sm text-gray-500 mb-5">
+              Connect the agent to any remote MCP server. Its tools become available to every user.
+            </p>
+
+            <div className="space-y-4">
+              <div>
+                <label className="block text-xs font-medium text-gray-500 mb-1">Name</label>
+                <input
+                  type="text"
+                  value={customForm.name}
+                  onChange={(e) => setCustomForm((f) => ({ ...f, name: e.target.value }))}
+                  placeholder="Acme MCP"
+                  className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-100"
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-gray-500 mb-1">Remote MCP server URL</label>
+                <input
+                  type="url"
+                  value={customForm.url}
+                  onChange={(e) => setCustomForm((f) => ({ ...f, url: e.target.value }))}
+                  placeholder="https://mcp.example.com/mcp"
+                  className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-100"
+                />
+              </div>
+
+              <button
+                type="button"
+                onClick={() => setCustomAdvanced((v) => !v)}
+                className="text-xs font-medium text-gray-500 hover:text-gray-700"
+              >
+                {customAdvanced ? "▾" : "▸"} Advanced settings
+              </button>
+              {customAdvanced && (
+                <div className="space-y-4 pl-1">
+                  <div>
+                    <label className="block text-xs font-medium text-gray-500 mb-1">Access token (optional)</label>
+                    <input
+                      type="password"
+                      value={customForm.token}
+                      onChange={(e) => setCustomForm((f) => ({ ...f, token: e.target.value }))}
+                      placeholder="Sent as the auth header value"
+                      className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-100"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs font-medium text-gray-500 mb-1">Auth header name (optional)</label>
+                    <input
+                      type="text"
+                      value={customForm.authHeader}
+                      onChange={(e) => setCustomForm((f) => ({ ...f, authHeader: e.target.value }))}
+                      placeholder="Authorization"
+                      className="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-100"
+                    />
+                    <p className="text-[11px] text-gray-400 mt-1">
+                      Defaults to <code>Authorization</code>. The token is sent as this header&apos;s value.
+                    </p>
+                  </div>
+                </div>
+              )}
+
+              <p className="text-xs text-amber-600 bg-amber-50 border border-amber-100 rounded-lg px-3 py-2">
+                Only add MCP servers you trust — their tools run for every user&apos;s agent. Interactive-OAuth
+                servers are not supported; use token/header auth.
+              </p>
+            </div>
+
+            <div className="flex justify-end gap-2 mt-6">
+              <button
+                onClick={() => setShowCustomModal(false)}
+                className="text-sm px-4 py-2 rounded-lg border border-gray-200 text-gray-600 hover:bg-gray-50 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleAddCustomConnector}
+                disabled={addingCustom || !customForm.name.trim() || !customForm.url.trim()}
+                className="text-sm px-4 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition-colors disabled:opacity-50"
+              >
+                {addingCustom ? "Adding..." : "Add"}
+              </button>
+            </div>
+          </div>
+        </div>
       )}
 
       {loading ? (
@@ -760,6 +906,86 @@ export default function IntegrationsPage() {
                   </div>
                 );
               })}
+            </div>
+          )}
+
+          {/* Custom MCP Connectors — admin only */}
+          {isAdmin && (
+            <div className="space-y-4">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <h2 className="text-sm font-semibold text-gray-700 uppercase tracking-wide">
+                    Custom Connectors
+                  </h2>
+                  <p className="text-xs text-gray-400 mt-0.5">
+                    Add any remote MCP server — its tools become available to every user
+                  </p>
+                </div>
+                <button
+                  onClick={() => setShowCustomModal(true)}
+                  className="text-sm px-4 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition-colors shrink-0"
+                >
+                  Add custom connector
+                </button>
+              </div>
+
+              {customConnectors.length === 0 ? (
+                <div className="bg-surface rounded-xl border border-dashed border-gray-200 p-6 text-center">
+                  <p className="text-sm text-gray-400">
+                    No custom connectors yet. Add a remote MCP server to extend the agent.
+                  </p>
+                </div>
+              ) : (
+                customConnectors.map((integ) => (
+                  <div
+                    key={integ.provider}
+                    className="bg-surface rounded-xl border border-gray-200 overflow-hidden"
+                  >
+                    <div className="p-6">
+                      <div className="flex items-start justify-between">
+                        <div className="flex items-center gap-4">
+                          <div className="w-12 h-12 bg-gray-50 rounded-xl flex items-center justify-center">
+                            <span className="text-lg font-bold text-gray-400">
+                              {integ.display_name[0]}
+                            </span>
+                          </div>
+                          <div>
+                            <div className="flex items-center gap-3">
+                              <h2 className="text-base font-semibold text-gray-900">
+                                {integ.display_name}
+                              </h2>
+                              <StatusBadge status="connected" />
+                            </div>
+                            <p className="text-sm text-gray-500 mt-0.5 font-mono break-all">
+                              {integ.url}
+                            </p>
+                          </div>
+                        </div>
+                        <button
+                          onClick={() => handleRemoveCustomConnector(integ.provider, integ.display_name)}
+                          disabled={removingCustom === integ.provider}
+                          className="text-sm px-4 py-2 rounded-lg border border-red-200 text-red-600 hover:bg-red-50 transition-colors disabled:opacity-50 shrink-0"
+                        >
+                          {removingCustom === integ.provider ? "Removing..." : "Remove"}
+                        </button>
+                      </div>
+                      <div className="mt-5 pt-5 border-t border-gray-100 flex flex-wrap items-center gap-2">
+                        <span className="text-xs px-2.5 py-1 rounded-full bg-emerald-50 text-emerald-600 border border-emerald-100">
+                          MCP tools active (mcp__{integ.provider})
+                        </span>
+                        <span className="text-xs px-2.5 py-1 rounded-full bg-gray-50 text-gray-500 border border-gray-100">
+                          {integ.has_token ? "Token auth" : "No auth"}
+                        </span>
+                        {integ.connected_by && (
+                          <span className="text-xs text-gray-400">
+                            Added {formatDate(integ.connected_at)} by {integ.connected_by}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                ))
+              )}
             </div>
           )}
 

--- a/dashboard/src/lib/integration-api.ts
+++ b/dashboard/src/lib/integration-api.ts
@@ -27,6 +27,10 @@ export interface Integration {
   connected_by?: string | null;
   connected_at?: string | null;
   has_webhook_secret?: boolean;
+  // Custom (admin-added) remote MCP connectors
+  is_custom?: boolean;
+  url?: string;
+  has_token?: boolean;
 }
 
 // ── API calls ─────────────────────────────────────────────────────────────
@@ -66,6 +70,38 @@ export async function disconnectIntegration(provider: string): Promise<void> {
   if (!res.ok) {
     const data = await res.json().catch(() => ({}));
     throw new Error(data.error || `Failed to disconnect ${provider}: ${res.status}`);
+  }
+}
+
+export async function addCustomConnector(input: {
+  name: string;
+  url: string;
+  token?: string;
+  authHeader?: string;
+}): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/integrations/custom`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      name: input.name,
+      url: input.url,
+      token: input.token || "",
+      auth_header: input.authHeader || "",
+    }),
+  });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error(data.error || `Failed to add connector: ${res.status}`);
+  }
+}
+
+export async function removeCustomConnector(provider: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/integrations/custom/${provider}`, {
+    method: "DELETE",
+  });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error(data.error || `Failed to remove connector: ${res.status}`);
   }
 }
 

--- a/tests/test_custom_connector.py
+++ b/tests/test_custom_connector.py
@@ -1,0 +1,83 @@
+"""Tests for custom (admin-added) remote MCP connectors.
+
+Covers merge_db_integrations: an `is_custom` integration record is turned into
+an inline remote http MCP server, with optional token/header auth, without
+needing a PROVIDER_CATALOG entry.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from agent.client import merge_db_integrations
+
+
+async def _aiter(docs):
+    for doc in docs:
+        yield doc
+
+
+def _mock_db(docs):
+    db = MagicMock()
+    db.integrations.find = MagicMock(return_value=_aiter(docs))
+    return db
+
+
+@pytest.mark.asyncio
+async def test_custom_connector_with_token():
+    doc = {
+        "provider": "acme",
+        "is_custom": True,
+        "status": "active",
+        "mcp_url": "https://mcp.acme.com/mcp",
+        "auth_header": "Authorization",
+        "api_key_encrypted": "ENC",
+    }
+    db = _mock_db([doc])
+    with patch("observability.db.get_db", return_value=db), \
+         patch("api.oauth_helpers.decrypt_token", return_value="tok-123"):
+        config = await merge_db_integrations({"mcp_servers": {}})
+
+    assert config["mcp_servers"]["acme"] == {
+        "type": "http",
+        "url": "https://mcp.acme.com/mcp",
+        "headers": {"Authorization": "tok-123"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_custom_connector_custom_header():
+    doc = {
+        "provider": "acme",
+        "is_custom": True,
+        "status": "active",
+        "mcp_url": "https://mcp.acme.com/mcp",
+        "auth_header": "X-Api-Key",
+        "api_key_encrypted": "ENC",
+    }
+    db = _mock_db([doc])
+    with patch("observability.db.get_db", return_value=db), \
+         patch("api.oauth_helpers.decrypt_token", return_value="tok-123"):
+        config = await merge_db_integrations({"mcp_servers": {}})
+
+    assert config["mcp_servers"]["acme"]["headers"] == {"X-Api-Key": "tok-123"}
+
+
+@pytest.mark.asyncio
+async def test_custom_connector_without_token_has_no_headers():
+    doc = {
+        "provider": "acme",
+        "is_custom": True,
+        "status": "active",
+        "mcp_url": "https://mcp.acme.com/mcp",
+        "auth_header": "Authorization",
+        "api_key_encrypted": None,
+    }
+    db = _mock_db([doc])
+    with patch("observability.db.get_db", return_value=db):
+        config = await merge_db_integrations({"mcp_servers": {}})
+
+    assert config["mcp_servers"]["acme"] == {
+        "type": "http",
+        "url": "https://mcp.acme.com/mcp",
+    }
+    assert "headers" not in config["mcp_servers"]["acme"]


### PR DESCRIPTION
## What

Adds an **admin-only** ability to register a **custom remote MCP server** directly from the Integrations page — fields: **Name**, **Remote MCP server URL**, and (under Advanced) an optional **access token / auth header**. Once added, its tools become available to **every user's agent**.

This generalizes integrations beyond the hardcoded `PROVIDER_CATALOG`: admins can now extend the agent with any remote MCP server without a code change/redeploy.

## How it works

- **Storage** — reuses the existing `integrations` collection, flagged `is_custom: true` (so the existing list/reload plumbing applies). The token is encrypted at rest; the URL is stored plain.
- **Agent wiring** — `merge_db_integrations` ([agent/client.py](agent/client.py)) now turns each `is_custom` record into an inline remote MCP server `{type:"http", url, headers?}` *before* the catalog lookup. This is the same shape the built-in Linear/GitHub remote integrations already use, so both the Claude pooled runtime and the OpenCode runtime handle it. The pool reloads on add/remove.
- **Server key** — the connector name is slugified (`[a-z0-9_]`) into the MCP server key, so its tools surface as `mcp__<slug>` automatically. Validated non-empty, unique, and non-colliding with a built-in provider.
- **Permissions** — `POST`/`DELETE /api/integrations/custom` are `require_admin` (arbitrary remote MCP for all users is security-sensitive, so stricter than the maintainer+ gate on catalog integrations). The UI button/section is gated on `isAdmin`.
- **Auth** — token/header only. The headless pooled agent can't perform interactive browser OAuth, so OAuth-consent connectors aren't supported (called out in the modal + docs).

## Scope (confirmed)

- **Global** — connectors are available to all users (matches Loma's shared-pool architecture; there's no per-user MCP filtering). Per-user scoping is noted as a future follow-up.

## UI

"Add custom connector" modal mirrors the reference dialog (Name, Remote MCP server URL, Advanced settings → access token + optional header name) with a trust warning *"Only add MCP servers you trust — their tools run for every user's agent."* A new **Custom Connectors** section lists them with a **Remove** button.

## Test

- New `tests/test_custom_connector.py` — `merge_db_integrations` builds `{type:"http", url, headers:{<header>:<token>}}` with a token, honors a custom header, and emits no `headers` when tokenless.
- Full suite: **220 passed**. `tsc --noEmit` clean.

## Follow-up (separate PR)

Docs page in `gogo-website` (`/docs/custom-mcp-connectors`) — coming next.