### PR TITLE
[codex] Add one-shot Loma skill dump command

### DIFF
--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -92,11 +92,12 @@ Loma skills are DB-backed company playbooks and references stored in MongoDB. Us
 
 - `python3 tools/loma_skills.py list`
 - `python3 tools/loma_skills.py search --query QUERY`
-- `python3 tools/loma_skills.py get --slug SLUG`
+- `python3 tools/loma_skills.py get --slug SLUG` — metadata plus `SKILL.md`
+- `python3 tools/loma_skills.py dump --slug SLUG` — all inline text files in one response
 - `python3 tools/loma_skills.py file --slug SLUG --path PATH`
 - `python3 tools/loma_skills.py asset --slug SLUG --path PATH`
 
-Do not use the built-in `Skill` tool for Loma DB-backed skills. Search or read the relevant Loma skill before starting work when the user asks for a domain-specific workflow, playbook, runbook, review, implementation, support investigation, or company procedure.
+Do not use the built-in `Skill` tool for Loma DB-backed skills. Search or read the relevant Loma skill before starting work when the user asks for a domain-specific workflow, playbook, runbook, review, implementation, support investigation, or company procedure. When the user asks to print, inspect, or load an entire skill, use `dump --slug` instead of repeatedly calling `file`.
 
 Only update skills when the user explicitly asks you to change company playbooks or skills. For write commands, use the authenticated user's `--user-email` and `--auth-token` values when they are provided in the current message.
 

--- a/api/skill_service.py
+++ b/api/skill_service.py
@@ -183,6 +183,45 @@ def _skill_metadata_from_files(slug: str, files: list[dict[str, Any]]) -> dict[s
     return {"name": name, "description": description, "tags": [str(t) for t in tags]}
 
 
+def format_skill_dump_markdown(skill: dict[str, Any]) -> str:
+    """Render all inline text files in a skill as one markdown document."""
+    slug = str(skill.get("slug") or "skill")
+    name = str(skill.get("name") or slug)
+    description = str(skill.get("description") or "").strip()
+    tags = [str(tag) for tag in (skill.get("tags") or [])]
+
+    lines = [f"# {name}", "", f"Slug: `{slug}`"]
+    if description:
+        lines.append(f"Description: {description}")
+    if tags:
+        lines.append(f"Tags: {', '.join(tags)}")
+
+    files = skill.get("files") or []
+    inline_files = [
+        file_doc for file_doc in files
+        if file_doc.get("kind") == "inline_text"
+    ]
+    asset_files = [
+        file_doc for file_doc in files
+        if file_doc.get("kind") == "local_asset"
+    ]
+
+    for file_doc in inline_files:
+        path = file_doc.get("path") or "file"
+        content = file_doc.get("content") or ""
+        lines.extend(["", f"## {path}", "", content.rstrip()])
+
+    if asset_files:
+        lines.extend(["", "## Asset files", ""])
+        for file_doc in asset_files:
+            path = file_doc.get("path") or "asset"
+            content_type = file_doc.get("content_type") or "application/octet-stream"
+            size = int(file_doc.get("size_bytes") or 0)
+            lines.append(f"- `{path}` ({content_type}, {size} bytes)")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
 async def ensure_skill_indexes(db) -> None:
     await db.skills.create_index("slug", unique=True)
     await db.skills.create_index("enabled")

--- a/dashboard/src/app/skills/[name]/page.tsx
+++ b/dashboard/src/app/skills/[name]/page.tsx
@@ -59,7 +59,7 @@ function buildEditSkillPrompt(skill: SkillDetailResponse, fallbackSlug: string):
     "Current files:",
     buildFileList(skill) || "- SKILL.md",
     "",
-    `First fetch the full skill with \`python3 tools/loma_skills.py get --slug ${slug}\` and inspect any supporting files you need with \`python3 tools/loma_skills.py file --slug ${slug} --path <path>\` or \`python3 tools/loma_skills.py asset --slug ${slug} --path <path>\`.`,
+    `First fetch the full skill with \`python3 tools/loma_skills.py dump --slug ${slug}\` and inspect any specific supporting file you need with \`python3 tools/loma_skills.py file --slug ${slug} --path <path>\` or \`python3 tools/loma_skills.py asset --slug ${slug} --path <path>\`.`,
     "",
     "Help me decide the exact change. Only update the live skill after I explicitly confirm what to change.",
   ].join("\n");
@@ -76,7 +76,7 @@ function buildEditSkillFilePrompt(skill: SkillDetailResponse, fallbackSlug: stri
     `File kind: ${file.kind}`,
     `Content type: ${file.content_type || "unknown"}`,
     "",
-    `First inspect it with \`${readCommand}\` and fetch the whole skill with \`python3 tools/loma_skills.py get --slug ${slug}\` if you need broader context.`,
+    `First inspect it with \`${readCommand}\` and fetch the whole skill with \`python3 tools/loma_skills.py dump --slug ${slug}\` if you need broader context.`,
     "",
     "Help me decide the exact change. Only update the live skill after I explicitly confirm what to change.",
   ].join("\n");

