### PR TITLE
Webhook flows: supersede in-flight run on a newer same-issue webhook

### DIFF
--- a/scheduler/webhook_executor.py
+++ b/scheduler/webhook_executor.py
@@ -35,6 +35,12 @@ Flow name: {flow_name}
 # Keeps token usage bounded for long-running conversations.
 _MAX_CONTEXT_MESSAGES = 20
 
+# In-flight webhook runs keyed by f"{flow_id}:{thread_id}". When a newer webhook
+# arrives for the same key, the older run is cancelled so only the latest executes.
+# Only used when a thread_id can be extracted; without one, runs stay independent.
+# In-process only (single backend process / one event loop).
+_inflight: dict[str, asyncio.Task] = {}
+
 
 def _flow_model(flow: dict) -> str:
     """Return the provider/model id configured for this flow."""
@@ -193,7 +199,9 @@ async def execute_webhook_flow(
                 {
                     "metadata.thread_id": thread_id,
                     "metadata.flow_id": flow_id,
-                    "status": {"$in": ["completed", "running"]},
+                    # "interrupted" lets the latest run resume a conversation whose
+                    # prior run we just cancelled (supersede), keeping one thread.
+                    "status": {"$in": ["completed", "running", "interrupted"]},
                 },
                 sort=[("finished_at", -1)],
             )
@@ -238,6 +246,17 @@ async def execute_webhook_flow(
         ):
             if isinstance(chunk, str):
                 last_text = chunk
+    except asyncio.CancelledError:
+        # Superseded by a newer webhook for the same (flow_id, thread_id), or a
+        # server shutdown. stream_agent's own finally releases the pooled client
+        # and SIGKILLs the agent subprocess; here we just settle the records.
+        # Shield so the status writes survive the cancellation in flight.
+        logger.info(
+            "[WEBHOOK-EXEC] Flow %s interrupted (conversation %s)",
+            flow_id, observer.conversation_id,
+        )
+        await asyncio.shield(_finalize_interrupted(db, observer, log_id))
+        raise
     except Exception as exc:
         logger.exception("[WEBHOOK-EXEC] Flow %s execution failed", flow_id)
         error_message = f"Flow execution failed: {exc}"
@@ -305,3 +324,79 @@ async def execute_webhook_flow(
         flow_id, observer.conversation_id,
     )
     return observer.conversation_id
