### PR TITLE
[codex] Improve Loma skill discovery prompting

### DIFF
--- a/agent/client.py
+++ b/agent/client.py
@@ -703,33 +703,6 @@ async def stream_agent(
             f"{conversation_context}"
         )
 
-    try:
-        from observability.db import get_db
-        from api.skill_service import skill_index_text
-
-        db = get_db()
-        if db is not None:
-            skills_text = await skill_index_text(db)
-            skill_tool_auth = ""
-            if user_email:
-                skill_tool_auth = (
-                    f" For write commands, pass `--user-email {user_email} --auth-token {auth_token}`."
-                )
-            text_parts.append(
-                "## Loma Skills\n"
-                "Loma skills are stored in MongoDB and are available through the first-party CLI "
-                "`python3 tools/loma_skills.py`. Do not use the built-in `skill` tool for Loma skills. "
-                "Use `python3 tools/loma_skills.py list`, `python3 tools/loma_skills.py search --query QUERY`, "
-                "`python3 tools/loma_skills.py get --slug SLUG`, `python3 tools/loma_skills.py file --slug SLUG --path PATH`, "
-                "and `python3 tools/loma_skills.py asset --slug SLUG --path PATH` to inspect skills. "
-                "Only update skills when the user explicitly asks you to change "
-                f"company playbooks or skills.{skill_tool_auth}\n\n"
-                "Available skill index:\n"
-                f"{skills_text}"
-            )
-    except Exception:
-        logger.exception("Failed to inject Loma skill index")
-
     text_parts.append(f"## Current Message\n{prompt}")
 
     # Append file contents inline; save images to temp files for the agent to read

--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -11,6 +11,7 @@ PROMPT_SETTING_TITLES = {
 }
 
 _prompt_settings_cache: dict[str, str] = {}
+_loma_skill_index_cache = "No Loma skills are configured yet."
 
 
 def set_prompt_settings_cache(settings: dict[str, str]) -> None:
@@ -20,6 +21,12 @@ def set_prompt_settings_cache(settings: dict[str, str]) -> None:
         key: (settings.get(key) or "").strip()
         for key in PROMPT_SETTING_KEYS
     }
+
+
+def set_loma_skill_index_cache(skill_index_text: str) -> None:
+    """Replace the in-memory Loma skill index used by prompt builders."""
+    global _loma_skill_index_cache
+    _loma_skill_index_cache = (skill_index_text or "").strip() or "No Loma skills are configured yet."
 
 
 async def refresh_prompt_settings_from_db() -> None:
@@ -42,6 +49,24 @@ async def refresh_prompt_settings_from_db() -> None:
         logger.exception("Failed to load prompt settings from MongoDB")
 
 
+async def refresh_loma_skill_index_from_db() -> None:
+    """Load DB-backed Loma skill summaries into the prompt cache."""
+    try:
+        from observability.db import get_db
+        from api.skill_service import skill_index_text
+
+        db = get_db()
+        if db is None:
+            logger.warning("Loma skill index unavailable: DB not configured")
+            set_loma_skill_index_cache("No Loma skills are configured yet.")
+            return
+
+        set_loma_skill_index_cache(await skill_index_text(db))
+        logger.info("Loaded Loma skill index into prompt cache")
+    except Exception:
+        logger.exception("Failed to load Loma skill index from MongoDB")
+
+
 _TOOLS_AND_SKILLS_SECTION = """
 ## Available Tools
 
@@ -56,6 +81,27 @@ Optional personal tool examples, when configured:
 - `send-email --to user@example.com --subject "Subject" --body "Body" [--attachments /path/to/file1 /path/to/file2]`
 - `create-draft --to user@example.com --subject "Subject" --body "Body" [--attachments /path/to/file1]`
 - `slack-personal send-message --channel CHANNEL --text "Message" [--file /path/to/file] [--file-title TITLE]`
+""".strip()
+
+
+def _build_loma_skills_section() -> str:
+    return f"""
+## Loma Skills
+
+Loma skills are DB-backed company playbooks and references stored in MongoDB. Use the first-party CLI via Bash to discover and read them:
+
+- `python3 tools/loma_skills.py list`
+- `python3 tools/loma_skills.py search --query QUERY`
+- `python3 tools/loma_skills.py get --slug SLUG`
+- `python3 tools/loma_skills.py file --slug SLUG --path PATH`
+- `python3 tools/loma_skills.py asset --slug SLUG --path PATH`
+
+Do not use the built-in `Skill` tool for Loma DB-backed skills. Search or read the relevant Loma skill before starting work when the user asks for a domain-specific workflow, playbook, runbook, review, implementation, support investigation, or company procedure.
+
+Only update skills when the user explicitly asks you to change company playbooks or skills. For write commands, use the authenticated user's `--user-email` and `--auth-token` values when they are provided in the current message.
+
+Available skill index:
+{_loma_skill_index_cache}
 """.strip()
 
 