--- a/tests/test_loma_skills_cli.py
+++ b/tests/test_loma_skills_cli.py
@@ -1,0 +1,39 @@
+import asyncio
+from types import SimpleNamespace
+
+
+from tools import loma_skills
+
+
+def test_get_notes_that_it_returns_skill_md_only(monkeypatch, capsys):
+    async def fake_get_skill(db, slug):
+        return {
+            "slug": slug,
+            "name": "Demo",
+            "description": "Demo description",
+            "content": "Main instructions",
+        }
+
+    monkeypatch.setattr(loma_skills, "_connect_db", lambda: (SimpleNamespace(close=lambda: None), object()))
+    monkeypatch.setattr(loma_skills.skill_service, "get_skill", fake_get_skill)
+
+    status = asyncio.run(loma_skills._run(SimpleNamespace(command="get", slug="demo")))
+
+    assert status == 0
+    output = capsys.readouterr().out
+    assert '"content": "Main instructions"' in output
+    assert "get returns metadata plus SKILL.md content only; use dump for all inline text files" in output
+
+
+def test_dump_prints_markdown(monkeypatch, capsys):
+    async def fake_get_skill(db, slug):
+        return {"slug": slug, "name": "Demo", "files": []}
+
+    monkeypatch.setattr(loma_skills, "_connect_db", lambda: (SimpleNamespace(close=lambda: None), object()))
+    monkeypatch.setattr(loma_skills.skill_service, "get_skill", fake_get_skill)
+    monkeypatch.setattr(loma_skills.skill_service, "format_skill_dump_markdown", lambda skill: "# Demo\n")
+
+    status = asyncio.run(loma_skills._run(SimpleNamespace(command="dump", slug="demo")))
+
+    assert status == 0
+    assert capsys.readouterr().out == "# Demo\n"

--- a/tests/test_prompt_settings.py
+++ b/tests/test_prompt_settings.py
@@ -35,6 +35,8 @@ def test_pooled_prompt_includes_loma_skill_discovery_commands():
 
     assert "## Loma Skills" in prompt
     assert "python3 tools/loma_skills.py search --query QUERY" in prompt
+    assert "python3 tools/loma_skills.py dump --slug SLUG" in prompt
+    assert "use `dump --slug` instead of repeatedly calling `file`" in prompt
     assert "Do not use the built-in `Skill` tool" in prompt
 
 

--- a/tests/test_skill_service.py
+++ b/tests/test_skill_service.py
@@ -35,3 +35,28 @@ def test_store_asset_uses_local_asset_dir(monkeypatch, tmp_path):
     assert doc["asset_path"].startswith(str(tmp_path))
     assert doc["content_hash"] in doc["asset_path"]
     assert doc["size_bytes"] == len(b"%PDF-1.4")
+
+
+def test_format_skill_dump_markdown_includes_all_inline_files_and_assets():
+    skill = {
+        "slug": "demo-skill",
+        "name": "Demo Skill",
+        "description": "Demo description",
+        "tags": ["demo", "test"],
+        "files": [
+            skill_service.validate_text_file("SKILL.md", "Main instructions"),
+            skill_service.validate_text_file("notes/extra.md", "Extra context"),
+            skill_service.validate_asset_file("assets/example.pdf", b"%PDF-1.4", "example.pdf"),
+        ],
+    }
+
+    rendered = skill_service.format_skill_dump_markdown(skill)
+
+    assert "# Demo Skill" in rendered
+    assert "Slug: `demo-skill`" in rendered
+    assert "Description: Demo description" in rendered
+    assert "Tags: demo, test" in rendered
+    assert "## SKILL.md\n\nMain instructions" in rendered
+    assert "## notes/extra.md\n\nExtra context" in rendered
+    assert "## Asset files" in rendered
+    assert "`assets/example.pdf` (application/pdf, 8 bytes)" in rendered

--- a/tools/loma_skills.py
+++ b/tools/loma_skills.py
@@ -4,8 +4,9 @@
 Examples:
   python3 tools/loma_skills.py list
   python3 tools/loma_skills.py search --query onboarding
-  python3 tools/loma_skills.py get --slug onboarding
+  python3 tools/loma_skills.py get --slug onboarding        # metadata + SKILL.md only
   python3 tools/loma_skills.py file --slug onboarding --path SKILL.md
+  python3 tools/loma_skills.py dump --slug onboarding       # all inline text files
   python3 tools/loma_skills.py update-file --slug onboarding --path SKILL.md --content-file /tmp/SKILL.md --user-email u@co.com --auth-token TOKEN
 """
 
@@ -78,7 +79,17 @@ async def _run(args) -> int:
 
         if args.command == "get":
             skill = await skill_service.get_skill(db, args.slug)
-            return _json(_compact_skill(skill) | {"content": skill.get("content", "")})
+            return _json(
+                _compact_skill(skill) | {
+                    "content": skill.get("content", ""),
+                    "note": "get returns metadata plus SKILL.md content only; use dump for all inline text files.",
+                }
+            )
+
+        if args.command == "dump":
+            skill = await skill_service.get_skill(db, args.slug)
+            print(skill_service.format_skill_dump_markdown(skill), end="")
+            return 0
 
         if args.command == "file":
             file_doc = await skill_service.get_skill_file(db, args.slug, args.path)
@@ -188,9 +199,12 @@ def main() -> int:
     search.add_argument("query_text", nargs="?")
     search.add_argument("--query")
     add_auth(search)
-    get = sub.add_parser("get")
+    get = sub.add_parser("get", help="Show skill metadata and SKILL.md content only")
     get.add_argument("--slug", required=True)
     add_auth(get)
+    dump = sub.add_parser("dump", help="Print all inline text files in one markdown response")
+    dump.add_argument("--slug", required=True)
+    add_auth(dump)
     file_cmd = sub.add_parser("file")
     file_cmd.add_argument("--slug", required=True)
     file_cmd.add_argument("--path", required=True)


### PR DESCRIPTION
## Summary
- Add `python3 tools/loma_skills.py dump --slug SLUG` to print all inline skill files in one markdown response.
- Clarify `get --slug` as metadata plus `SKILL.md` only, with a note to use `dump` for full skill contents.
- Update system prompt and Skills UI-generated chat prompts to prefer `dump --slug` for whole-skill reads.

## Validation
- `/Users/adarsh/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_prompt_settings.py tests/test_skill_service.py tests/test_loma_skills_cli.py` -> 11 passed