+
+
+async def _finalize_interrupted(db, observer: ConversationObserver, log_id: str) -> None:
+    """Settle a superseded run: mark the conversation interrupted + flag the log."""
+    await observer.mark_interrupted("Superseded by newer webhook for same issue")
+    try:
+        await db.webhook_logs.update_one(
+            {"log_id": log_id},
+            {"$set": {
+                "execution_status": "interrupted",
+                "conversation_id": observer.conversation_id,
+            }},
+        )
+    except Exception:
+        logger.warning("[WEBHOOK-EXEC] Failed to mark webhook log %s interrupted", log_id)
+
+
+async def _run_superseding(
+    key: str,
+    predecessor: asyncio.Task | None,
+    flow: dict,
+    raw_body: bytes,
+    headers: dict,
+    log_id: str,
+) -> str | None:
+    """Run the latest webhook after letting a cancelled predecessor tear down.
+
+    Waiting for the predecessor avoids two agents writing the same conversation
+    at once and lets the latest run resume the just-interrupted thread cleanly.
+    `asyncio.wait` never raises for the predecessor's own outcome (cancelled or
+    errored); it only propagates a cancellation of *this* task — in which case an
+    even-newer webhook has superseded us and we must not start.
+    """
+    if predecessor is not None and not predecessor.done():
+        await asyncio.wait({predecessor}, timeout=30)
+    return await execute_webhook_flow(flow, raw_body, headers, log_id)
+
+
+def dispatch_webhook_flow(flow: dict, raw_body: bytes, headers: dict, log_id: str) -> None:
+    """Schedule a webhook run, superseding any in-flight run for the same
+    (flow_id, thread_id). Returns immediately so the HTTP handler can 202 fast.
+
+    With no extractable thread_id, runs stay independent and concurrent (the
+    prior behavior) — there is no key to dedupe on.
+    """
+    flow_id = flow["flow_id"]
+
+    try:
+        payload = json.loads(raw_body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        payload = {}
+    thread_id = extract_thread_id(flow, payload) if isinstance(payload, dict) else None
+
+    if not thread_id:
+        asyncio.create_task(execute_webhook_flow(flow, raw_body, headers, log_id))
+        return
+
+    key = f"{flow_id}:{thread_id}"
+    predecessor = _inflight.get(key)
+    if predecessor is not None and not predecessor.done():
+        logger.info("[WEBHOOK-EXEC] Newer webhook superseding in-flight run for %s", key)
+        predecessor.cancel()
+
+    # No await between read/cancel/create/store → atomic w.r.t. the event loop.
+    task = asyncio.create_task(
+        _run_superseding(key, predecessor, flow, raw_body, headers, log_id)
+    )
+    _inflight[key] = task
+
+    def _cleanup(done_task: asyncio.Task, _key: str = key) -> None:
+        # Only clear if we're still the current run for this key (don't clobber a
+        # newer task that already replaced us).
+        if _inflight.get(_key) is done_task:
+            _inflight.pop(_key, None)
+
+    task.add_done_callback(_cleanup)

--- a/tests/test_webhook_executor.py
+++ b/tests/test_webhook_executor.py
@@ -7,6 +7,7 @@ Covers:
 - execute_webhook_flow: resume vs create logic with mocked DB and agent
 """
 
+import asyncio
 import json
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -505,6 +506,131 @@ class TestExecuteWebhookFlowThreadContinuity:
                 flow, json.dumps(payload).encode(), {}, "log-skip"
             )
             assert result is None
+
+
+class TestDispatchSupersede:
+    """dispatch_webhook_flow: supersede in-flight runs for the same (flow_id, thread_id)."""
+
+    @pytest.mark.asyncio
+    async def test_no_thread_id_runs_independently(self):
+        """Without a thread_id, no registry entry is made — runs stay independent."""
+        import scheduler.webhook_executor as we
+        we._inflight.clear()
+        flow = _make_flow()
+        ran = asyncio.Event()
+
+        async def fake_exec(flow, raw_body, headers, log_id):
+            ran.set()
+            return "c"
+
+        with patch.object(we, "execute_webhook_flow", fake_exec):
+            we.dispatch_webhook_flow(flow, json.dumps({"event": "x"}).encode(), {}, "log-1")
+            await asyncio.wait_for(ran.wait(), timeout=1)
+            assert we._inflight == {}
+
+    @pytest.mark.asyncio
+    async def test_same_thread_supersedes_predecessor(self):
+        """A newer webhook for the same thread cancels the in-flight run; latest completes."""
+        import scheduler.webhook_executor as we
+        we._inflight.clear()
+        flow = _make_flow()
+        started: list[str] = []
+        first_cancelled = asyncio.Event()
+        release = asyncio.Event()
+        body = json.dumps(_make_payload(issue_id="iss-1")).encode()
+
+        async def fake_exec(flow, raw_body, headers, log_id):
+            started.append(log_id)
+            try:
+                await release.wait()
+                return f"convo-{log_id}"
+            except asyncio.CancelledError:
+                if log_id == "log-A":
+                    first_cancelled.set()
+                raise
+
+        with patch.object(we, "execute_webhook_flow", fake_exec):
+            we.dispatch_webhook_flow(flow, body, {}, "log-A")
+            await asyncio.sleep(0)  # let the first run start
+            we.dispatch_webhook_flow(flow, body, {}, "log-B")
+            task_b = we._inflight[f"{flow['flow_id']}:iss-1"]
+
+            # Predecessor (A) is cancelled by the newer webhook.
+            await asyncio.wait_for(first_cancelled.wait(), timeout=1)
+            # Let the latest (B) finish.
+            release.set()
+            result = await asyncio.wait_for(task_b, timeout=1)
+
+        assert started == ["log-A", "log-B"]
+        assert result == "convo-log-B"
+        assert we._inflight == {}  # cleaned up via done-callback
+
+    @pytest.mark.asyncio
+    async def test_different_threads_run_concurrently(self):
+        """Distinct thread_ids do not supersede each other."""
+        import scheduler.webhook_executor as we
+        we._inflight.clear()
+        flow = _make_flow()
+        started: list[str] = []
+        release = asyncio.Event()
+
+        async def fake_exec(flow, raw_body, headers, log_id):
+            started.append(log_id)
+            await release.wait()
+            return log_id
+
+        with patch.object(we, "execute_webhook_flow", fake_exec):
+            we.dispatch_webhook_flow(flow, json.dumps(_make_payload(issue_id="a")).encode(), {}, "log-a")
+            we.dispatch_webhook_flow(flow, json.dumps(_make_payload(issue_id="b")).encode(), {}, "log-b")
+            await asyncio.sleep(0)
+            assert len(we._inflight) == 2
+            tasks = list(we._inflight.values())
+            release.set()
+            await asyncio.wait_for(asyncio.gather(*tasks), timeout=1)
+
+        assert sorted(started) == ["log-a", "log-b"]
+        assert we._inflight == {}
+
+    @pytest.mark.asyncio
+    async def test_cancelled_run_marked_interrupted(self):
+        """Cancelling execute_webhook_flow marks the conversation interrupted + flags the log."""
+        db = _make_db_mock(existing_convo=None)
+        flow = _make_flow()
+        payload = _make_payload(issue_id="iss-int")
+        release = asyncio.Event()
+
+        async def _blocking_agen(*args, **kwargs):
+            await release.wait()  # suspend here so the task can be cancelled mid-run
+            return
+            yield  # noqa: unreachable — makes this an async generator
+
+        with patch("scheduler.webhook_executor.get_db", return_value=db), \
+             patch("scheduler.webhook_executor.stream_agent", _blocking_agen), \
+             patch("scheduler.webhook_executor.ConversationObserver") as MockObserver:
+
+            obs = MagicMock()
+            obs.conversation_id = "convo-int"
+            obs.start = AsyncMock()
+            obs.resume = AsyncMock()
+            obs.mark_interrupted = AsyncMock()
+            MockObserver.return_value = obs
+
+            from scheduler.webhook_executor import execute_webhook_flow
+            task = asyncio.create_task(
+                execute_webhook_flow(flow, json.dumps(payload).encode(), {}, "log-int")
+            )
+            await asyncio.sleep(0)  # reach the streaming await
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        obs.mark_interrupted.assert_awaited_once()
+        # webhook log flagged interrupted
+        statuses = [
+            c.kwargs.get("$set", c.args[1].get("$set") if len(c.args) > 1 else {})
+            for c in db.webhook_logs.update_one.call_args_list
+        ]
+        assert any(s.get("execution_status") == "interrupted" for s in statuses)
 
 
 # ---------------------------------------------------------------------------

--- a/webhooks/incoming.py
+++ b/webhooks/incoming.py
@@ -10,7 +10,6 @@ or none).  Every request is logged to the ``webhook_logs`` collection for
 debugging, regardless of auth or execution outcome.
 """
 
-import asyncio
 import hashlib
 import hmac
 import json
@@ -193,12 +192,12 @@ async def handle_incoming_webhook(request: web.Request) -> web.Response:
 
     await update_webhook_log(db, log_id, auth_result="success")
 
-    # 5. Fire-and-forget execution
-    from scheduler.webhook_executor import execute_webhook_flow
+    # 5. Fire-and-forget execution. dispatch_webhook_flow supersedes any in-flight
+    # run for the same (flow_id, thread_id) so only the latest webhook executes;
+    # without an extractable thread_id it stays independent and concurrent.
+    from scheduler.webhook_executor import dispatch_webhook_flow
 
-    asyncio.create_task(
-        execute_webhook_flow(flow, raw_body, headers, log_id)
-    )
+    dispatch_webhook_flow(flow, raw_body, headers, log_id)
 
     logger.info("[WEBHOOK] Accepted webhook for flow %s (%s), log=%s", flow_id, flow_name, log_id)
     return web.json_response({"status": "accepted", "log_id": log_id}, status=202)


### PR DESCRIPTION
## What

When multiple webhooks arrive back-to-back for the same issue, **interrupt the in-flight run and execute only on the latest** — instead of running them all concurrently.

## Why

The webhook endpoint was pure fire-and-forget (`asyncio.create_task(execute_webhook_flow(...))`), so N webhooks for the same `issue_id` ran **concurrently** and **raced** on the thread-resume lookup. Result: overlapping agent runs on one issue → duplicated/conflicting side effects (e.g. two replies). There was no registry, lock, debounce, or supersede anywhere.

## Behavior

- When a flow can extract a `thread_id` (via `webhook_config.thread_id_path` or the auto-detect shapes), a newer webhook for the same **`(flow_id, thread_id)`** **hard-cancels** the in-flight run and runs only the latest.
- The latest **resumes the same conversation thread**; the cancelled run is marked **`interrupted`** (conversation + webhook log).
- **No extractable `thread_id` → unchanged**: independent, concurrent runs (no key to dedupe on).

## How

- `dispatch_webhook_flow()` — in-flight registry keyed by `f"{flow_id}:{thread_id}"`; cancels the predecessor, schedules the latest, self-cleans via a done-callback (guarded so it never clobbers a newer run). Returns immediately so the handler still `202`s fast.
- `_run_superseding()` — waits for the cancelled predecessor to finish tearing down before the latest resumes (avoids two agents writing one conversation); if an *even-newer* webhook cancels us mid-wait, we propagate and don't start.
- `execute_webhook_flow()` — new `except asyncio.CancelledError` → `mark_interrupted()` + flag the webhook log (shielded so the writes survive cancellation), then re-raise. `stream_agent()`'s `finally` already releases the pooled client and SIGKILLs the agent subprocess, so **no orphaned process or leaked pool slot**.
- Resume lookup `$in` now includes `interrupted` so the latest run picks up the just-superseded thread.

## Notes / limitations

- **In-process only** — the registry lives in one event loop. Loma runs a single backend process, so this is correct today; horizontal scaling would need a shared lock (Mongo/Redis). 
- The `key` design is generic enough to reuse for the planned **Slack-triggered** flow type (keyed on channel + message ts).
- Default-on for all webhook flows; no config surface.

## Test

- `pytest tests/test_webhook_executor.py` → **42 passed** (4 new): same-thread supersede (predecessor cancelled, latest resumes same convo), different threads run concurrently, no-thread-id stays independent, and the cancellation path marks the run interrupted.
- `compileall` clean; imports resolve.