@@ -135,7 +181,7 @@ def build_system_prompt(source: str = "slack") -> str:
     formatting = _FORMATTING_DASHBOARD if source == "dashboard" else _FORMATTING_SLACK
     prompt = SYSTEM_PROMPT_WRAPPER.format(
         rulebook=load_rulebook(),
-        tools_and_skills=_TOOLS_AND_SKILLS_SECTION,
+        tools_and_skills=f"{_TOOLS_AND_SKILLS_SECTION}\n\n{_build_loma_skills_section()}",
         formatting=formatting,
         gh_pr=_GH_PR_SECTION,
     )
@@ -147,7 +193,7 @@ def build_pooled_system_prompt() -> str:
     """Build a universal system prompt for pooled clients."""
     prompt = SYSTEM_PROMPT_WRAPPER.format(
         rulebook=load_rulebook(),
-        tools_and_skills=_TOOLS_AND_SKILLS_SECTION,
+        tools_and_skills=f"{_TOOLS_AND_SKILLS_SECTION}\n\n{_build_loma_skills_section()}",
         formatting=_FORMATTING_POOLED,
         gh_pr=_GH_PR_SECTION,
     )

--- a/api/routes.py
+++ b/api/routes.py
@@ -14,7 +14,8 @@ from aiohttp import web
 
 from agent.client import stream_agent
 from agent.opencode_runtime import get_agent_models, get_opencode_pool_status
-from agent.pool import ClientPool
+from agent.pool import ClientPool, get_pool
+from agent.prompt import refresh_loma_skill_index_from_db
 from observability.db import get_db
 from observability.observer import ConversationObserver
 from api.auth_helpers import (
@@ -995,6 +996,18 @@ def _skill_error_response(exc: skill_service.SkillError) -> web.Response:
     return web.json_response({"error": str(exc)}, status=exc.status)
 
 
+async def _refresh_skill_prompt_cache() -> None:
+    """Best-effort refresh for system prompts after DB-backed skill mutations."""
+    try:
+        await refresh_loma_skill_index_from_db()
+        try:
+            await get_pool().reload_prompt()
+        except RuntimeError:
+            logger.info("Skipping prompt reload: client pool is not initialized")
+    except Exception:
+        logger.exception("Failed to refresh Loma skill prompt cache")
+
+
 async def handle_create_skill(request: web.Request) -> web.Response:
     """POST /api/skills — create a live DB-native skill."""
     require_maintainer_or_above(request)
@@ -1018,6 +1031,7 @@ async def handle_create_skill(request: web.Request) -> web.Response:
             source="dashboard",
             message="Created skill",
         )
+        await _refresh_skill_prompt_cache()
         return web.json_response(skill, status=201)
     except skill_service.SkillError as exc:
         return _skill_error_response(exc)
@@ -1049,6 +1063,7 @@ async def handle_update_skill(request: web.Request) -> web.Response:
             source="dashboard",
             message=body.get("message") or "Updated skill",
         )
+        await _refresh_skill_prompt_cache()
         return web.json_response(skill)
     except skill_service.SkillError as exc:
         return _skill_error_response(exc)
@@ -1076,13 +1091,15 @@ async def handle_update_skill_file(request: web.Request) -> web.Response:
     try:
         body = await request.json()
         file_doc = skill_service.validate_text_file(body.get("path", ""), body.get("content", ""))
-        return web.json_response(await skill_service.update_skill_file(
+        skill = await skill_service.update_skill_file(
             db,
             slug=request.match_info["name"],
             file_doc=file_doc,
             actor=get_user_email(request),
             source="dashboard",
-        ))
+        )
+        await _refresh_skill_prompt_cache()
+        return web.json_response(skill)
     except skill_service.SkillError as exc:
         return _skill_error_response(exc)
 
@@ -1108,14 +1125,16 @@ async def handle_upload_skill_asset(request: web.Request) -> web.Response:
             return web.json_response({"error": "Multipart fields path and file are required"}, status=400)
         slug = skill_service.slugify(request.match_info["name"])
         file_doc = skill_service.store_asset(slug, path, data, filename)
-        return web.json_response(await skill_service.update_skill_file(
+        skill = await skill_service.update_skill_file(
             db,
             slug=slug,
             file_doc=file_doc,
             actor=get_user_email(request),
             source="dashboard",
             message=f"Uploaded {path}",
-        ))
+        )
+        await _refresh_skill_prompt_cache()
+        return web.json_response(skill)
     except skill_service.SkillError as exc:
         return _skill_error_response(exc)
 
@@ -1127,13 +1146,15 @@ async def handle_delete_skill_file(request: web.Request) -> web.Response:
         return web.json_response({"error": "MongoDB is not configured"}, status=503)
     try:
         body = await request.json()
-        return web.json_response(await skill_service.delete_skill_file(
+        skill = await skill_service.delete_skill_file(
             db,
             slug=request.match_info["name"],
             path=body.get("path", ""),
             actor=get_user_email(request),
             source="dashboard",
-        ))
+        )
+        await _refresh_skill_prompt_cache()
+        return web.json_response(skill)
     except skill_service.SkillError as exc:
         return _skill_error_response(exc)
 
@@ -1150,6 +1171,7 @@ async def handle_delete_skill(request: web.Request) -> web.Response:
             actor=get_user_email(request),
             source="dashboard",
         )
