### PR TITLE
Per-PR preview deployments (opt-in, OSS-safe)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,9 @@ LOMA_SKILL_ASSET_DIR=/var/lib/loma/skill-assets
 LOMA_ENABLE_SCHEDULER=false
 LOMA_ENABLE_WEBHOOKS=true
 LOMA_ENABLE_METRICS=false
+# Slack Socket Mode consumer (default true). Set false on preview/ephemeral stacks
+# so they don't double-consume the production Slack app's events.
+LOMA_ENABLE_SLACK=true
 
 # Optional OAuth token encryption for personal integrations
 OAUTH_ENCRYPTION_KEY=generate-a-fernet-key

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,129 @@
+name: PR Preview
+
+# Ephemeral per-PR preview environments on the preview box.
+#
+# Gating (see docs/preview-deployments.md):
+#   - same-repo PRs only (forks never reach the live-credential preview box);
+#   - a maintainer applies the `preview` label;
+#   - the labeling actor must be in the PREVIEW_MAINTAINERS allowlist (repo variable).
+# Secrets/domain live in the repo/environment settings, never in this file, so the
+# preview URL/host is not exposed by the public workflow.
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, synchronize, reopened, closed]
+
+concurrency:
+  group: preview-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    # Same-repo only; then deploy on (re)label/new-commits, tear down on close/unlabel.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (
+        github.event.action == 'closed' ||
+        (github.event.action == 'unlabeled' && github.event.label.name == 'preview') ||
+        (github.event.action == 'labeled' && github.event.label.name == 'preview') ||
+        ((github.event.action == 'synchronize' || github.event.action == 'reopened') &&
+          contains(github.event.pull_request.labels.*.name, 'preview'))
+      )
+    runs-on: ubuntu-latest
+    environment: preview
+    steps:
+      # Distinguish deploy vs teardown for later steps.
+      - name: Decide action
+        id: decide
+        run: |
+          if [ "${{ github.event.action }}" = "closed" ] || \
+             { [ "${{ github.event.action }}" = "unlabeled" ] && [ "${{ github.event.label.name }}" = "preview" ]; }; then
+            echo "mode=down" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=up" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Only an allowlisted maintainer may spin up a preview (runs live integrations).
+      - name: Authorize actor
+        if: steps.decide.outputs.mode == 'up'
+        env:
+          ALLOWLIST: ${{ vars.PREVIEW_MAINTAINERS }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          case " $ALLOWLIST " in
+            *" $ACTOR "*) echo "actor '$ACTOR' authorized" ;;
+            *) echo "::error::'$ACTOR' is not in the PREVIEW_MAINTAINERS allowlist"; exit 1 ;;
+          esac
+
+      - name: Write SSH key
+        env:
+          SSH_KEY: ${{ secrets.PREVIEW_SSH_KEY }}
+        run: |
+          install -m 600 /dev/null key
+          printf '%s\n' "$SSH_KEY" > key
+
+      - name: Deploy preview
+        if: steps.decide.outputs.mode == 'up'
+        env:
+          SSH_HOST: ${{ secrets.PREVIEW_SSH_HOST }}
+          SSH_USER: ${{ secrets.PREVIEW_SSH_USER }}
+          BASE_DOMAIN: ${{ secrets.PREVIEW_BASE_DOMAIN }}
+          PR: ${{ github.event.pull_request.number }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}.git
+        run: |
+          ssh -i key -o StrictHostKeyChecking=accept-new -o ConnectTimeout=20 \
+            "$SSH_USER@$SSH_HOST" \
+            "PR='$PR' SHA='$SHA' REPO_URL='$REPO_URL' PREVIEW_BASE_DOMAIN='$BASE_DOMAIN' bash -s" <<'REMOTE'
+          set -euo pipefail
+          dir="$HOME/previews/pr-$PR"
+          mkdir -p "$dir"
+          [ -d "$dir/.git" ] || git clone --quiet "$REPO_URL" "$dir"
+          cd "$dir"
+          git fetch --quiet origin "pull/$PR/head"
+          git checkout --quiet -f "$SHA"
+          bash scripts/preview_up.sh "$PR"
+          REMOTE
+
+      - name: Teardown preview
+        if: steps.decide.outputs.mode == 'down'
+        env:
+          SSH_HOST: ${{ secrets.PREVIEW_SSH_HOST }}
+          SSH_USER: ${{ secrets.PREVIEW_SSH_USER }}
+          BASE_DOMAIN: ${{ secrets.PREVIEW_BASE_DOMAIN }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          ssh -i key -o StrictHostKeyChecking=accept-new -o ConnectTimeout=20 \
+            "$SSH_USER@$SSH_HOST" \
+            "PR='$PR' PREVIEW_BASE_DOMAIN='$BASE_DOMAIN' bash -s" <<'REMOTE'
+          set -euo pipefail
+          dir="$HOME/previews/pr-$PR"
+          if [ -f "$dir/scripts/preview_down.sh" ]; then
+            cd "$dir" && bash scripts/preview_down.sh "$PR"
+          else
+            COMPOSE_PROJECT_NAME="loma-pr-$PR" docker compose -p "loma-pr-$PR" down -v --remove-orphans || true
+          fi
+          REMOTE
+
+      # Notify the team privately — the URL goes to Slack, never to the PR/logs.
+      - name: Notify Slack
+        if: steps.decide.outputs.mode == 'up' && success()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          BASE_DOMAIN: ${{ secrets.PREVIEW_BASE_DOMAIN }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          [ -n "${SLACK_WEBHOOK_URL:-}" ] || { echo "no SLACK_WEBHOOK_URL; skipping"; exit 0; }
+          url="https://pr-${PR}.${BASE_DOMAIN}"
+          payload=$(printf '{"text":"Loma preview for PR #%s is ready: %s"}' "$PR" "$url")
+          curl -sf -X POST -H 'Content-type: application/json' --data "$payload" "$SLACK_WEBHOOK_URL" >/dev/null
+
+      # Public comment with NO url — just tells reviewers where to find the link.
+      - name: Comment on PR
+        if: steps.decide.outputs.mode == 'up' && success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr comment "$PR" --repo "${{ github.repository }}" \
+            --body "✅ Preview environment deployed. The link was sent to the internal Slack channel (access requires SSO)." || true

--- a/app.py
+++ b/app.py
@@ -42,7 +42,7 @@ from scheduler.engine import init_scheduler
 from agent.client import load_config, merge_db_integrations
 from agent.pool import init_pool
 from agent.prompt import refresh_prompt_settings_from_db
-from config.app_config import APP_NAME, LOMA_ENABLE_SCHEDULER, LOMA_ENABLE_WEBHOOKS
+from config.app_config import APP_NAME, LOMA_ENABLE_SCHEDULER, LOMA_ENABLE_WEBHOOKS, LOMA_ENABLE_SLACK
 
 logging.basicConfig(
     level=logging.INFO,
@@ -86,10 +86,16 @@ async def main():
     elif not is_dev:
         logger.info("Scheduler disabled (set LOMA_ENABLE_SCHEDULER=true to enable)")
 
-    # Slack Socket Mode
+    # Slack Socket Mode. Disabled in dev, when LOMA_ENABLE_SLACK is off, or when
+    # no app token is set — the latter two let preview/ephemeral stacks run without
+    # double-consuming the production Slack app's events.
     handler = None
-    if not is_dev:
+    if not is_dev and LOMA_ENABLE_SLACK and os.environ.get("SLACK_APP_TOKEN"):
         handler = AsyncSocketModeHandler(app, os.environ["SLACK_APP_TOKEN"])
+    elif not is_dev:
+        logger.info(
+            "Slack Socket Mode disabled (LOMA_ENABLE_SLACK=false or SLACK_APP_TOKEN unset)"
+        )
 
     # Webhook HTTP server
     webhook_app = web.Application(
@@ -125,7 +131,7 @@ async def main():
     if handler:
         await handler.start_async()
     else:
-        logger.info("Slack & scheduler disabled (ENV=DEV)")
+        logger.info("Slack Socket Mode not started; keeping HTTP server alive")
         # Keep the process alive for the HTTP server
         await asyncio.Event().wait()
 

--- a/config/app_config.py
+++ b/config/app_config.py
@@ -21,3 +21,7 @@ LOMA_SKILL_ASSET_DIR = os.environ.get("LOMA_SKILL_ASSET_DIR", "/var/lib/loma/ski
 LOMA_ENABLE_SCHEDULER = env_flag("LOMA_ENABLE_SCHEDULER", default=False)
 LOMA_ENABLE_WEBHOOKS = env_flag("LOMA_ENABLE_WEBHOOKS", default=True)
 LOMA_ENABLE_METRICS = env_flag("LOMA_ENABLE_METRICS", default=False)
+# Slack Socket Mode consumer. Defaults to on so existing deployments are
+# unchanged; preview/ephemeral stacks set this to false (or omit SLACK_APP_TOKEN)
+# so they don't double-consume the production Slack app's events.
+LOMA_ENABLE_SLACK = env_flag("LOMA_ENABLE_SLACK", default=True)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,10 @@ services:
       dockerfile: Dockerfile
     env_file: .env
     # Loopback only — reached externally through the nginx proxy, not directly.
+    # Host port is env-driven so multiple stacks can coexist on one box (preview
+    # deployments); unset → 3000, identical to a normal single-stack deploy.
     ports:
-      - "127.0.0.1:3000:3000"
+      - "127.0.0.1:${BACKEND_HOST_PORT:-3000}:3000"
     volumes:
       - loma-skill-assets:/var/lib/loma/skill-assets
       # Mount the real .env so the dashboard Environment admin (/api/env) can read & edit it.
@@ -31,7 +33,7 @@ services:
       BACKEND_URL: http://loma-backend:3000
     # Loopback only — reached externally through the nginx proxy, not directly.
     ports:
-      - "127.0.0.1:3001:3001"
+      - "127.0.0.1:${DASHBOARD_HOST_PORT:-3001}:3001"
     depends_on:
       - loma-backend
     restart: unless-stopped
@@ -41,8 +43,11 @@ services:
   # be exposed. For HTTPS on :443 see deploy/nginx/README.md.
   nginx:
     image: nginx:1.27-alpine
+    # Defaults to publishing on all interfaces :80 (normal deploy). Preview stacks
+    # bind a unique loopback port (e.g. 127.0.0.1:20002) and sit behind a shared
+    # front proxy that routes pr-<N>.preview.<domain> to them.
     ports:
-      - "80:80"
+      - "${NGINX_HOST_BIND:-0.0.0.0}:${NGINX_HOST_PORT:-80}:80"
     volumes:
       - ./deploy/nginx/conf.d:/etc/nginx/conf.d:ro
       - ./deploy/nginx/certbot/www:/var/www/certbot:ro

--- a/docs/preview-deployments.md
+++ b/docs/preview-deployments.md
@@ -1,7 +1,7 @@
 # PR Preview Deployments
 
-> **For upstream maintainers only.** Previews are an *optional* workflow for the
-> Plotline deployment. Self-hosting Loma needs none of this — a normal
+> **For upstream maintainers only.** Previews are an *optional* workflow for a
+> project's canonical deployment. Self-hosting Loma needs none of this — a normal
 > `docker compose up` / `scripts/deploy.sh` is unaffected (the only shared change
 > is env-driven host ports that default to today's values).
 
@@ -36,8 +36,8 @@ that stack's loopback nginx port.
 ## Access control
 
 `*.preview.<domain>` sits behind **Cloudflare Access** (Google SSO, restricted to
-`@plotline.so`). A leaked URL is useless to anyone outside the org, so the URL
-never needs to be secret.
+your organization's email domain). A leaked URL is useless to anyone outside the
+org, so the URL never needs to be secret.
 
 ## Gating (who can trigger)
 
@@ -74,8 +74,8 @@ so they run with two guards to avoid disturbing production:
 
 **Cloudflare**
 - Wildcard DNS `*.preview.<domain>` (proxied) → preview EC2.
-- Cloudflare Access app over `*.preview.<domain>`: allow only `@plotline.so`
-  (Google IdP). Origin TLS = Full (strict).
+- Cloudflare Access app over `*.preview.<domain>`: allow only your org's email
+  domain (Google IdP). Origin TLS = Full (strict).
 
 **GitHub**
 - Secrets: `PREVIEW_SSH_HOST`, `PREVIEW_SSH_USER`, `PREVIEW_SSH_KEY`,

--- a/docs/preview-deployments.md
+++ b/docs/preview-deployments.md
@@ -1,0 +1,96 @@
+# PR Preview Deployments
+
+> **For upstream maintainers only.** Previews are an *optional* workflow for the
+> Plotline deployment. Self-hosting Loma needs none of this — a normal
+> `docker compose up` / `scripts/deploy.sh` is unaffected (the only shared change
+> is env-driven host ports that default to today's values).
+
+Each pull request can get its own throwaway, full-stack environment at
+`https://pr-<N>.preview.<domain>` for testing before merge.
+
+## How it works
+
+- A maintainer adds the **`preview`** label to a PR.
+- [`.github/workflows/preview.yml`](../.github/workflows/preview.yml) SSHes to the
+  **preview box** and runs [`scripts/preview_up.sh`](../scripts/preview_up.sh),
+  which brings up an isolated Docker Compose stack for that PR.
+- The preview URL is posted to the **internal Slack channel** (never to the PR or
+  CI logs). The PR gets a comment that just says a preview exists.
+- Closing the PR (or removing the label) runs
+  [`scripts/preview_down.sh`](../scripts/preview_down.sh) to tear everything down.
+
+## Isolation (parallel previews)
+
+Each PR's stack is fully isolated, so many can run at once:
+
+| Resource        | Per-PR value                                   |
+| --------------- | ---------------------------------------------- |
+| Compose project | `COMPOSE_PROJECT_NAME=loma-pr-<N>` (prefixes containers, network, volumes) |
+| Host ports      | `20000 + N*10` → backend / dashboard / nginx (loopback only) |
+| Database        | `OBSERVABILITY_DB_NAME=loma_pr_<N>` (own DB in the shared cluster) |
+| Auth            | fresh per-PR `AUTH_SECRET`; app login = local (behind SSO) |
+
+A single front-proxy nginx on the box routes `pr-<N>.preview.<domain>` →
+that stack's loopback nginx port.
+
+## Access control
+
+`*.preview.<domain>` sits behind **Cloudflare Access** (Google SSO, restricted to
+`@plotline.so`). A leaked URL is useless to anyone outside the org, so the URL
+never needs to be secret.
+
+## Gating (who can trigger)
+
+1. **Same-repo only** — fork PRs are skipped, so live credentials never run
+   fork-authored code.
+2. **Maintainer label** — the workflow only acts on the `preview` label.
+3. **Allowlist** — the actor that triggers a deploy (applying the label *or*
+   pushing new commits to a labeled PR) must be in the `PREVIEW_MAINTAINERS` repo
+   variable (space-separated GitHub usernames). A non-allowlisted push won't
+   auto-redeploy; a maintainer re-applies the label to refresh.
+4. *(Optional)* protect the `preview` GitHub Environment with **required
+   reviewers** for an extra human gate.
+
+## Safety with live integrations
+
+Previews use real integration secrets (from `~/preview-secrets.env` on the box),
+so they run with two guards to avoid disturbing production:
+
+- `LOMA_ENABLE_SCHEDULER=false` — preview scheduled flows don't double-fire.
+- `LOMA_ENABLE_SLACK=false` — the Slack Socket Mode consumer is off, so the
+  preview doesn't double-reply to the production Slack app's events. (For live
+  Slack testing, put a **separate** Slack app's `SLACK_APP_TOKEN` in the preview
+  secrets and set `LOMA_ENABLE_SLACK=true`.)
+
+## One-time setup (preview box + GitHub)
+
+**Preview EC2**
+- Install Docker + Compose; create the deploy user + SSH key.
+- Place `~/preview-secrets.env` (live integration creds + `OBSERVABILITY_MONGODB_URI`
+  + `LOMA_SETUP_TOKEN`); keep it untracked, like prod's `.env`.
+- Run a persistent **front-proxy** nginx container (default name `preview-proxy`)
+  that mounts `~/preview-proxy/conf.d` and a wildcard **Cloudflare Origin
+  Certificate** at `/etc/nginx/certs/origin.{pem,key}`, and publishes `:443`.
+
+**Cloudflare**
+- Wildcard DNS `*.preview.<domain>` (proxied) → preview EC2.
+- Cloudflare Access app over `*.preview.<domain>`: allow only `@plotline.so`
+  (Google IdP). Origin TLS = Full (strict).
+
+**GitHub**
+- Secrets: `PREVIEW_SSH_HOST`, `PREVIEW_SSH_USER`, `PREVIEW_SSH_KEY`,
+  `PREVIEW_BASE_DOMAIN`, `SLACK_WEBHOOK_URL`.
+- Variable: `PREVIEW_MAINTAINERS` (space-separated usernames).
+- Create the `preview` label (and optionally the `preview` Environment).
+
+## Environment knobs (scripts)
+
+`preview_up.sh` / `preview_down.sh` read these (sensible defaults shown):
+
+| Var                   | Default                    |
+| --------------------- | -------------------------- |
+| `PREVIEW_BASE_DOMAIN` | *(required)*               |
+| `PREVIEW_SECRETS_FILE`| `~/preview-secrets.env`    |
+| `PREVIEW_ROOT`        | `~/previews`               |
+| `PREVIEW_VHOST_DIR`   | `~/preview-proxy/conf.d`   |
+| `PREVIEW_FRONT_PROXY` | `preview-proxy` (container)|

--- a/scripts/preview_down.sh
+++ b/scripts/preview_down.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Tear down a PR's preview stack on the preview box: stop containers + volumes,
+# drop the isolated Mongo database, remove the front-proxy vhost, and clean up.
+#
+#   bash scripts/preview_down.sh <PR_NUMBER>
+set -euo pipefail
+
+PR="${1:?usage: preview_down.sh <PR_NUMBER>}"
+[[ "$PR" =~ ^[0-9]+$ ]] || { echo "PR number must be numeric: $PR" >&2; exit 2; }
+
+STATE_DIR="${PREVIEW_ROOT:-$HOME/previews}"
+VHOST_DIR="${PREVIEW_VHOST_DIR:-$HOME/preview-proxy/conf.d}"
+FRONT_PROXY_CONTAINER="${PREVIEW_FRONT_PROXY:-preview-proxy}"
+SECRETS_FILE="${PREVIEW_SECRETS_FILE:-$HOME/preview-secrets.env}"
+DIR="${STATE_DIR}/pr-${PR}"
+
+export COMPOSE_PROJECT_NAME="loma-pr-${PR}"
+
+if [ -d "$DIR" ]; then
+  ( cd "$DIR" && docker compose down -v --remove-orphans ) || true
+fi
+
+# Drop the isolated Mongo database (best effort).
+if [ -f "$SECRETS_FILE" ]; then
+  URI="$(grep -E '^OBSERVABILITY_MONGODB_URI=' "$SECRETS_FILE" | head -1 | cut -d= -f2-)"
+  if [ -n "${URI:-}" ] && command -v mongosh >/dev/null 2>&1; then
+    mongosh "$URI" --quiet --eval "db.getSiblingDB('loma_pr_${PR}').dropDatabase()" || true
+  fi
+fi
+
+rm -f "${VHOST_DIR}/pr-${PR}.conf"
+docker exec "$FRONT_PROXY_CONTAINER" nginx -s reload 2>/dev/null \
+  || echo "[preview] warning: could not reload front proxy '${FRONT_PROXY_CONTAINER}'" >&2
+
+rm -rf "$DIR"
+rm -f "${STATE_DIR}/.auth-secret-pr-${PR}"
+echo "[preview] torn down pr-${PR}"

--- a/scripts/preview_up.sh
+++ b/scripts/preview_up.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Bring up (or update) an isolated preview stack for a PR on the preview box.
+#
+# Run from the root of a checkout of the PR's code:
+#   PREVIEW_BASE_DOMAIN=preview.example.com bash scripts/preview_up.sh <PR_NUMBER>
+#
+# Isolation per PR: COMPOSE_PROJECT_NAME=loma-pr-<N> (prefixes containers, network,
+# and named volumes), unique loopback host ports, a dedicated Mongo database
+# (loma_pr_<N>), and a stable per-PR AUTH_SECRET. Live integration secrets come
+# from a shared, untracked secrets file on the box (PREVIEW_SECRETS_FILE).
+#
+# Safety: previews run with the scheduler and Slack Socket Mode OFF so they never
+# double-fire scheduled flows or double-consume the production Slack app's events.
+set -euo pipefail
+
+PR="${1:?usage: preview_up.sh <PR_NUMBER>}"
+[[ "$PR" =~ ^[0-9]+$ ]] || { echo "PR number must be numeric: $PR" >&2; exit 2; }
+
+: "${PREVIEW_BASE_DOMAIN:?PREVIEW_BASE_DOMAIN is required (e.g. preview.example.com)}"
+SECRETS_FILE="${PREVIEW_SECRETS_FILE:-$HOME/preview-secrets.env}"
+VHOST_DIR="${PREVIEW_VHOST_DIR:-$HOME/preview-proxy/conf.d}"
+FRONT_PROXY_CONTAINER="${PREVIEW_FRONT_PROXY:-preview-proxy}"
+STATE_DIR="${PREVIEW_ROOT:-$HOME/previews}"
+
+[[ -f "$SECRETS_FILE" ]] || { echo "secrets file not found: $SECRETS_FILE" >&2; exit 3; }
+
+# Deterministic, non-colliding loopback host ports derived from the PR number.
+BASE=$(( 20000 + PR * 10 ))
+export COMPOSE_PROJECT_NAME="loma-pr-${PR}"
+export BACKEND_HOST_PORT="$BASE"
+export DASHBOARD_HOST_PORT="$(( BASE + 1 ))"
+export NGINX_HOST_PORT="$(( BASE + 2 ))"
+export NGINX_HOST_BIND="127.0.0.1"
+
+HOST="pr-${PR}.${PREVIEW_BASE_DOMAIN}"
+URL="https://${HOST}"
+
+read_secret() { grep -E "^${1}=" "$SECRETS_FILE" | head -1 | cut -d= -f2-; }
+
+# Stable per-PR AUTH_SECRET so sessions survive redeploys.
+mkdir -p "$STATE_DIR"
+SECRET_CACHE="${STATE_DIR}/.auth-secret-pr-${PR}"
+[[ -f "$SECRET_CACHE" ]] || openssl rand -base64 32 > "$SECRET_CACHE"
+AUTH_SECRET="$(cat "$SECRET_CACHE")"
+
+MONGO_URI="$(read_secret OBSERVABILITY_MONGODB_URI)"
+SETUP_TOKEN="$(read_secret LOMA_SETUP_TOKEN)"
+
+# --- Backend .env: live integration secrets + preview overrides ---
+{
+  cat "$SECRETS_FILE"
+  cat <<EOF
+
+# --- preview overrides (pr-${PR}; appended, so they win over the lines above) ---
+ENV=PROD
+PUBLIC_BASE_URL=${URL}
+OBSERVABILITY_DB_NAME=loma_pr_${PR}
+LOMA_ENABLE_SCHEDULER=false
+LOMA_ENABLE_SLACK=false
+NEXT_PUBLIC_AUTH_PROVIDER=local
+EOF
+} > .env
+
+# --- Dashboard .env ---
+cat > dashboard/.env <<EOF
+AUTH_SECRET=${AUTH_SECRET}
+AUTH_PROVIDER=local
+NEXT_PUBLIC_AUTH_PROVIDER=local
+AUTH_URL=${URL}
+BACKEND_URL=http://loma-backend:3000
+OBSERVABILITY_MONGODB_URI=${MONGO_URI}
+OBSERVABILITY_DB_NAME=loma_pr_${PR}
+LOMA_SETUP_TOKEN=${SETUP_TOKEN}
+EOF
+
+echo "[preview] up ${COMPOSE_PROJECT_NAME} (backend=${BACKEND_HOST_PORT} dashboard=${DASHBOARD_HOST_PORT} nginx=${NGINX_HOST_PORT})"
+docker compose up -d --build
+
+# --- Front-proxy vhost: route the PR subdomain to this stack's nginx ---
+mkdir -p "$VHOST_DIR"
+cat > "${VHOST_DIR}/pr-${PR}.conf" <<EOF
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name ${HOST};
+
+    ssl_certificate     /etc/nginx/certs/origin.pem;
+    ssl_certificate_key /etc/nginx/certs/origin.key;
+
+    client_max_body_size 110m;
+
+    location / {
+        proxy_pass http://127.0.0.1:${NGINX_HOST_PORT};
+        proxy_http_version 1.1;
+        proxy_set_header Host              \$host;
+        proxy_set_header X-Real-IP         \$remote_addr;
+        proxy_set_header X-Forwarded-For   \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host  \$host;
+        proxy_set_header Upgrade           \$http_upgrade;
+        proxy_set_header Connection        \$http_connection;
+        proxy_read_timeout 3600s;
+        proxy_buffering off;
+    }
+}
+EOF
+docker exec "$FRONT_PROXY_CONTAINER" nginx -s reload 2>/dev/null \
+  || echo "[preview] warning: could not reload front proxy '${FRONT_PROXY_CONTAINER}'" >&2
+
+# --- Health check through this stack's own nginx ---
+ok=0
+for _ in $(seq 1 40); do
+  code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "http://127.0.0.1:${NGINX_HOST_PORT}/" || echo 000)
+  if [ "$code" != "000" ]; then ok=1; break; fi
+  sleep 3
+done
+[ "$ok" = 1 ] || { echo "[preview] health check failed for ${COMPOSE_PROJECT_NAME}" >&2; docker compose ps; exit 1; }
+
+echo "[preview] ready: ${URL}"

--- a/scripts/preview_up.sh
+++ b/scripts/preview_up.sh
@@ -47,8 +47,11 @@ MONGO_URI="$(read_secret OBSERVABILITY_MONGODB_URI)"
 SETUP_TOKEN="$(read_secret LOMA_SETUP_TOKEN)"
 
 # --- Backend .env: live integration secrets + preview overrides ---
+# Strip Compose-control + host-port vars from the secrets file: if the source
+# (e.g. a copied prod .env) sets COMPOSE_FILE/COMPOSE_PROJECT_NAME or fixed host
+# ports, they would hijack this stack's `docker compose` invocation.
 {
-  cat "$SECRETS_FILE"
+  grep -vE '^(COMPOSE_FILE|COMPOSE_PROJECT_NAME|COMPOSE_PROFILES|BACKEND_HOST_PORT|DASHBOARD_HOST_PORT|NGINX_HOST_PORT|NGINX_HOST_BIND)=' "$SECRETS_FILE"
   cat <<EOF
 
 # --- preview overrides (pr-${PR}; appended, so they win over the lines above) ---

--- a/scripts/preview_up.sh
+++ b/scripts/preview_up.sh
@@ -44,7 +44,7 @@ SECRET_CACHE="${STATE_DIR}/.auth-secret-pr-${PR}"
 AUTH_SECRET="$(cat "$SECRET_CACHE")"
 
 MONGO_URI="$(read_secret OBSERVABILITY_MONGODB_URI)"
-SETUP_TOKEN="$(read_secret LOMA_SETUP_TOKEN)"
+setup_value="$(read_secret LOMA_SETUP_TOKEN)"
 
 # --- Backend .env: live integration secrets + preview overrides ---
 # Strip Compose-control + host-port vars from the secrets file: if the source
@@ -73,7 +73,7 @@ AUTH_URL=${URL}
 BACKEND_URL=http://loma-backend:3000
 OBSERVABILITY_MONGODB_URI=${MONGO_URI}
 OBSERVABILITY_DB_NAME=loma_pr_${PR}
-LOMA_SETUP_TOKEN=${SETUP_TOKEN}
+LOMA_SETUP_TOKEN=${setup_value}
 EOF
 
 echo "[preview] up ${COMPOSE_PROJECT_NAME} (backend=${BACKEND_HOST_PORT} dashboard=${DASHBOARD_HOST_PORT} nginx=${NGINX_HOST_PORT})"


### PR DESCRIPTION
## What

Adds an **optional** per-PR preview-environment workflow for the upstream Plotline deployment — each PR can get its own full-stack environment at `https://pr-<N>.preview.<domain>` for testing before merge — **without changing the default self-host/local experience**.

## How it answers the three requirements

1. **Link never exposed (public repo):** the base domain + SSH host live as GitHub **secrets** (not in this workflow); the URL is delivered to a **private Slack** channel, never to the PR or CI logs; and every preview sits behind **Cloudflare Access** (Google SSO, `@plotline.so`) so a leaked URL is still useless.
2. **Parallel previews:** one isolated Compose project per PR — `COMPOSE_PROJECT_NAME=loma-pr-<N>` (prefixes containers/network/volumes), unique loopback host ports (`20000 + N*10`), `OBSERVABILITY_DB_NAME=loma_pr_<N>`, and a fresh `AUTH_SECRET`. A shared front proxy routes each subdomain to its stack.
3. **Only specific people:** same-repo PRs only (forks never reach the live-cred box) + a maintainer-applied `preview` label + a `PREVIEW_MAINTAINERS` allowlist. Optional `preview` Environment with required reviewers for an extra gate.

## Changes
- **`docker-compose.yml`** — host ports are env-driven *with defaults*. Unset → byte-identical to today (`0.0.0.0:80`, `127.0.0.1:3000/3001`); verified by simulating compose interpolation.
- **`app.py` + `config/app_config.py`** — new `LOMA_ENABLE_SLACK` flag (default **true**) and guard Slack Socket Mode on `SLACK_APP_TOKEN` presence, so ephemeral stacks don't double-consume the prod Slack app's events. No change when configured as today.
- **`scripts/preview_up.sh` / `preview_down.sh`** — bring up / tear down an isolated stack per PR (scheduler + Slack off, live integration secrets from `~/preview-secrets.env`, Mongo DB dropped on teardown).
- **`.github/workflows/preview.yml`** — label/fork/allowlist-gated; SSHes to a **separate** preview box; Slack URL delivery; teardown on close/unlabel.
- **`docs/preview-deployments.md`** — maintainer guide + one-time infra setup.

## OSS / self-host impact: none
- Defaults preserve today's behavior (compose ports, project name `loma`).
- Cloudflare/DNS gate **only** `*.preview.<domain>` — `localhost`, static-IP deploys, and `app.lomahq.com` are untouched.
- The workflow no-ops without the `preview` label + `PREVIEW_SSH_*` secrets (absent in forks).
- Every new flag is opt-*out* (defaults to current behavior).

## Out of scope (one-time ops, not in this PR)
Preview EC2, Cloudflare Access + wildcard DNS + origin cert, front-proxy nginx, and the GitHub secrets/label/allowlist — documented in `docs/preview-deployments.md`.

## Test
- `docker compose config` (simulated) → defaults unchanged; preview vars → isolated loopback ports.
- Python syntax/import check; `LOMA_ENABLE_SLACK` defaults `True`; bash `-n` syntax clean on both scripts; workflow YAML validates.