### PR TITLE
Normalize OAuth tool assignments

### DIFF
--- a/api/oauth_helpers.py
+++ b/api/oauth_helpers.py
@@ -146,6 +146,18 @@ def verify_oauth_state(state: str, max_age: int = 600) -> str | None:
 # ── Token storage ─────────────────────────────────────────────────────────
 
 
+async def _ensure_tool_assignments_mapping(db, user_email: str) -> None:
+    """Normalize legacy user rows before nested tool assignment updates."""
+    user = await db.users.find_one({"email": user_email}, {"tool_assignments": 1})
+    if user is None:
+        return
+    if not isinstance(user.get("tool_assignments", {}), dict):
+        await db.users.update_one(
+            {"email": user_email},
+            {"$set": {"tool_assignments": {}}},
+        )
+
+
 async def store_google_tokens(
     db,
     user_email: str,
@@ -176,6 +188,7 @@ async def store_google_tokens(
     )
 
     # Update user's tool_assignments status
+    await _ensure_tool_assignments_mapping(db, user_email)
     await db.users.update_one(
         {"email": user_email},
         {"$set": {
@@ -277,6 +290,7 @@ async def revoke_google_tokens(db, user_email: str) -> bool:
 
     # Update user status
     now = datetime.now(timezone.utc)
+    await _ensure_tool_assignments_mapping(db, user_email)
     await db.users.update_one(
         {"email": user_email},
         {"$set": {
@@ -319,6 +333,7 @@ async def _refresh_google_token(refresh_token: str) -> dict | None:
 async def _mark_expired(db, user_email: str) -> None:
     """Mark a user's Google OAuth status as expired."""
     now = datetime.now(timezone.utc)
+    await _ensure_tool_assignments_mapping(db, user_email)
     await db.users.update_one(
         {"email": user_email},
         {"$set": {
@@ -362,6 +377,7 @@ async def store_slack_tokens(
     )
 
     # Update user's tool_assignments status
+    await _ensure_tool_assignments_mapping(db, user_email)
     await db.users.update_one(
         {"email": user_email},
         {"$set": {
@@ -402,6 +418,7 @@ async def revoke_slack_tokens(db, user_email: str) -> bool:
 
     # Update user status
     now = datetime.now(timezone.utc)
+    await _ensure_tool_assignments_mapping(db, user_email)
     await db.users.update_one(
         {"email": user_email},
         {"$set": {

--- a/tests/test_oauth_helpers.py
+++ b/tests/test_oauth_helpers.py
@@ -1,0 +1,85 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from api.oauth_helpers import store_google_tokens, store_slack_tokens
+
+
+class FakeCollection:
+    def __init__(self, docs=None):
+        self.docs = docs or []
+        self.updates = []
+
+    async def find_one(self, query, projection=None):
+        for doc in self.docs:
+            if all(doc.get(k) == v for k, v in query.items()):
+                if projection is None:
+                    return doc
+                return {k: doc[k] for k in projection if k in doc}
+        return None
+
+    async def update_one(self, query, update, upsert=False):
+        self.updates.append((query, update, upsert))
+        doc = await self.find_one(query)
+        if doc is None:
+            if not upsert:
+                return SimpleNamespace(modified_count=0)
+            doc = dict(query)
+            self.docs.append(doc)
+        for key, value in update.get("$set", {}).items():
+            if key == "tool_assignments":
+                doc[key] = value
+                continue
+            target = doc
+            parts = key.split(".")
+            for part in parts[:-1]:
+                target = target.setdefault(part, {})
+            target[parts[-1]] = value
+        for key, value in update.get("$setOnInsert", {}).items():
+            doc.setdefault(key, value)
+        return SimpleNamespace(modified_count=1)
+
+
+def test_store_google_tokens_normalizes_legacy_tool_assignments():
+    db = SimpleNamespace(
+        users=FakeCollection([{"email": "user@example.com", "tool_assignments": []}]),
+        oauth_tokens=FakeCollection(),
+    )
+
+    with patch("api.oauth_helpers.encrypt_token", side_effect=lambda token: f"enc:{token}"):
+        asyncio.run(
+            store_google_tokens(
+                db,
+                "user@example.com",
+                "access-token",
+                "refresh-token",
+                3600,
+                ["email"],
+            )
+        )
+
+    user = db.users.docs[0]
+    assert user["tool_assignments"]["google-personal"]["oauth_status"] == "connected"
+
+
+def test_store_slack_tokens_normalizes_legacy_tool_assignments():
+    db = SimpleNamespace(
+        users=FakeCollection([{"email": "user@example.com", "tool_assignments": []}]),
+        oauth_tokens=FakeCollection(),
+    )
+
+    with patch("api.oauth_helpers.encrypt_token", side_effect=lambda token: f"enc:{token}"):
+        asyncio.run(
+            store_slack_tokens(
+                db,
+                "user@example.com",
+                "slack-token",
+                ["chat:write"],
+                slack_user_id="U123",
+                slack_team_id="T123",
+            )
+        )
+
+    user = db.users.docs[0]
+    assert user["tool_assignments"]["slack-personal"]["oauth_status"] == "connected"
+


### PR DESCRIPTION
## Summary
- normalize legacy users.tool_assignments values before writing nested OAuth statuses
- fixes Google/Slack callbacks failing after successful provider auth when a user row has tool_assignments: []
- add regression coverage for Google and Slack token storage

## Tests
- /Users/adarsh/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/test_oauth_routes.py tests/test_oauth_helpers.py