+        await _refresh_skill_prompt_cache()
         return web.json_response({"ok": True})
     except skill_service.SkillError as exc:
         return _skill_error_response(exc)

--- a/app.py
+++ b/app.py
@@ -41,7 +41,7 @@ from recovery import start_recovery_loop
 from scheduler.engine import init_scheduler
 from agent.client import load_config, merge_db_integrations
 from agent.pool import init_pool
-from agent.prompt import refresh_prompt_settings_from_db
+from agent.prompt import refresh_loma_skill_index_from_db, refresh_prompt_settings_from_db
 from config.app_config import APP_NAME, LOMA_ENABLE_SCHEDULER, LOMA_ENABLE_WEBHOOKS, LOMA_ENABLE_SLACK
 
 logging.basicConfig(
@@ -68,6 +68,7 @@ async def main():
     # Initialize observability MongoDB
     await init_observability()
     await refresh_prompt_settings_from_db()
+    await refresh_loma_skill_index_from_db()
 
     # Pre-warm Claude SDK client pool (background \u2014 doesn't block startup)
     agent_config = load_config()

--- a/tests/test_github_webhook_prompt.py
+++ b/tests/test_github_webhook_prompt.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+
+
+def test_pr_review_prompt_uses_loma_skill_cli():
+    source = Path("webhooks/github.py").read_text()
+    old_skill_tool_instruction = "Use the " + "`Skill` tool"
+
+    assert old_skill_tool_instruction not in source
+    assert "python3 tools/loma_skills.py get --slug code-review" in source
+    assert "After reading the code-review skill" in source

--- a/tests/test_prompt_settings.py
+++ b/tests/test_prompt_settings.py
@@ -1,4 +1,9 @@
-from agent.prompt import build_pooled_system_prompt, set_prompt_settings_cache
+from agent.prompt import (
+    build_pooled_system_prompt,
+    build_system_prompt,
+    set_loma_skill_index_cache,
+    set_prompt_settings_cache,
+)
 
 
 def test_pooled_prompt_uses_mongo_backed_prompt_settings_cache():
@@ -21,3 +26,23 @@ def test_pooled_prompt_has_generic_fallback_without_prompt_settings():
     prompt = build_pooled_system_prompt()
 
     assert "You are Loma, a helpful company assistant." in prompt
+
+
+def test_pooled_prompt_includes_loma_skill_discovery_commands():
+    set_loma_skill_index_cache("No Loma skills are configured yet.")
+
+    prompt = build_pooled_system_prompt()
+
+    assert "## Loma Skills" in prompt
+    assert "python3 tools/loma_skills.py search --query QUERY" in prompt
+    assert "Do not use the built-in `Skill` tool" in prompt
+
+
+def test_loma_skill_index_cache_appears_in_prompts():
+    set_loma_skill_index_cache("- code-review: Review GitHub pull requests")
+
+    pooled_prompt = build_pooled_system_prompt()
+    dashboard_prompt = build_system_prompt(source="dashboard")
+
+    assert "- code-review: Review GitHub pull requests" in pooled_prompt
+    assert "- code-review: Review GitHub pull requests" in dashboard_prompt

--- a/webhooks/github.py
+++ b/webhooks/github.py
@@ -1203,7 +1203,7 @@ async def _process_pr_review(
         "## IMPORTANT: First Steps (MUST DO)",
         "",
         "Before anything else, you MUST:",
-        "1. Use the `Skill` tool to load `code-review` - this contains the review methodology",
+        "1. Read the DB-backed `code-review` skill with `python3 tools/loma_skills.py get --slug code-review` - this contains the review methodology",
         "2. Check for repo-specific rules by fetching `.agent/skills/review/SKILL.md` from the repo",
         "",
         f"## PR Details",
@@ -1247,7 +1247,7 @@ async def _process_pr_review(
     prompt_parts.extend([
         "## Review Workflow",
         "",
-        "After loading the skill, follow this workflow:",
+        "After reading the code-review skill, follow this workflow:",
         "",
         "1. **Get the list of changed files first:**",
         f"   `mcp__github__list_pull_request_files` with owner=`{repo_owner}`, repo=`{repo_name}`, pull_number={pr_number}",


### PR DESCRIPTION
## Summary
- Move DB-backed Loma skill discovery into the system prompt via a cached skill index.
- Refresh the skill prompt cache at startup and after skill mutations.
- Update GitHub PR review prompts to read the DB-backed `code-review` skill through `tools/loma_skills.py` instead of the old built-in `Skill` tool.

## Validation
- `rg 'Use the \`Skill\` tool|built-in \`skill\` tool for Loma skills|loma_skills.py get --slug code-review' agent api webhooks tests`
- `PYTHONPATH=<temporary claude_agent_sdk stub> python3.12 -m pytest tests/test_prompt_settings.py tests/test_phase4_file_delivery.py tests/test_skill_service.py tests/test_github_webhook_prompt.py` -> 45 passed, 1 pre-existing SyntaxWarning in `agent/client.py`

## Notes
- The local environment could not install `claude-agent-sdk` from pip, so the test run used a temporary import stub for that package only.
