### PR TITLE
Seed generic starter skills on first run

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,9 @@ LOMA_ENABLE_METRICS=false
 # Slack Socket Mode consumer (default true). Set false on preview/ephemeral stacks
 # so they don't double-consume the production Slack app's events.
 LOMA_ENABLE_SLACK=true
+# Seed generic starter skills on first run when the skills collection is empty
+# (default true). Existing deployments are untouched regardless.
+LOMA_SEED_SKILLS=true
 
 # Optional OAuth token encryption for personal integrations
 OAUTH_ENCRYPTION_KEY=generate-a-fernet-key

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM python:3.12-slim
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends nodejs npm git curl ca-certificates \
+    poppler-utils tesseract-ocr \
     && OPENCODE_INSTALL_DIR=/usr/local/bin sh -c 'curl -fsSL https://opencode.ai/install | bash' \
     && ln -sf /root/.opencode/bin/opencode /usr/local/bin/opencode \
     && opencode --version \

--- a/api/skill_seed.py
+++ b/api/skill_seed.py
@@ -1,0 +1,59 @@
+"""First-run seeding of generic starter skills.
+
+A freshly cloned Loma deployment starts with an empty `skills` collection, so the
+agent has nothing useful to draw on. On startup we import a curated set of
+generic, company-agnostic starter skills bundled under ``seed/skills/`` — but
+ONLY when the collection is completely empty, so existing deployments are never
+touched and skills are never overwritten or duplicated.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from api import skill_service
+from config.app_config import LOMA_SEED_SKILLS
+
+logger = logging.getLogger(__name__)
+
+SEED_DIR = Path(__file__).resolve().parent.parent / "seed" / "skills"
+
+
+async def seed_default_skills(db) -> None:
+    """Import bundled starter skills if (and only if) no skills exist yet.
+
+    Idempotent and safe: keyed on the whole ``skills`` collection being empty, so
+    it never runs on a populated deployment (e.g. an upgrade) and can't collide
+    with user-authored skills. Disable entirely with ``LOMA_SEED_SKILLS=false``.
+    """
+    if not LOMA_SEED_SKILLS:
+        return
+    if db is None:
+        return
+
+    try:
+        existing = await db.skills.count_documents({})
+    except Exception:
+        logger.exception("[SEED] Could not read skills collection; skipping seed")
+        return
+    if existing > 0:
+        return
+
+    if not SEED_DIR.is_dir():
+        logger.warning("[SEED] Seed directory not found: %s", SEED_DIR)
+        return
+
+    await skill_service.ensure_skill_indexes(db)
+    seeded: list[str] = []
+    for child in sorted(p for p in SEED_DIR.iterdir() if p.is_dir()):
+        try:
+            result = await skill_service.import_skill_directory(db, child, actor="system")
+            seeded.append(result.get("slug", child.name))
+        except Exception:
+            logger.exception("[SEED] Failed to seed starter skill from %s", child)
+
+    if seeded:
+        logger.info("[SEED] Seeded %d starter skills: %s", len(seeded), ", ".join(seeded))
+    else:
+        logger.warning("[SEED] No starter skills were seeded from %s", SEED_DIR)

--- a/app.py
+++ b/app.py
@@ -24,7 +24,8 @@ from webhooks.pylon import setup_pylon_webhook_routes
 from webhooks.hubspot import setup_hubspot_webhook_routes
 from webhooks.github import setup_github_webhook_routes
 from webhooks.incoming import setup_incoming_webhook_routes
-from observability.db import init_observability
+from observability.db import init_observability, get_db
+from api.skill_seed import seed_default_skills
 from api.routes import setup_api_routes
 from api.auth_middleware import auth_middleware
 from api.governance_routes import setup_governance_routes
@@ -67,6 +68,8 @@ async def log_404_middleware(request, handler):
 async def main():
     # Initialize observability MongoDB
     await init_observability()
+    # First-run only: seed generic starter skills into an empty deployment.
+    await seed_default_skills(get_db())
     await refresh_prompt_settings_from_db()
     await refresh_loma_skill_index_from_db()
 

--- a/config/app_config.py
+++ b/config/app_config.py
@@ -20,6 +20,9 @@ LOMA_SKILL_ASSET_DIR = os.environ.get("LOMA_SKILL_ASSET_DIR", "/var/lib/loma/ski
 
 LOMA_ENABLE_SCHEDULER = env_flag("LOMA_ENABLE_SCHEDULER", default=False)
 LOMA_ENABLE_WEBHOOKS = env_flag("LOMA_ENABLE_WEBHOOKS", default=True)
+# Seed generic starter skills on first run, only when the skills collection is
+# empty. Existing deployments are never touched; disable with =false.
+LOMA_SEED_SKILLS = env_flag("LOMA_SEED_SKILLS", default=True)
 LOMA_ENABLE_METRICS = env_flag("LOMA_ENABLE_METRICS", default=False)
 # Slack Socket Mode consumer. Defaults to on so existing deployments are
 # unchanged; preview/ephemeral stacks set this to false (or omit SLACK_APP_TOKEN)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,14 @@ anthropic>=0.39.0
 voyageai>=0.3.0
 pymupdf>=1.24.0
 python-docx>=1.1.0
+# PDF starter-skill toolchain (seed/skills/pdf, pdf-reading)
+pypdf>=4.2.0
+pdfplumber>=0.11.0
+pypdfium2>=4.30.0
+reportlab>=4.2.0
+pillow>=10.3.0
+pdf2image>=1.17.0
+pytesseract>=0.3.10
 apscheduler>=3.10.0
 openai>=1.50.0
 cryptography>=41.0.0

--- a/seed/skills/algorithmic-art/SKILL.md
+++ b/seed/skills/algorithmic-art/SKILL.md
@@ -1,0 +1,405 @@
+---
+name: algorithmic-art
+description: Creating algorithmic art using p5.js with seeded randomness and interactive parameter exploration. Use this when users request creating art using code, generative art, algorithmic art, flow fields, or particle systems. Create original algorithmic art rather than copying existing artists' work to avoid copyright violations.
+user-invocable: false
+---
+
+Algorithmic philosophies are computational aesthetic movements that are then expressed through code. Output .md files (philosophy), .html files (interactive viewer), and .js files (generative algorithms).
+
+This happens in two steps:
+1. Algorithmic Philosophy Creation (.md file)
+2. Express by creating p5.js generative art (.html + .js files)
+
+First, undertake this task:
+
+## ALGORITHMIC PHILOSOPHY CREATION
+
+To begin, create an ALGORITHMIC PHILOSOPHY (not static images or templates) that will be interpreted through:
+- Computational processes, emergent behavior, mathematical beauty
+- Seeded randomness, noise fields, organic systems
+- Particles, flows, fields, forces
+- Parametric variation and controlled chaos
+
+### THE CRITICAL UNDERSTANDING
+- What is received: Some subtle input or instructions by the user to take into account, but use as a foundation; it should not constrain creative freedom.
+- What is created: An algorithmic philosophy/generative aesthetic movement.
+- What happens next: The same version receives the philosophy and EXPRESSES IT IN CODE - creating p5.js sketches that are 90% algorithmic generation, 10% essential parameters.
+
+Consider this approach:
+- Write a manifesto for a generative art movement
+- The next phase involves writing the algorithm that brings it to life
+
+The philosophy must emphasize: Algorithmic expression. Emergent behavior. Computational beauty. Seeded variation.
+
+### HOW TO GENERATE AN ALGORITHMIC PHILOSOPHY
+
+**Name the movement** (1-2 words): "Organic Turbulence" / "Quantum Harmonics" / "Emergent Stillness"
+
+**Articulate the philosophy** (4-6 paragraphs - concise but complete):
+
+To capture the ALGORITHMIC essence, express how this philosophy manifests through:
+- Computational processes and mathematical relationships?
+- Noise functions and randomness patterns?
+- Particle behaviors and field dynamics?
+- Temporal evolution and system states?
+- Parametric variation and emergent complexity?
+
+**CRITICAL GUIDELINES:**
+- **Avoid redundancy**: Each algorithmic aspect should be mentioned once. Avoid repeating concepts about noise theory, particle dynamics, or mathematical principles unless adding new depth.
+- **Emphasize craftsmanship REPEATEDLY**: The philosophy MUST stress multiple times that the final algorithm should appear as though it took countless hours to develop, was refined with care, and comes from someone at the absolute top of their field. This framing is essential - repeat phrases like "meticulously crafted algorithm," "the product of deep computational expertise," "painstaking optimization," "master-level implementation."
+- **Leave creative space**: Be specific about the algorithmic direction, but concise enough that the next Claude has room to make interpretive implementation choices at an extremely high level of craftsmanship.
+
+The philosophy must guide the next version to express ideas ALGORITHMICALLY, not through static images. Beauty lives in the process, not the final frame.
+
+### PHILOSOPHY EXAMPLES
+
+**"Organic Turbulence"**
+Philosophy: Chaos constrained by natural law, order emerging from disorder.
+Algorithmic expression: Flow fields driven by layered Perlin noise. Thousands of particles following vector forces, their trails accumulating into organic density maps. Multiple noise octaves create turbulent regions and calm zones. Color emerges from velocity and density - fast particles burn bright, slow ones fade to shadow. The algorithm runs until equilibrium - a meticulously tuned balance where every parameter was refined through countless iterations by a master of computational aesthetics.
+
+**"Quantum Harmonics"**
+Philosophy: Discrete entities exhibiting wave-like interference patterns.
+Algorithmic expression: Particles initialized on a grid, each carrying a phase value that evolves through sine waves. When particles are near, their phases interfere - constructive interference creates bright nodes, destructive creates voids. Simple harmonic motion generates complex emergent mandalas. The result of painstaking frequency calibration where every ratio was carefully chosen to produce resonant beauty.
+
+**"Recursive Whispers"**
+Philosophy: Self-similarity across scales, infinite depth in finite space.
+Algorithmic expression: Branching structures that subdivide recursively. Each branch slightly randomized but constrained by golden ratios. L-systems or recursive subdivision generate tree-like forms that feel both mathematical and organic. Subtle noise perturbations break perfect symmetry. Line weights diminish with each recursion level. Every branching angle the product of deep mathematical exploration.
+
+**"Field Dynamics"**
+Philosophy: Invisible forces made visible through their effects on matter.
+Algorithmic expression: Vector fields constructed from mathematical functions or noise. Particles born at edges, flowing along field lines, dying when they reach equilibrium or boundaries. Multiple fields can attract, repel, or rotate particles. The visualization shows only the traces - ghost-like evidence of invisible forces. A computational dance meticulously choreographed through force balance.
+
+**"Stochastic Crystallization"**
+Philosophy: Random processes crystallizing into ordered structures.
+Algorithmic expression: Randomized circle packing or Voronoi tessellation. Start with random points, let them evolve through relaxation algorithms. Cells push apart until equilibrium. Color based on cell size, neighbor count, or distance from center. The organic tiling that emerges feels both random and inevitable. Every seed produces unique crystalline beauty - the mark of a master-level generative algorithm.
+
+*These are condensed examples. The actual algorithmic philosophy should be 4-6 substantial paragraphs.*
+
+### ESSENTIAL PRINCIPLES
+- **ALGORITHMIC PHILOSOPHY**: Creating a computational worldview to be expressed through code
+- **PROCESS OVER PRODUCT**: Always emphasize that beauty emerges from the algorithm's execution - each run is unique
+- **PARAMETRIC EXPRESSION**: Ideas communicate through mathematical relationships, forces, behaviors - not static composition
+- **ARTISTIC FREEDOM**: The next Claude interprets the philosophy algorithmically - provide creative implementation room
+- **PURE GENERATIVE ART**: This is about making LIVING ALGORITHMS, not static images with randomness
+- **EXPERT CRAFTSMANSHIP**: Repeatedly emphasize the final algorithm must feel meticulously crafted, refined through countless iterations, the product of deep expertise by someone at the absolute top of their field in computational aesthetics
+
+**The algorithmic philosophy should be 4-6 paragraphs long.** Fill it with poetic computational philosophy that brings together the intended vision. Avoid repeating the same points. Output this algorithmic philosophy as a .md file.
+
+---
+
+## DEDUCING THE CONCEPTUAL SEED
+
+**CRITICAL STEP**: Before implementing the algorithm, identify the subtle conceptual thread from the original request.
+
+**THE ESSENTIAL PRINCIPLE**:
+The concept is a **subtle, niche reference embedded within the algorithm itself** - not always literal, always sophisticated. Someone familiar with the subject should feel it intuitively, while others simply experience a masterful generative composition. The algorithmic philosophy provides the computational language. The deduced concept provides the soul - the quiet conceptual DNA woven invisibly into parameters, behaviors, and emergence patterns.
+
+This is **VERY IMPORTANT**: The reference must be so refined that it enhances the work's depth without announcing itself. Think like a jazz musician quoting another song through algorithmic harmony - only those who know will catch it, but everyone appreciates the generative beauty.
+
+---
+
+## P5.JS IMPLEMENTATION
+
+With the philosophy AND conceptual framework established, express it through code. Pause to gather thoughts before proceeding. Use only the algorithmic philosophy created and the instructions below.
+
+### ⚠️ STEP 0: READ THE TEMPLATE FIRST ⚠️
+
+**CRITICAL: BEFORE writing any HTML:**
+
+1. **Read** `templates/viewer.html` using the Read tool
+2. **Study** the exact structure, styling, and Anthropic branding
+3. **Use that file as the LITERAL STARTING POINT** - not just inspiration
+4. **Keep all FIXED sections exactly as shown** (header, sidebar structure, Anthropic colors/fonts, seed controls, action buttons)
+5. **Replace only the VARIABLE sections** marked in the file's comments (algorithm, parameters, UI controls for parameters)
+
+**Avoid:**
+- ❌ Creating HTML from scratch
+- ❌ Inventing custom styling or color schemes
+- ❌ Using system fonts or dark themes
+- ❌ Changing the sidebar structure
+
+**Follow these practices:**
+- ✅ Copy the template's exact HTML structure
+- ✅ Keep Anthropic branding (Poppins/Lora fonts, light colors, gradient backdrop)
+- ✅ Maintain the sidebar layout (Seed → Parameters → Colors? → Actions)
+- ✅ Replace only the p5.js algorithm and parameter controls
+
+The template is the foundation. Build on it, don't rebuild it.
+
+---
+
+To create gallery-quality computational art that lives and breathes, use the algorithmic philosophy as the foundation.
+
+### TECHNICAL REQUIREMENTS
+
+**Seeded Randomness (Art Blocks Pattern)**:
+```javascript
+// ALWAYS use a seed for reproducibility
+let seed = 12345; // or hash from user input
+randomSeed(seed);
+noiseSeed(seed);
+```
+
+**Parameter Structure - FOLLOW THE PHILOSOPHY**:
+
+To establish parameters that emerge naturally from the algorithmic philosophy, consider: "What qualities of this system can be adjusted?"
+
+```javascript
+let params = {
+  seed: 12345,  // Always include seed for reproducibility
+  // colors
+  // Add parameters that control YOUR algorithm:
+  // - Quantities (how many?)
+  // - Scales (how big? how fast?)
+  // - Probabilities (how likely?)
+  // - Ratios (what proportions?)
+  // - Angles (what direction?)
+  // - Thresholds (when does behavior change?)
+};
+```
+
+**To design effective parameters, focus on the properties the system needs to be tunable rather than thinking in terms of "pattern types".**
+
+**Core Algorithm - EXPRESS THE PHILOSOPHY**:
+
+**CRITICAL**: The algorithmic philosophy should dictate what to build.
+
+To express the philosophy through code, avoid thinking "which pattern should I use?" and instead think "how to express this philosophy through code?"
+
+If the philosophy is about **organic emergence**, consider using:
+- Elements that accumulate or grow over time
+- Random processes constrained by natural rules
+- Feedback loops and interactions
+
+If the philosophy is about **mathematical beauty**, consider using:
+- Geometric relationships and ratios
+- Trigonometric functions and harmonics
+- Precise calculations creating unexpected patterns
+
+If the philosophy is about **controlled chaos**, consider using:
+- Random variation within strict boundaries
+- Bifurcation and phase transitions
+- Order emerging from disorder
+
+**The algorithm flows from the philosophy, not from a menu of options.**
+
+To guide the implementation, let the conceptual essence inform creative and original choices. Build something that expresses the vision for this particular request.
+
+**Canvas Setup**: Standard p5.js structure:
+```javascript
+function setup() {
+  createCanvas(1200, 1200);
+  // Initialize your system
+}
+
+function draw() {
+  // Your generative algorithm
+  // Can be static (noLoop) or animated
+}
+```
+
+### CRAFTSMANSHIP REQUIREMENTS
+
+**CRITICAL**: To achieve mastery, create algorithms that feel like they emerged through countless iterations by a master generative artist. Tune every parameter carefully. Ensure every pattern emerges with purpose. This is NOT random noise - this is CONTROLLED CHAOS refined through deep expertise.
+
+- **Balance**: Complexity without visual noise, order without rigidity
+- **Color Harmony**: Thoughtful palettes, not random RGB values
+- **Composition**: Even in randomness, maintain visual hierarchy and flow
+- **Performance**: Smooth execution, optimized for real-time if animated
+- **Reproducibility**: Same seed ALWAYS produces identical output
+
+### OUTPUT FORMAT
+
+Output:
+1. **Algorithmic Philosophy** - As markdown or text explaining the generative aesthetic
+2. **Single HTML Artifact** - Self-contained interactive generative art built from `templates/viewer.html` (see STEP 0 and next section)
+
+The HTML artifact contains everything: p5.js (from CDN), the algorithm, parameter controls, and UI - all in one file that works immediately in claude.ai artifacts or any browser. Start from the template file, not from scratch.
+
+---
+
+## INTERACTIVE ARTIFACT CREATION
+
+**REMINDER: `templates/viewer.html` should have already been read (see STEP 0). Use that file as the starting point.**
+
+To allow exploration of the generative art, create a single, self-contained HTML artifact. Ensure this artifact works immediately in claude.ai or any browser - no setup required. Embed everything inline.
+
+### CRITICAL: WHAT'S FIXED VS VARIABLE
+
+The `templates/viewer.html` file is the foundation. It contains the exact structure and styling needed.
+
+**FIXED (always include exactly as shown):**
+- Layout structure (header, sidebar, main canvas area)
+- Anthropic branding (UI colors, fonts, gradients)
+- Seed section in sidebar:
+  - Seed display
+  - Previous/Next buttons
+  - Random button
+  - Jump to seed input + Go button
+- Actions section in sidebar:
+  - Regenerate button
+  - Reset button
+
+**VARIABLE (customize for each artwork):**
+- The entire p5.js algorithm (setup/draw/classes)
+- The parameters object (define what the art needs)
+- The Parameters section in sidebar:
+  - Number of parameter controls
+  - Parameter names
+  - Min/max/step values for sliders
+  - Control types (sliders, inputs, etc.)
+- Colors section (optional):
+  - Some art needs color pickers
+  - Some art might use fixed colors
+  - Some art might be monochrome (no color controls needed)
+  - Decide based on the art's needs
+
+**Every artwork should have unique parameters and algorithm!** The fixed parts provide consistent UX - everything else expresses the unique vision.
+
+### REQUIRED FEATURES
+
+**1. Parameter Controls**
+- Sliders for numeric parameters (particle count, noise scale, speed, etc.)
+- Color pickers for palette colors
+- Real-time updates when parameters change
+- Reset button to restore defaults
+
+**2. Seed Navigation**
+- Display current seed number
+- "Previous" and "Next" buttons to cycle through seeds
+- "Random" button for random seed
+- Input field to jump to specific seed
+- Generate 100 variations when requested (seeds 1-100)
+
+**3. Single Artifact Structure**
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <!-- p5.js from CDN - always available -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.7.0/p5.min.js"></script>
+  <style>
+    /* All styling inline - clean, minimal */
+    /* Canvas on top, controls below */
+  </style>
+</head>
+<body>
+  <div id="canvas-container"></div>
+  <div id="controls">
+    <!-- All parameter controls -->
+  </div>
+  <script>
+    // ALL p5.js code inline here
+    // Parameter objects, classes, functions
+    // setup() and draw()
+    // UI handlers
+    // Everything self-contained
+  </script>
+</body>
+</html>
+```
+
+**CRITICAL**: This is a single artifact. No external files, no imports (except p5.js CDN). Everything inline.
+
+**4. Implementation Details - BUILD THE SIDEBAR**
+
+The sidebar structure:
+
+**1. Seed (FIXED)** - Always include exactly as shown:
+- Seed display
+- Prev/Next/Random/Jump buttons
+
+**2. Parameters (VARIABLE)** - Create controls for the art:
+```html
+<div class="control-group">
+    <label>Parameter Name</label>
+    <input type="range" id="param" min="..." max="..." step="..." value="..." oninput="updateParam('param', this.value)">
+    <span class="value-display" id="param-value">...</span>
+</div>
+```
+Add as many control-group divs as there are parameters.
+
+**3. Colors (OPTIONAL/VARIABLE)** - Include if the art needs adjustable colors:
+- Add color pickers if users should control palette
+- Skip this section if the art uses fixed colors
+- Skip if the art is monochrome
+
+**4. Actions (FIXED)** - Always include exactly as shown:
+- Regenerate button
+- Reset button
+- Download PNG button
+
+**Requirements**:
+- Seed controls must work (prev/next/random/jump/display)
+- All parameters must have UI controls
+- Regenerate, Reset, Download buttons must work
+- Keep Anthropic branding (UI styling, not art colors)
+
+### USING THE ARTIFACT
+
+The HTML artifact works immediately:
+1. **In claude.ai**: Displayed as an interactive artifact - runs instantly
+2. **As a file**: Save and open in any browser - no server needed
+3. **Sharing**: Send the HTML file - it's completely self-contained
+
+---
+
+## VARIATIONS & EXPLORATION
+
+The artifact includes seed navigation by default (prev/next/random buttons), allowing users to explore variations without creating multiple files. If the user wants specific variations highlighted:
+
+- Include seed presets (buttons for "Variation 1: Seed 42", "Variation 2: Seed 127", etc.)
+- Add a "Gallery Mode" that shows thumbnails of multiple seeds side-by-side
+- All within the same single artifact
+
+This is like creating a series of prints from the same plate - the algorithm is consistent, but each seed reveals different facets of its potential. The interactive nature means users discover their own favorites by exploring the seed space.
+
+---
+
+## THE CREATIVE PROCESS
+
+**User request** → **Algorithmic philosophy** → **Implementation**
+
+Each request is unique. The process involves:
+
+1. **Interpret the user's intent** - What aesthetic is being sought?
+2. **Create an algorithmic philosophy** (4-6 paragraphs) describing the computational approach
+3. **Implement it in code** - Build the algorithm that expresses this philosophy
+4. **Design appropriate parameters** - What should be tunable?
+5. **Build matching UI controls** - Sliders/inputs for those parameters
+
+**The constants**:
+- Anthropic branding (colors, fonts, layout)
+- Seed navigation (always present)
+- Self-contained HTML artifact
+
+**Everything else is variable**:
+- The algorithm itself
+- The parameters
+- The UI controls
+- The visual outcome
+
+To achieve the best results, trust creativity and let the philosophy guide the implementation.
+
+---
+
+## RESOURCES
+
+This skill includes helpful templates and documentation:
+
+- **templates/viewer.html**: REQUIRED STARTING POINT for all HTML artifacts.
+  - This is the foundation - contains the exact structure and Anthropic branding
+  - **Keep unchanged**: Layout structure, sidebar organization, Anthropic colors/fonts, seed controls, action buttons
+  - **Replace**: The p5.js algorithm, parameter definitions, and UI controls in Parameters section
+  - The extensive comments in the file mark exactly what to keep vs replace
+
+- **templates/generator_template.js**: Reference for p5.js best practices and code structure principles.
+  - Shows how to organize parameters, use seeded randomness, structure classes
+  - NOT a pattern menu - use these principles to build unique algorithms
+  - Embed algorithms inline in the HTML artifact (don't create separate .js files)
+
+**Critical reminder**:
+- The **template is the STARTING POINT**, not inspiration
+- The **algorithm is where to create** something unique
+- Don't copy the flow field example - build what the philosophy demands
+- But DO keep the exact UI structure and Anthropic branding from the template

--- a/seed/skills/code-review/SKILL.md
+++ b/seed/skills/code-review/SKILL.md
@@ -1,0 +1,501 @@
+---
+name: code-review
+description: Review a GitHub pull request — analyze the diff, check for issues, and post review comments with severity labels. Use when a PR needs automated code review.
+user-invocable: false
+---
+
+# Code Review Playbook
+
+This skill provides a systematic approach to reviewing pull requests. It combines best practices from industry-standard code review methodologies.
+
+---
+
+## Philosophy
+
+- **Focus on code, not personality** — critique the code, not the author
+- **Be educational, not judgmental** — explain the "why" behind suggestions
+- **Prioritize by severity** — distinguish blocking issues from nice-to-haves
+- **Balance criticism with praise** — acknowledge good patterns
+
+---
+
+## Phase 1: Context Gathering (Quick)
+
+Before diving into the code, understand the PR's purpose and scope.
+
+### 1.1 Read PR Metadata
+
+Use GitHub MCP to fetch:
+- PR title and description
+- Linked issues or tickets
+- Labels and milestone
+- CI/CD status (if available)
+
+### 1.2 Understand the Scope
+
+- How many files changed?
+- What areas of the codebase are affected?
+- Is this a feature, bug fix, refactor, or docs update?
+
+### 1.3 Check for Repo-Specific Rules
+
+Look for custom review rules in the repository:
+- `.agent/skills/review/SKILL.md` — repo-specific review rules (**primary authority when present**)
+- `.agent/skills/review/CHECKLIST.md` — additional checks
+- `.agent/skills/review/EXAMPLES.md` — review style examples
+
+If found, these rules **take priority** over the general guidelines in this playbook.
+Load and incorporate those rules into your review. The repo-specific SKILL.md defines
+what matters most for that particular codebase — priority review areas, common pitfalls,
+conventions, and high-risk files.
+
+---
+
+## Phase 2: High-Level Review
+
+Assess the overall approach before examining individual lines.
+
+### 2.1 Architecture
+
+- Does this change fit the existing architecture?
+- Are new patterns introduced? If so, are they justified?
+- Does the change follow separation of concerns?
+
+### 2.2 File Organization
+
+- Are files in the right directories?
+- Are new files named consistently with existing conventions?
+- Is code split appropriately (not too large, not over-fragmented)?
+
+### 2.3 Testing Strategy
+
+- Are there tests for new functionality?
+- Do existing tests need updates?
+- Is the test coverage appropriate for the risk level?
+
+### 2.4 Documentation
+
+- Are public APIs documented?
+- Are complex algorithms explained?
+- Is the PR description clear enough for future reference?
+
+---
+
+## Phase 3: Line-by-Line Review
+
+Examine the actual code changes in detail.
+
+### 3.0 API Contract Changes (CHECK FIRST - MOST CRITICAL)
+
+**This is the #1 source of bugs in refactoring PRs.** Before anything else, check:
+
+- **Did any function/component signatures change?**
+  - Parameters added, removed, or reordered
+  - Return type changed
+  - Callback parameter types changed (e.g., `onChange(string)` → `onChange(event)`)
+
+- **For shared/common components:**
+  - Search for all consumers of the modified component
+  - Verify each consumer is compatible with the new API
+  - Check if `value` vs `defaultValue` handling changed
+  - Check if event handlers receive the same arguments
+
+**Example of a BLOCKING issue:**
+```javascript
+// OLD component API
+onChange(value) // value is a string
+
+// NEW component API
+onChange({ target: { value, name } }) // value is inside an object
+
+// This BREAKS all existing consumers that expect a string!
+```
+
+**When reviewing refactors, ASK:**
+- "How many places use this component/function?"
+- "Will the existing callers work with this change?"
+- "Is this a breaking change that needs a migration?"
+
+### 3.1 Correctness
+
+- Does the logic do what it's supposed to?
+- Are edge cases handled?
+- Are there off-by-one errors, null checks missing, or race conditions?
+
+### 3.2 Security (OWASP Top 10)
+
+- **Injection**: SQL, command, XSS vulnerabilities
+- **Authentication/Authorization**: Proper access controls
+- **Sensitive Data**: No secrets, tokens, or PII in code
+- **Input Validation**: All external input validated
+- **Error Handling**: No sensitive info in error messages
+
+### 3.3 Performance
+
+- Obvious N+1 queries or O(n²) loops?
+- Unnecessary re-renders (React)?
+- Large objects in memory?
+- Missing indexes for new queries?
+
+### 3.4 Maintainability
+
+- Is the code readable?
+- Are variable/function names descriptive?
+- Is there unnecessary complexity?
+- Are there magic numbers or strings that should be constants?
+
+### 3.5 Code Style
+
+- Does it match the repo's conventions?
+- Consistent indentation and formatting?
+- (Note: Defer pure style issues to linters when possible)
+
+### 3.6 API Handler Version Consistency
+
+When reviewing API handlers, check that all handler versions (V1, V2, etc.) have consistent validation guards (e.g., `BAD_REQUEST` for invalid input). Missing validation in one version while present in siblings is a common bug pattern.
+
+**What to check:**
+- If a V2 handler adds input validation (e.g., checking for empty/invalid request body), verify that the corresponding V1 handler also has equivalent validation
+- Look for patterns where newer handler versions add guards that older versions lack — this creates inconsistent behavior depending on which API version the client calls
+- Check that error responses (status codes, error messages) are consistent across versions for the same invalid input
+
+**Example of a BLOCKING issue:**
+```go
+// V2 handler has validation
+func HandleTriggerV2(ctx) {
+    if req.Body == nil || len(req.FlowIDs) == 0 {
+        return BadRequest("invalid request")
+    }
+    // ... process
+}
+
+// V1 handler is MISSING the same validation
+func HandleTrigger(ctx) {
+    // No validation — proceeds with nil body, causing downstream panic
+    // ... process
+}
+```
+
+### 3.7 React: Extract Object/Array Literals to Module-Level Constants
+
+When reviewing React code, flag object or array literals defined inside component bodies (e.g., default values, empty state objects, configuration objects) that should be extracted to module-level constants. Defining these inline causes:
+- **Unnecessary re-renders**: A new object/array reference is created on every render, defeating `React.memo`, `useMemo`, and shallow comparison optimizations
+- **Referential equality issues**: Passing inline objects as props to child components triggers re-renders even when the value hasn't logically changed
+
+**What to flag:**
+- Default prop values defined as inline literals: `const value = props.items || []`
+- Empty/static objects used as initial state: `useState({})`
+- Configuration objects that never change but are defined inside the component
+
+**Example:**
+```tsx
+// BAD — new array reference on every render
+function MyComponent({ items }) {
+  const data = items || [];
+  return <ChildComponent data={data} />;
+}
+
+// GOOD — stable reference
+const EMPTY_ITEMS = [];
+function MyComponent({ items }) {
+  const data = items || EMPTY_ITEMS;
+  return <ChildComponent data={data} />;
+}
+```
+
+### 3.8 React: Verify `isDisabled` Guard Prop Consumption
+
+When a component accepts an `isDisabled` (or similar guard/gating prop like `isReadOnly`, `isLocked`), verify that:
+- The prop is actually consumed in **all** interactive handlers (add, delete, duplicate, reorder, edit, etc.) — not just some of them
+- Interactive UI elements (buttons, popovers, dropdowns, drag handles) are also disabled or hidden when the prop is true
+- Early returns or conditional guards using the prop are present at the top of each handler
+
+This is a recurring pattern in campaign builder components where `isDisabled` is accepted but only partially enforced, allowing unintended edits in read-only states.
+
+**Example of a BLOCKING issue:**
+```tsx
+// Component accepts isDisabled but doesn't use it in the delete handler
+function StepList({ isDisabled, steps, onDelete }) {
+  const handleDelete = (id) => {
+    // BUG: no isDisabled check here!
+    onDelete(id);
+  };
+  return steps.map(s => (
+    <button onClick={() => handleDelete(s.id)}>Delete</button> // Still clickable!
+  ));
+}
+```
+
+### 3.9 GraphQL: Mutation Error Handling Pragmatism
+
+When reviewing GraphQL mutation error handling, apply pragmatic judgment:
+- `console.error` after `await` in mutations is **acceptable** for operator debuggability if the error only fires on server-side mutation failure and isn't visible to end users. Do not flag this as a blocking issue.
+- Descriptive error returns from mutations require resolver return type changes (e.g., adding an `errors` field to the mutation response type), which can be tracked as a follow-up improvement rather than blocking the PR.
+- Focus review energy on whether the mutation handles the **happy path correctly** and whether **user-facing error states** are handled (loading states, toast notifications, retry logic) rather than backend-only error logging patterns.
+
+### 3.10 Platform-Conditional UI: Visual Context Preservation
+
+When reviewing platform-conditional UI (e.g., toggling between Android/iOS previews, showing/hiding web-only features):
+- Hiding a toggle/selector when only one option is valid is **good UX** — do not flag this as an issue
+- However, check whether the user still needs **feedback about which option is active** when the selector is hidden. If a toggle is hidden because only "Android" applies, the user should still see somewhere that they're viewing the Android preview.
+- Verify that conditional rendering doesn't leave orphaned state (e.g., a hidden toggle still controlling which content renders, but no way for the user to change it back if the condition changes)
+
+---
+
+## Phase 4: Summary & Decision
+
+Consolidate your findings into a clear verdict.
+
+### 4.1 Overall Assessment
+
+Rate the PR:
+- ✅ **APPROVE** — Good to merge (may have minor nits)
+- 💬 **COMMENT** — Observations but no blockers
+- 🔄 **REQUEST_CHANGES** — Has blocking issues that must be addressed
+
+### 4.2 Summary Structure
+
+```markdown
+## Summary
+
+[1-3 sentence overview of what this PR does and your overall impression]
+
+## Review
+
+### 🔴 Blocking Issues
+- [Issue 1 — must fix]
+- [Issue 2 — must fix]
+
+### 🟡 Suggestions
+- [Suggestion 1 — should consider]
+- [Suggestion 2 — should consider]
+
+### 🟢 Nits
+- [Minor style/preference issues]
+
+### 🎉 What's Good
+- [Highlight positive patterns worth noting]
+
+<!-- loma-agent-review -->
+```
+
+---
+
+## Severity Labels
+
+Use these consistently in inline comments:
+
+| Label | Meaning | Action |
+|-------|---------|--------|
+| 🔴 **BLOCKING** | Must fix before merge | `REQUEST_CHANGES` |
+| 🟡 **SUGGESTION** | Should strongly consider | `COMMENT` |
+| 🟢 **NIT** | Minor preference/style | `COMMENT` |
+| 💡 **TIP** | Learning opportunity | `COMMENT` |
+| 🎉 **PRAISE** | Highlight good code | `COMMENT` |
+
+---
+
+## Inline Comment Format
+
+When leaving inline comments on specific lines:
+
+```
+🟡 **SUGGESTION**: Consider using `useMemo` here to avoid recalculating on every render.
+
+The current implementation recalculates `expensiveValue` on every render, which could impact performance as the list grows.
+
+**Suggested fix:**
+\`\`\`tsx
+const expensiveValue = useMemo(() => calculateExpensive(items), [items]);
+\`\`\`
+```
+
+---
+
+## What NOT to Comment On
+
+Delegate these to automated tools (linters, formatters):
+- Import ordering
+- Trailing whitespace
+- Semicolons vs no semicolons
+- Tabs vs spaces
+- Line length (unless egregious)
+
+Only comment on style if the repo has no linter configured.
+
+---
+
+## Language-Specific Patterns
+
+### TypeScript/JavaScript
+
+- Prefer `const` over `let`
+- Use TypeScript types (avoid `any`)
+- Handle Promise rejections
+- Avoid console.log in production code
+
+### React
+
+- Check for missing dependency arrays in hooks — but **VERIFY before flagging**: before claiming a variable is missing from a `useEffect`/`useCallback`/`useMemo` dependency array, READ the actual code at the referenced line to confirm the variable is genuinely absent. False positives (flagging a dep that is already present) erode trust in the review.
+- When reviewing `useEffect`/`useCallback` with intentionally omitted dependencies (to avoid infinite loops), do NOT just flag the omission — suggest concrete alternatives: extract the callback to a `useRef`, use the functional updater pattern for state, or extract the logic into a custom hook. Simply saying "add X to deps" when it would cause an infinite re-render loop is unhelpful.
+- Ensure keys are stable (not array indices for dynamic lists)
+- Look for unnecessary re-renders
+- Verify proper cleanup in useEffect
+
+### Go
+
+- Check error handling (no ignored errors)
+- Look for goroutine leaks
+- Verify proper context propagation
+- Check for race conditions in concurrent code
+
+### Python
+
+- Check for proper exception handling
+- Look for resource leaks (files, connections)
+- Verify type hints on public functions
+- Check for mutable default arguments
+
+---
+
+## GitHub MCP Tools Reference
+
+### Fetching PR Data
+
+```
+mcp__github__get_pull_request
+  - owner: "<owner>"
+  - repo: "<repo-name>"
+  - pull_number: <number>
+
+mcp__github__get_pull_request_diff
+  - owner: "<owner>"
+  - repo: "<repo-name>"
+  - pull_number: <number>
+
+mcp__github__list_pull_request_files
+  - owner: "<owner>"
+  - repo: "<repo-name>"
+  - pull_number: <number>
+```
+
+### Posting Review
+
+```
+mcp__github__create_pull_request_review
+  - owner: "<owner>"
+  - repo: "<repo-name>"
+  - pull_number: <number>
+  - event: "APPROVE" | "COMMENT" | "REQUEST_CHANGES"
+  - body: "Overall review summary"
+  - comments: [
+      {
+        "path": "src/file.ts",
+        "line": 42,
+        "body": "🟡 **SUGGESTION**: ..."
+      }
+    ]
+```
+
+**CRITICAL: Inline comments must be submitted WITH the review.** When submitting a PR review with inline comments, always include all inline comments in the SAME API call that creates the review. Do NOT submit the review first and then try to add inline comments afterward — once a review is submitted (not pending), GitHub's API does not allow attaching inline comments to that review. Collect all comments first, then submit them together in a single `create_review` call using the `comments` parameter.
+
+### Fetching File Contents (for context)
+
+```
+mcp__github__get_file_contents
+  - owner: "<owner>"
+  - repo: "<repo-name>"
+  - path: "src/file.ts"
+  - branch: "<head-branch>"
+```
+
+---
+
+## Review Style Guidelines
+
+Based on real review examples from senior reviewers, follow these patterns:
+
+### Be Concise for Obvious Issues
+
+```
+Wrap in useMemo
+```
+
+```
+use apiVars constants here - FLOW_TYPE_MILESTONE etc
+```
+
+### Explain Consequences for Non-Obvious Issues
+
+```
+Do this for grouped widgets alone. Otherwise it might lead to some save
+loop on all flow previews
+```
+
+```
+Call this in FlowBuilder and pass allWidgets in context or as props. Otherwise
+this GQL happens every time this component re-renders
+```
+
+### Suggest Architectural Alternatives
+
+```
+Just store `isGroupable` at the step level after creating from a template
+instead of doing all this across multiple files just to see if a widget
+needs to be allowed in grouping
+```
+
+```
+All this extra prop drilling for stepTemplates is avoidable. Add a nullable
+field in step typedef called `isGroupable`
+```
+
+### Ask Clarifying Questions
+
+```
+why are we not using the step level flag here?
+```
+
+```
+Do we need preloadAspectRatio for streaks/milestones?
+```
+
+```
+In which case will this isGroupable variable change from a user edit?
+Can remove this from editStep if no such case exists
+```
+
+### Reference Existing Patterns
+
+```
+If `stepTemplates` is being added to flow builder context already, then avoid
+passing it as prop to FlowLocation/FlowStyling. Fetch it from the context itself
+```
+
+```
+No need to pass productId as prop, just use the useSelector in the child
+component to get selectedProduct.id
+```
+
+---
+
+## Loading Repo-Specific Examples
+
+When reviewing a PR, also check for:
+- `.agent/skills/review/EXAMPLES.md` — real review examples showing expected style
+
+If found, study the examples to match the review tone and focus areas.
+
+---
+
+## Guardrails
+
+- **Never approve without reading** — Always review the actual changes
+- **Don't nitpick excessively** — Focus on what matters
+- **Be constructive** — Every criticism should come with a suggestion
+- **Acknowledge uncertainty** — If unsure, say so rather than guessing
+- **Respect author's time** — Group related comments, don't spam notifications
+- **Ask questions** — When reasoning isn't clear, ask "why" instead of assuming
+- **Loop prevention** — Always include `<!-- loma-agent-review -->` marker in review body
+- **Cross-repo PR porting** — When asked to make one PR match another PR across different repositories, NEVER assume the two repos have identical base states on main. Always compare the `main` branch of BOTH repos first. Replicate the INTENT of the source PR (what it changes relative to its own main), not the literal file contents.
+- **Cross-repo PR comparison** — When comparing changes across two PRs in different repositories, NEVER conclude they are 'identical' after a single pass. Perform a file-by-file diff comparison. Account for different main baselines — the same logical change will produce different raw diffs when starting points differ.

--- a/seed/skills/diagrams/SKILL.md
+++ b/seed/skills/diagrams/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: diagrams
+description: Generate visual diagrams (flowcharts, architecture, sequence) as PNG/SVG via Mermaid.js, upload to Google Drive, and embed in Google Docs — use when a user asks for a diagram, flowchart, architecture visualization, or visual representation of a flow
+user-invocable: false
+---
+
+# Diagram Generation
+
+Generate visual diagrams from Mermaid.js syntax, render them as PNG/SVG images via the mermaid.ink API, upload to Google Drive, and optionally embed them in Google Docs.
+
+**Tool**: `tools/diagrams.py` — Python CLI called via Bash
+**Rendering**: [mermaid.ink](https://mermaid.ink) public API (no API key required)
+**Auth**: Google Drive/Docs operations require `--user-email` and `--auth-token` (user's personal Google OAuth)
+
+---
+
+## When to Use
+
+- User asks for a diagram, flowchart, or architecture visualization
+- User asks to visualize a process, flow, or system design
+- User asks for a sequence diagram, state diagram, or ER diagram
+- User wants a visual added to a Google Doc or slide deck
+- User asks you to "draw" or "create a visual" of something
+
+---
+
+## Commands
+
+### Render a Diagram
+
+Writes Mermaid code to a temp file, then pipes it to the render command:
+
+```bash
+cat <<'MERMAID' > /tmp/diagram.mmd
+graph LR
+    A[Start] --> B[Process]
+    B --> C{Decision}
+    C -->|Yes| D[Action A]
+    C -->|No| E[Action B]
+MERMAID
+python3 tools/diagrams.py render --output /tmp/diagram.png --type png < /tmp/diagram.mmd
+```
+
+**Flags:**
+- `--output PATH` — Output file path (default: `/tmp/diagram.png`)
+- `--type png|svg|jpeg|webp` — Image format (default: `png`)
+- `--theme default|neutral|dark|forest` — Mermaid theme (default: `default`)
+- `--width N` — Width in pixels (optional, sets rendered image width)
+- `--height N` — Height in pixels (optional)
+- `--scale N` — Scale multiplier 1-3 (requires width or height)
+- `--bg-color HEX` — Background color as hex without `#` (e.g., `FFFFFF` for white, default: transparent)
+
+**Response:**
+```json
+{"success": true, "output": "/tmp/diagram.png", "size_bytes": 43642, "type": "png"}
+```
+
+**IMPORTANT:** The `render` command reads Mermaid code from **stdin**. Always use file redirect (`< /tmp/diagram.mmd`) rather than inline piping with `echo` or `printf` for multi-line diagrams, because shell piping can silently drop content.
+
+### Upload to Google Drive
+
+```bash
+python3 tools/diagrams.py upload --file /tmp/diagram.png --name "Architecture Diagram.png" --user-email EMAIL --auth-token TOKEN
+```
+
+**Flags:**
+- `--file PATH` — Path to the rendered image file
+- `--name NAME` — Display name on Google Drive
+- `--user-email EMAIL` — User's email (from auth context)
+- `--auth-token TOKEN` — User's auth token (from auth context)
+
+**Response:**
+```json
+{
+  "success": true,
+  "file_id": "1abc...",
+  "name": "Architecture Diagram.png",
+  "web_view_link": "https://drive.google.com/file/d/1abc.../view",
+  "embed_url": "https://lh3.googleusercontent.com/d/1abc..."
+}
+```
+
+The file is automatically made publicly readable so it can be embedded in Google Docs.
+
+### Embed in Google Doc
+
+```bash
+python3 tools/diagrams.py embed \
+  --doc-id DOC_ID \
+  --image-id DRIVE_FILE_ID \
+  --replace-start "HEADING_BEFORE_DIAGRAM" \
+  --replace-end "HEADING_AFTER_DIAGRAM" \
+  --width 500 --height 250 \
+  --user-email EMAIL --auth-token TOKEN
+```
+
+**Flags:**
+- `--doc-id` — Google Doc document ID
+- `--image-id` — Google Drive file ID of the uploaded image
+- `--replace-start` — Text marker indicating the start of the area to replace (content AFTER this marker is deleted)
+- `--replace-end` — Text marker indicating the end of the area to replace (content BEFORE this marker is deleted)
+- `--width` — Image width in points (default: 500)
+- `--height` — Image height in points (default: 250)
+- `--user-email` / `--auth-token` — Auth context
+
+**Response:**
+```json
+{"success": true, "doc_id": "...", "image_embedded": true, "replaced_range": "337-4100"}
+```
+
+---
+
+## Common Workflows
+
+> **Preview-first delivery**: When generating diagrams, always emit the Mermaid code as an inline code block FIRST — the chat UI renders Mermaid diagrams as interactive SVGs in the right-side preview panel. Then render a PNG and upload to Google Drive as a persistent backup.
+
+### Create a Diagram (Primary Workflow)
+
+1. Write the Mermaid code and **emit it as an inline mermaid code block** in the chat response — this gives the user an instant interactive preview in the right-side panel.
+2. Also write the Mermaid code to a temp file and render a PNG: `python3 tools/diagrams.py render --output /tmp/diagram.png --type png --width 1200 < /tmp/diagram.mmd`
+3. Upload the PNG to Google Drive: `python3 tools/diagrams.py upload --file /tmp/diagram.png --name "Diagram Name.png" --user-email EMAIL --auth-token TOKEN`
+4. Share both the inline preview (already visible) and the Drive link for persistence/sharing
+
+**Never skip the inline Mermaid preview** by jumping straight to a Google Drive PNG link. The user should see the diagram rendered in-chat first.
+
+### Create a Diagram and Share as Drive Link (Legacy/Fallback)
+
+Use this workflow only when the Mermaid diagram is too complex for inline rendering or the user specifically asks for a PNG/image file:
+
+1. Write Mermaid code to a temp file based on the user's request
+2. Render: `python3 tools/diagrams.py render --output /tmp/diagram.png --type png --width 1200 < /tmp/diagram.mmd`
+3. Upload: `python3 tools/diagrams.py upload --file /tmp/diagram.png --name "Diagram Name.png" --user-email EMAIL --auth-token TOKEN`
+4. Share the `web_view_link` with the user
+
+### Create a Diagram and Embed in a Google Doc
+
+1. Write Mermaid code to a temp file
+2. Render as PNG with appropriate width (1200px works well for docs)
+3. Upload to Drive
+4. Use the `embed` command to insert the image between two section headings in the doc
+5. The content between the two markers is replaced with the image
+
+### Choosing the Right Diagram Type
+
+| Use Case | Mermaid Syntax | Best Theme |
+|----------|---------------|------------|
+| Architecture / system design | `graph LR` or `graph TD` with subgraphs | `default` or `neutral` |
+| API / integration flow | `sequenceDiagram` | `default` |
+| Decision tree / logic flow | `graph TD` with `{Decision}` nodes | `neutral` |
+| State machine | `stateDiagram-v2` | `default` |
+| Database / ER diagram | `erDiagram` | `neutral` |
+| Timeline | `timeline` | `default` |
+| User journey | `journey` | `default` |
+
+### Mermaid Tips for Better Diagrams
+
+- Use `subgraph` to group related nodes visually
+- Add descriptive labels on edges: `A -->|label| B`
+- Use different node shapes: `[rectangle]`, `(rounded)`, `{diamond}`, `([stadium])`, `[[subroutine]]`, `((circle))`
+- For architecture diagrams, prefer `graph LR` (left-to-right) for horizontal flows
+- For process flows, prefer `graph TD` (top-down)
+- Set `--width 1200` for diagrams that will be embedded in documents
+- Use `--bg-color FFFFFF` (white background) when embedding in documents for clean appearance
+- Use `--theme neutral` for professional/business diagrams
+
+---
+
+## Error Handling
+
+- **400 (Mermaid syntax error)**: The diagram code has invalid Mermaid syntax. Check for missing arrows, unclosed brackets, or unsupported syntax.
+- **431 (Header too large)**: Diagram is very large. The tool automatically falls back to base64 encoding.
+- **503 (Rendering timeout)**: mermaid.ink took too long. Simplify the diagram.
+- **Auth errors**: User needs to connect Google account at the Integrations page.
+
+---
+
+## Safety / Guardrails
+
+- The `render` command does NOT require auth (uses free public mermaid.ink API)
+- The `upload` and `embed` commands require user auth tokens
+- Uploaded files are made publicly readable (anyone with link) so Google Docs can embed them
+- Always use descriptive file names when uploading to Drive
+- For the `embed` command, double-check marker text exists in the doc before running

--- a/seed/skills/doc-coauthoring/SKILL.md
+++ b/seed/skills/doc-coauthoring/SKILL.md
@@ -1,0 +1,376 @@
+---
+name: doc-coauthoring
+description: Guide users through a structured workflow for co-authoring documentation. Use when user wants to write documentation, proposals, technical specs, decision docs, or similar structured content. This workflow helps users efficiently transfer context, refine content through iteration, and verify the doc works for readers. Trigger when user mentions writing docs, creating proposals, drafting specs, or similar documentation tasks.
+user-invocable: false
+---
+
+# Doc Co-Authoring Workflow
+
+This skill provides a structured workflow for guiding users through collaborative document creation. Act as an active guide, walking users through three stages: Context Gathering, Refinement & Structure, and Reader Testing.
+
+## When to Offer This Workflow
+
+**Trigger conditions:**
+- User mentions writing documentation: "write a doc", "draft a proposal", "create a spec", "write up"
+- User mentions specific doc types: "PRD", "design doc", "decision doc", "RFC"
+- User seems to be starting a substantial writing task
+
+**Initial offer:**
+Offer the user a structured workflow for co-authoring the document. Explain the three stages:
+
+1. **Context Gathering**: User provides all relevant context while Claude asks clarifying questions
+2. **Refinement & Structure**: Iteratively build each section through brainstorming and editing
+3. **Reader Testing**: Test the doc with a fresh Claude (no context) to catch blind spots before others read it
+
+Explain that this approach helps ensure the doc works well when others read it (including when they paste it into Claude). Ask if they want to try this workflow or prefer to work freeform.
+
+If user declines, work freeform. If user accepts, proceed to Stage 1.
+
+## Stage 1: Context Gathering
+
+**Goal:** Close the gap between what the user knows and what Claude knows, enabling smart guidance later.
+
+### Initial Questions
+
+Start by asking the user for meta-context about the document:
+
+1. What type of document is this? (e.g., technical spec, decision doc, proposal)
+2. Who's the primary audience?
+3. What's the desired impact when someone reads this?
+4. Is there a template or specific format to follow?
+5. Any other constraints or context to know?
+
+Inform them they can answer in shorthand or dump information however works best for them.
+
+**If user provides a template or mentions a doc type:**
+- Ask if they have a template document to share
+- If they provide a link to a shared document, use the appropriate integration to fetch it
+- If they provide a file, read it
+
+**If user mentions editing an existing shared document:**
+- Use the appropriate integration to read the current state
+- Check for images without alt-text
+- If images exist without alt-text, explain that when others use Claude to understand the doc, Claude won't be able to see them. Ask if they want alt-text generated. If so, request they paste each image into chat for descriptive alt-text generation.
+
+### Info Dumping
+
+Once initial questions are answered, encourage the user to dump all the context they have. Request information such as:
+- Background on the project/problem
+- Related team discussions or shared documents
+- Why alternative solutions aren't being used
+- Organizational context (team dynamics, past incidents, politics)
+- Timeline pressures or constraints
+- Technical architecture or dependencies
+- Stakeholder concerns
+
+Advise them not to worry about organizing it - just get it all out. Offer multiple ways to provide context:
+- Info dump stream-of-consciousness
+- Point to team channels or threads to read
+- Link to shared documents
+
+**If integrations are available** (e.g., Slack, Teams, Google Drive, SharePoint, or other MCP servers), mention that these can be used to pull in context directly.
+
+**If no integrations are detected and in Claude.ai or Claude app:** Suggest they can enable connectors in their Claude settings to allow pulling context from messaging apps and document storage directly.
+
+Inform them clarifying questions will be asked once they've done their initial dump.
+
+**During context gathering:**
+
+- If user mentions team channels or shared documents:
+  - If integrations available: Inform them the content will be read now, then use the appropriate integration
+  - If integrations not available: Explain lack of access. Suggest they enable connectors in Claude settings, or paste the relevant content directly.
+
+- If user mentions entities/projects that are unknown:
+  - Ask if connected tools should be searched to learn more
+  - Wait for user confirmation before searching
+
+- As user provides context, track what's being learned and what's still unclear
+
+**Asking clarifying questions:**
+
+When user signals they've done their initial dump (or after substantial context provided), ask clarifying questions to ensure understanding:
+
+Generate 5-10 numbered questions based on gaps in the context.
+
+Inform them they can use shorthand to answer (e.g., "1: yes, 2: see #channel, 3: no because backwards compat"), link to more docs, point to channels to read, or just keep info-dumping. Whatever's most efficient for them.
+
+**Exit condition:**
+Sufficient context has been gathered when questions show understanding - when edge cases and trade-offs can be asked about without needing basics explained.
+
+**Transition:**
+Ask if there's any more context they want to provide at this stage, or if it's time to move on to drafting the document.
+
+If user wants to add more, let them. When ready, proceed to Stage 2.
+
+## Stage 2: Refinement & Structure
+
+**Goal:** Build the document section by section through brainstorming, curation, and iterative refinement.
+
+**Instructions to user:**
+Explain that the document will be built section by section. For each section:
+1. Clarifying questions will be asked about what to include
+2. 5-20 options will be brainstormed
+3. User will indicate what to keep/remove/combine
+4. The section will be drafted
+5. It will be refined through surgical edits
+
+Start with whichever section has the most unknowns (usually the core decision/proposal), then work through the rest.
+
+**Section ordering:**
+
+If the document structure is clear:
+Ask which section they'd like to start with.
+
+Suggest starting with whichever section has the most unknowns. For decision docs, that's usually the core proposal. For specs, it's typically the technical approach. Summary sections are best left for last.
+
+If user doesn't know what sections they need:
+Based on the type of document and template, suggest 3-5 sections appropriate for the doc type.
+
+Ask if this structure works, or if they want to adjust it.
+
+**Once structure is agreed:**
+
+Create the initial document structure with placeholder text for all sections.
+
+**If access to artifacts is available:**
+Use `create_file` to create an artifact. This gives both Claude and the user a scaffold to work from.
+
+Inform them that the initial structure with placeholders for all sections will be created.
+
+Create artifact with all section headers and brief placeholder text like "[To be written]" or "[Content here]".
+
+Provide the scaffold link and indicate it's time to fill in each section.
+
+**If no access to artifacts:**
+Create a markdown file in the working directory. Name it appropriately (e.g., `decision-doc.md`, `technical-spec.md`).
+
+Inform them that the initial structure with placeholders for all sections will be created.
+
+Create file with all section headers and placeholder text.
+
+Confirm the filename has been created and indicate it's time to fill in each section.
+
+**For each section:**
+
+### Step 1: Clarifying Questions
+
+Announce work will begin on the [SECTION NAME] section. Ask 5-10 clarifying questions about what should be included:
+
+Generate 5-10 specific questions based on context and section purpose.
+
+Inform them they can answer in shorthand or just indicate what's important to cover.
+
+### Step 2: Brainstorming
+
+For the [SECTION NAME] section, brainstorm [5-20] things that might be included, depending on the section's complexity. Look for:
+- Context shared that might have been forgotten
+- Angles or considerations not yet mentioned
+
+Generate 5-20 numbered options based on section complexity. At the end, offer to brainstorm more if they want additional options.
+
+### Step 3: Curation
+
+Ask which points should be kept, removed, or combined. Request brief justifications to help learn priorities for the next sections.
+
+Provide examples:
+- "Keep 1,4,7,9"
+- "Remove 3 (duplicates 1)"
+- "Remove 6 (audience already knows this)"
+- "Combine 11 and 12"
+
+**If user gives freeform feedback** (e.g., "looks good" or "I like most of it but...") instead of numbered selections, extract their preferences and proceed. Parse what they want kept/removed/changed and apply it.
+
+### Step 4: Gap Check
+
+Based on what they've selected, ask if there's anything important missing for the [SECTION NAME] section.
+
+### Step 5: Drafting
+
+Use `str_replace` to replace the placeholder text for this section with the actual drafted content.
+
+Announce the [SECTION NAME] section will be drafted now based on what they've selected.
+
+**If using artifacts:**
+After drafting, provide a link to the artifact.
+
+Ask them to read through it and indicate what to change. Note that being specific helps learning for the next sections.
+
+**If using a file (no artifacts):**
+After drafting, confirm completion.
+
+Inform them the [SECTION NAME] section has been drafted in [filename]. Ask them to read through it and indicate what to change. Note that being specific helps learning for the next sections.
+
+**Key instruction for user (include when drafting the first section):**
+Provide a note: Instead of editing the doc directly, ask them to indicate what to change. This helps learning of their style for future sections. For example: "Remove the X bullet - already covered by Y" or "Make the third paragraph more concise".
+
+### Step 6: Iterative Refinement
+
+As user provides feedback:
+- Use `str_replace` to make edits (never reprint the whole doc)
+- **If using artifacts:** Provide link to artifact after each edit
+- **If using files:** Just confirm edits are complete
+- If user edits doc directly and asks to read it: mentally note the changes they made and keep them in mind for future sections (this shows their preferences)
+
+**Continue iterating** until user is satisfied with the section.
+
+### Quality Checking
+
+After 3 consecutive iterations with no substantial changes, ask if anything can be removed without losing important information.
+
+When section is done, confirm [SECTION NAME] is complete. Ask if ready to move to the next section.
+
+**Repeat for all sections.**
+
+### Near Completion
+
+As approaching completion (80%+ of sections done), announce intention to re-read the entire document and check for:
+- Flow and consistency across sections
+- Redundancy or contradictions
+- Anything that feels like "slop" or generic filler
+- Whether every sentence carries weight
+
+Read entire document and provide feedback.
+
+**When all sections are drafted and refined:**
+Announce all sections are drafted. Indicate intention to review the complete document one more time.
+
+Review for overall coherence, flow, completeness.
+
+Provide any final suggestions.
+
+Ask if ready to move to Reader Testing, or if they want to refine anything else.
+
+## Stage 3: Reader Testing
+
+**Goal:** Test the document with a fresh Claude (no context bleed) to verify it works for readers.
+
+**Instructions to user:**
+Explain that testing will now occur to see if the document actually works for readers. This catches blind spots - things that make sense to the authors but might confuse others.
+
+### Testing Approach
+
+**If access to sub-agents is available (e.g., in Claude Code):**
+
+Perform the testing directly without user involvement.
+
+### Step 1: Predict Reader Questions
+
+Announce intention to predict what questions readers might ask when trying to discover this document.
+
+Generate 5-10 questions that readers would realistically ask.
+
+### Step 2: Test with Sub-Agent
+
+Announce that these questions will be tested with a fresh Claude instance (no context from this conversation).
+
+For each question, invoke a sub-agent with just the document content and the question.
+
+Summarize what Reader Claude got right/wrong for each question.
+
+### Step 3: Run Additional Checks
+
+Announce additional checks will be performed.
+
+Invoke sub-agent to check for ambiguity, false assumptions, contradictions.
+
+Summarize any issues found.
+
+### Step 4: Report and Fix
+
+If issues found:
+Report that Reader Claude struggled with specific issues.
+
+List the specific issues.
+
+Indicate intention to fix these gaps.
+
+Loop back to refinement for problematic sections.
+
+---
+
+**If no access to sub-agents (e.g., claude.ai web interface):**
+
+The user will need to do the testing manually.
+
+### Step 1: Predict Reader Questions
+
+Ask what questions people might ask when trying to discover this document. What would they type into Claude.ai?
+
+Generate 5-10 questions that readers would realistically ask.
+
+### Step 2: Setup Testing
+
+Provide testing instructions:
+1. Open a fresh Claude conversation: https://claude.ai
+2. Paste or share the document content (if using a shared doc platform with connectors enabled, provide the link)
+3. Ask Reader Claude the generated questions
+
+For each question, instruct Reader Claude to provide:
+- The answer
+- Whether anything was ambiguous or unclear
+- What knowledge/context the doc assumes is already known
+
+Check if Reader Claude gives correct answers or misinterprets anything.
+
+### Step 3: Additional Checks
+
+Also ask Reader Claude:
+- "What in this doc might be ambiguous or unclear to readers?"
+- "What knowledge or context does this doc assume readers already have?"
+- "Are there any internal contradictions or inconsistencies?"
+
+### Step 4: Iterate Based on Results
+
+Ask what Reader Claude got wrong or struggled with. Indicate intention to fix those gaps.
+
+Loop back to refinement for any problematic sections.
+
+---
+
+### Exit Condition (Both Approaches)
+
+When Reader Claude consistently answers questions correctly and doesn't surface new gaps or ambiguities, the doc is ready.
+
+## Final Review
+
+When Reader Testing passes:
+Announce the doc has passed Reader Claude testing. Before completion:
+
+1. Recommend they do a final read-through themselves - they own this document and are responsible for its quality
+2. Suggest double-checking any facts, links, or technical details
+3. Ask them to verify it achieves the impact they wanted
+
+Ask if they want one more review, or if the work is done.
+
+**If user wants final review, provide it. Otherwise:**
+Announce document completion. Provide a few final tips:
+- Consider linking this conversation in an appendix so readers can see how the doc was developed
+- Use appendices to provide depth without bloating the main doc
+- Update the doc as feedback is received from real readers
+
+## Tips for Effective Guidance
+
+**Tone:**
+- Be direct and procedural
+- Explain rationale briefly when it affects user behavior
+- Don't try to "sell" the approach - just execute it
+
+**Handling Deviations:**
+- If user wants to skip a stage: Ask if they want to skip this and write freeform
+- If user seems frustrated: Acknowledge this is taking longer than expected. Suggest ways to move faster
+- Always give user agency to adjust the process
+
+**Context Management:**
+- Throughout, if context is missing on something mentioned, proactively ask
+- Don't let gaps accumulate - address them as they come up
+
+**Artifact Management:**
+- Use `create_file` for drafting full sections
+- Use `str_replace` for all edits
+- Provide artifact link after every change
+- Never use artifacts for brainstorming lists - that's just conversation
+
+**Quality over Speed:**
+- Don't rush through stages
+- Each iteration should make meaningful improvements
+- The goal is a document that actually works for readers

--- a/seed/skills/frontend-design/SKILL.md
+++ b/seed/skills/frontend-design/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: frontend-design
+description: Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.
+user-invocable: false
+---
+
+This skill guides creation of distinctive, production-grade frontend interfaces that avoid generic "AI slop" aesthetics. Implement real working code with exceptional attention to aesthetic details and creative choices.
+
+The user provides frontend requirements: a component, page, application, or interface to build. They may include context about the purpose, audience, or technical constraints.
+
+## Design Thinking
+
+Before coding, understand the context and commit to a BOLD aesthetic direction:
+- **Purpose**: What problem does this interface solve? Who uses it?
+- **Tone**: Pick an extreme: brutally minimal, maximalist chaos, retro-futuristic, organic/natural, luxury/refined, playful/toy-like, editorial/magazine, brutalist/raw, art deco/geometric, soft/pastel, industrial/utilitarian, etc. There are so many flavors to choose from. Use these for inspiration but design one that is true to the aesthetic direction.
+- **Constraints**: Technical requirements (framework, performance, accessibility).
+- **Differentiation**: What makes this UNFORGETTABLE? What's the one thing someone will remember?
+
+**CRITICAL**: Choose a clear conceptual direction and execute it with precision. Bold maximalism and refined minimalism both work - the key is intentionality, not intensity.
+
+Then implement working code (HTML/CSS/JS, React, Vue, etc.) that is:
+- Production-grade and functional
+- Visually striking and memorable
+- Cohesive with a clear aesthetic point-of-view
+- Meticulously refined in every detail
+
+## Frontend Aesthetics Guidelines
+
+Focus on:
+- **Typography**: Choose fonts that are beautiful, unique, and interesting. Avoid generic fonts like Arial and Inter; opt instead for distinctive choices that elevate the frontend's aesthetics; unexpected, characterful font choices. Pair a distinctive display font with a refined body font.
+- **Color & Theme**: Commit to a cohesive aesthetic. Use CSS variables for consistency. Dominant colors with sharp accents outperform timid, evenly-distributed palettes.
+- **Motion**: Use animations for effects and micro-interactions. Prioritize CSS-only solutions for HTML. Use Motion library for React when available. Focus on high-impact moments: one well-orchestrated page load with staggered reveals (animation-delay) creates more delight than scattered micro-interactions. Use scroll-triggering and hover states that surprise.
+- **Spatial Composition**: Unexpected layouts. Asymmetry. Overlap. Diagonal flow. Grid-breaking elements. Generous negative space OR controlled density.
+- **Backgrounds & Visual Details**: Create atmosphere and depth rather than defaulting to solid colors. Add contextual effects and textures that match the overall aesthetic. Apply creative forms like gradient meshes, noise textures, geometric patterns, layered transparencies, dramatic shadows, decorative borders, custom cursors, and grain overlays.
+
+NEVER use generic AI-generated aesthetics like overused font families (Inter, Roboto, Arial, system fonts), cliched color schemes (particularly purple gradients on white backgrounds), predictable layouts and component patterns, and cookie-cutter design that lacks context-specific character.
+
+Interpret creatively and make unexpected choices that feel genuinely designed for the context. No design should be the same. Vary between light and dark themes, different fonts, different aesthetics. NEVER converge on common choices (Space Grotesk, for example) across generations.
+
+**IMPORTANT**: Match implementation complexity to the aesthetic vision. Maximalist designs need elaborate code with extensive animations and effects. Minimalist or refined designs need restraint, precision, and careful attention to spacing, typography, and subtle details. Elegance comes from executing the vision well.
+
+Remember: Claude is capable of extraordinary creative work. Don't hold back, show what can truly be created when thinking outside the box and committing fully to a distinctive vision.

--- a/seed/skills/implement-ticket/SKILL.md
+++ b/seed/skills/implement-ticket/SKILL.md
@@ -1,0 +1,382 @@
+---
+name: implement-ticket
+description: Implement a Linear ticket — read the ticket, plan code changes, create a branch, push code, and open a draft PR on GitHub. Use when someone shares a Linear ticket and asks you to implement it.
+user-invocable: false
+---
+
+# Implement Linear Ticket Playbook
+
+When someone shares a Linear ticket (URL or ID) and asks you to implement it, follow this workflow.
+
+---
+
+## Tool Usage Rules (MANDATORY)
+
+### BANNED tools after cloning
+
+Once a repo is cloned to `/tmp/<repo-name>-<ticket-id>`, the following tools are **BANNED for the rest of the session**:
+
+Only use GitHub MCP tools for operations that CANNOT be done locally:
+- `mcp__github__create_branch` — only if not using local `git checkout -b`
+
+| Banned Tool | Use Instead |
+|---|---|
+| `mcp__github__get_file_contents` | `Read` tool on `/tmp/<repo-name>-<ticket-id>/...` |
+| `mcp__github__search_code` | `Grep` tool on `/tmp/<repo-name>-<ticket-id>/...` |
+
+**Zero tolerance** — every call to a banned tool after cloning is a bug. There are no exceptions.
+
+**This ban applies to subagents too.** When spawning Agent/Task subagents for code exploration, instruct them to use `Read`/`Grep`/`Glob` on the local clone path — NOT GitHub MCP tools.
+
+### Allowed GitHub MCP tools (non-file operations only)
+- `mcp__github__get_label` / `mcp__github__issue_write` — label management
+- `mcp__github__search_code` — **ONLY in Step 0** (before cloning, for duplicate PR checks)
+- `mcp__github__update_pull_request` — updating PR descriptions
+
+> **PR creation**: Use `gh pr create` via Bash with a HEREDOC (NOT `mcp__github__create_pull_request`). The MCP tool double-escapes newlines in the body parameter, causing broken formatting on GitHub.
+
+---
+
+## Step 0: Check for Existing PRs and Duplicates
+
+Before starting implementation, always check for existing PRs and duplicate/related tickets:
+
+1. **Search GitHub for existing PRs**: Search for the ticket ID in branch names and PR titles to check if a PR already exists.
+2. **Check Linear for related/duplicate tickets**: Search for similar titles or linked issues that may already have been implemented.
+3. **If a PR already exists**: Report the existing PR and ask whether to update it or if the ticket is a duplicate. Even when a ticket is a duplicate with an existing PR, still post any requested comments on the ORIGINAL ticket that was specified — follow the user's instructions precisely regarding which ticket to comment on, regardless of duplicate status.
+
+---
+
+## Step 1: Read the Linear Ticket
+
+Use **Linear MCP** tools to fetch the issue. Extract:
+- **Title** and **description** (the requirements)
+- **Acceptance criteria** (if listed)
+- **Labels** and **team** (helps identify which area of the codebase)
+- **Priority** (helps decide how thorough to be)
+- **Comments** (may contain additional context or decisions)
+
+If the ticket is vague or lacks enough detail to implement, say so and ask for clarification before proceeding.
+
+---
+
+## Step 2: Identify the Affected Repo(s)
+
+Determine the target repository from the available context, in this order:
+
+1. **The ticket itself** — a linked repo, a branch reference, file paths, or component names mentioned in the description, labels, or comments often point directly at the repo.
+2. **The conversation** — the user may name the repo explicitly, or the thread may already reference one.
+3. **A user-provided or configured repo** — if your environment defines a default repo (or a mapping of teams/areas to repos), use it. If a project-specific skill or doc maps feature areas to repositories, load it and follow that mapping.
+
+If you maintain such a mapping, keep it obviously illustrative, e.g.:
+- Frontend / web UI → your web app repo
+- Backend API / business logic → your server repo
+- Client SDKs → your SDK repo
+
+Do **not** assume a fixed monorepo layout. Inspect the cloned repo (Step 3) to learn its actual structure rather than relying on a hardcoded directory map.
+
+If you cannot confidently determine the target repo from any of the above, ask the user which repository to work in before proceeding.
+
+**Important**: If the ticket requires changes across multiple *separate* repos, create separate PRs for each repo. If the scope is too large (major refactor, many repos), say so and suggest breaking the ticket into smaller tasks.
+
+---
+
+## Step 3: Clone the Repo Locally & Understand the Code
+
+Clone the target repo to `/tmp` for local exploration and code changes:
+
+```bash
+# Clone the repo (shallow clone for speed)
+git clone --depth=50 git@github.com:<owner>/<repo-name>.git /tmp/<repo-name>-<ticket-id>
+cd /tmp/<repo-name>-<ticket-id>
+
+# Checkout the default branch (confirm the repo's actual default — e.g. `main`, `master`, or `release`)
+git checkout <default-branch>
+```
+
+Once cloned, explore the codebase locally to understand what exists:
+
+1. **Search for relevant code** using Grep and Glob tools on the local clone
+2. **Read the specific files** that will be modified — note coding style, patterns, imports
+3. **Check for related files**: tests, type definitions, configuration files
+
+> **Why local clone?** Working locally allows faster file reads, better search across the codebase, and the ability to run linters/tests before pushing.
+
+> **IMPORTANT:** From this point forward, use ONLY local tools (`Read`, `Grep`, `Glob`) to explore the codebase. Do NOT use `mcp__github__get_file_contents` or `mcp__github__search_code` — the repo is already on disk.
+
+---
+
+## Step 4: Present the Implementation Plan
+
+Before making any changes, share your plan in Slack:
+
+```
+*Implementation Plan for <ticket-id>*
+
+*Repo*: <owner>/<repo-name>
+
+*Files to modify*:
+• `path/to/file1.ts` — <what change and why>
+• `path/to/file2.ts` — <what change and why>
+
+*New files*:
+• `path/to/new-file.ts` — <purpose>
+
+*Approach*:
+<brief description of the implementation approach>
+
+Shall I proceed with this implementation?
+```
+
+**Wait for confirmation** before proceeding to Step 5. Do NOT push code without explicit approval.
+
+> **Webhook-triggered mode:** When this skill is invoked from a Linear webhook (automated flow), skip this step entirely — there is no human in the loop to approve. Proceed directly to Step 5.
+
+---
+
+## Step 5: Implement Changes Locally
+
+After approval, work on the local clone in `/tmp/<repo-name>-<ticket-id>`. Use ONLY local tools (`Read`, `Grep`, `Glob`, `Edit`, `Write`) — never `mcp__github__get_file_contents`.
+
+1. **Create a branch** from the default branch:
+   ```bash
+   cd /tmp/<repo-name>-<ticket-id>
+   git checkout -b <branch-name>
+   # Branch naming: ENG-123/short-description or feat/ENG-123-add-webhook-retry
+   ```
+
+2. **Make the code changes** using Edit/Write tools on the local files
+
+3. **Verify the changes**:
+   - Run any available linters or type checks
+   - Review the diff: `git diff`
+
+4. **Commit and push**:
+   ```bash
+   cd /tmp/<repo-name>-<ticket-id>
+   git add <specific-files>
+   git commit -m "feat: <description> (<ticket-id>)"
+   git push -u origin <branch-name>
+   ```
+
+**Guidelines for the code you write (MANDATORY):**
+- **Minimal changes only** — make the smallest diff that satisfies the requirement. Fewer lines changed = easier to review and merge. Do not refactor, rename, or reorganize surrounding code.
+- **Reuse existing code** — before writing anything new, search the codebase for existing components, utilities, helpers, and patterns that already do what you need. Import and reuse them. Never recreate something that already exists.
+- **Match existing UI patterns** — for frontend/UI changes, find similar existing components and copy their structure, styling, and patterns. The result must look visually coherent with the rest of the app. Do not invent new styles or layouts when existing ones can be reused.
+- Follow the existing code style in the repo (indentation, naming, imports)
+- Add comments only where the logic isn't self-evident
+- Reference the Linear ticket ID in the commit message
+
+---
+
+## Step 6: Create a Draft PR
+
+Use `gh pr create` via Bash with a HEREDOC for the body. Do NOT use `mcp__github__create_pull_request` — the MCP tool's JSON serialization double-escapes newlines (`\\n` instead of actual line breaks), causing PR descriptions to render as broken text on GitHub.
+
+```bash
+cd /tmp/<repo-name>
+gh pr create \
+  --repo <owner>/<repo-name> \
+  --head <branch-name> \
+  --base <default-branch> \
+  --draft \
+  --title "feat: <concise PR title>" \
+  --body "$(cat <<'EOF'
+## Summary
+<1-3 bullet points describing what changed>
+
+## Linear Ticket
+<link to the Linear ticket>
+
+## Changes
+- `path/to/file1.ts` — <what changed>
+- `path/to/file2.ts` — <what changed>
+
+## Notes
+- This PR was generated by the agent based on the Linear ticket above
+- Please review carefully before merging
+EOF
+)"
+```
+
+The HEREDOC (`<<'EOF'`) ensures actual newlines are preserved in the body text. Extract the PR number from the URL printed by `gh pr create` for use in Step 6a.
+
+---
+
+## Step 6a: Add "Agent PR" Label
+
+After creating the draft PR, add the `Agent PR` label to it. This applies to *every* draft PR you create, regardless of which repo it targets.
+
+### Procedure
+
+1. **Check if the label exists** on the target repo:
+   - Use `mcp__github__get_label` with `owner: "<owner>"`, `repo: <target-repo>`, `name: "Agent PR"`
+
+2. **If the label does NOT exist** (the call returns an error or not found), create it using Bash:
+   ```bash
+   curl -s -X POST \
+     -H "Authorization: token $GITHUB_API_KEY" \
+     -H "Accept: application/vnd.github+json" \
+     https://api.github.com/repos/<owner>/<target-repo>/labels \
+     -d '{"name":"Agent PR","color":"D93F0B","description":"PR generated by the agent"}'
+   ```
+
+3. **Add the label to the PR**:
+   - Use `mcp__github__issue_write` with:
+     - `method: "update"`
+     - `owner: "<owner>"`
+     - `repo: <target-repo>`
+     - `issue_number: <PR number from Step 6>`
+     - `labels: ["Agent PR"]`
+
+> **Note:** GitHub PRs and issues share the same numbering — `issue_write` works for PRs too.
+
+---
+
+## Step 6b: Add a "preview" Label for Significant Changes (optional)
+
+If your repo uses a `preview` label to trigger preview deployments or extra review, evaluate whether the changes are significant enough to warrant it. Add the label if **any** of the following are true:
+
+- Changes touch **multiple apps or packages** within a monorepo
+- Changes modify **API contracts**, schemas, or shared interfaces
+- Changes affect **database schemas**, migrations, or data models
+- Changes touch **critical paths**: authentication, billing, delivery, event pipeline
+- The PR modifies **10+ files** or includes substantial new functionality
+- Changes affect **infrastructure config** (Dockerfiles, CI workflows, build config)
+
+If none of the above apply (e.g. a small single-file fix, copy change, or config tweak), skip this step.
+
+### Procedure
+
+**Add the label to the PR** (in addition to "Agent PR"):
+- Use `mcp__github__issue_write` with:
+  - `method: "update"`
+  - `owner: "<owner>"`
+  - `repo: <target-repo>`
+  - `issue_number: <PR number from Step 6>`
+  - `labels: ["Agent PR", "preview"]`
+
+> **Scope:** Only apply this label if the target repo actually uses it. Skip this step otherwise.
+
+---
+
+## Step 7: Share the Result
+
+Post back in Slack:
+
+```
+*PR Created* :white_check_mark:
+
+<pr-url|View Draft PR>
+
+*Changes*:
+• `path/to/file1.ts` — <brief description>
+• `path/to/file2.ts` — <brief description>
+
+This is a *draft PR* — please review the changes before marking it ready for review.
+```
+
+> **Webhook-triggered mode:** When invoked from a Linear webhook, instead of posting to Slack, comment on the Linear ticket with the PR details using `mcp__linear__create_comment`. The comment MUST start with a bot marker comment (e.g. `<!-- agent -->`) to prevent webhook loops.
+
+---
+
+## Step 8: Cleanup
+
+After the PR is created, clean up the local clone:
+
+```bash
+rm -rf /tmp/<repo-name>-<ticket-id>
+```
+
+---
+
+## Guardrails
+
+- *Always draft PRs* — never create ready-for-review PRs. Humans must review AI-generated code.
+- *Always ask before pushing* — present the plan (Step 4) and wait for explicit confirmation.
+  - Exception: webhook-triggered flows skip approval (Step 4 is skipped).
+- *One repo per PR* — if changes span multiple repos, create separate PRs.
+- *Scope limits* — if the ticket requires a large refactor, touches 10+ files, or needs changes across many repos, explain that it's too complex for automated implementation and suggest breaking it down.
+- *No destructive changes* — don't delete files or remove functionality unless the ticket explicitly asks for it.
+- *Follow existing patterns* — match the repo's code style, don't introduce new frameworks or patterns.
+- *Local clone in /tmp* — always clone to `/tmp/<repo-name>-<ticket-id>` for implementation. This keeps the working directory clean and ensures a fresh codebase state.
+
+---
+
+## Thread Follow-ups
+
+When someone replies in a thread where you've created a PR:
+- **First, check if the PR is still open.** If the PR has already been merged, create a new branch from the latest default branch and open a fresh PR for follow-up changes. Do not assume the original PR branch is still open for updates.
+- If they ask for changes to the PR → clone the repo again to `/tmp`, checkout the PR branch, make changes, commit, and push
+- If they ask to update the PR description → use `mcp__github__update_pull_request`
+- If they report issues with the code → read the specific feedback, fix the code, push a new commit
+- If they approve → note that they can mark the PR as ready for review on GitHub
+
+---
+
+## Webhook-triggered PR Modifications
+
+When invoked from a Linear webhook in "modify" mode (a comment mentioning the agent on a ticket that already has a PR):
+
+1. **FIRST: Distinguish human change requests from automated/bot messages.** If the comment contains no actionable change requests (e.g., it's a bot status update like "⏳ Working on it!", a progress link, or an automated notification), do NOT proceed through the full "update PR" workflow. Instead, immediately respond that the comment contained no specific change requests and skip unnecessary steps. This avoids wasted tool calls.
+2. Find the existing draft PR for the ticket on GitHub (search by ticket ID in title/branch)
+3. Read the comment to understand what changes are requested
+4. **Clone the repo locally** to `/tmp/<repo-name>-<ticket-id>`, checkout the PR branch, and read the current files using local tools (`Read`, `Grep`, `Glob` — NOT `mcp__github__get_file_contents`). Also read the latest ticket description. If the comment says "ticket content was updated, re-implement these changes", perform a detailed diff between the current ticket description and the existing PR code to identify specific deltas. Something must have changed — find exactly what changed and implement only the delta. Pushing an identical commit that re-applies the same files without any actual changes is wasteful and misleading. If after careful comparison you genuinely find no differences, explicitly call that out and ask for clarification rather than pushing a no-op commit.
+5. Make changes locally, commit, and push to the same branch
+6. Comment on the Linear ticket confirming the changes (with a bot marker comment, e.g. `<!-- agent -->`)
+7. Clean up: `rm -rf /tmp/<repo-name>-<ticket-id>`
+
+This is different from the initial implementation flow — you are *modifying* an existing PR, not creating a new one.
+
+---
+
+## Learnings from PR Reviews
+
+Rules extracted from human PR review feedback and bot self-review patterns. These address recurring issues the agent should avoid when implementing tickets.
+
+- **Update the PR description after follow-up commits that change behavior or output format.** When a follow-up commit changes the behavior described in the PR (e.g., switching a date format, changing an API response shape), update the PR description to match the new behavior using `mcp__github__update_pull_request`. Stale PR descriptions mislead reviewers and downstream consumers who reference the PR for integration details.
+
+- **Use deep copies when duplicating objects with nested properties.** When duplicating or cloning objects that contain nested objects or arrays, use a deep copy mechanism (e.g., `JSON.parse(JSON.stringify(...))` in JS/TS, a serialization round-trip in other languages) instead of a shallow spread (`{ ...obj }`). Shallow copies create shared references to nested objects, causing mutations to one copy to affect the other.
+
+- **Ensure all fields referenced by downstream code are included in data queries.** When adding UI components or logic that references specific data fields, verify that the upstream query actually fetches those fields. A common bug: code references a field the query never selected, causing it to silently fall through to a fallback value. Always trace the data flow from query → transform → render to confirm field availability.
+
+- **Use explicit timezone formatting for external-facing timestamps.** When formatting timestamps for webhooks, API responses, or any external consumer, always use explicit timezone-aware formats (e.g., RFC3339 with a `Z` or offset, `toISOString()` in JS). Never rely on the implicit server timezone — normalize to UTC before formatting to make the intent self-documenting.
+
+- **Follow the established route/endpoint conventions when adding API routes.** When adding a new API route, check how existing routes are organized (prefixes, versioning, grouping) and follow that pattern exactly rather than inventing an ad-hoc prefix. Consistent routing keeps the API predictable for consumers and reviewers.
+
+- **Use batch operations for bulk database deletes/updates, not individual calls in a loop.** When implementing cleanup, migration, or bulk-action logic that deletes or updates multiple records, use batch/bulk database operations (e.g., a single bulk delete/write) instead of looping and operating one record at a time. Per-record calls in a loop create unnecessary round-trips, are slower, and can cause timeouts at scale. Before implementing, estimate how many records could be affected and design accordingly.
+
+- **Verify that error-handling control flow is correct.** When writing error-handling blocks, double-check that the handling code (logging, returning) only runs on the error path. In some languages, misplaced braces or indentation compile cleanly but change control flow so the handler runs unconditionally. After writing any error-handling block, re-read it and confirm the scope is correct.
+
+- **Match the repo's styling conventions for UI changes.** When adding or modifying UI components, follow the project's established styling approach (e.g., CSS/SCSS modules, a styling library, utility classes) rather than introducing a different one. Before adding styles, check how adjacent components are styled and reuse the same pattern.
+
+- **Sanitize all user-controlled or dynamic values interpolated into SQL queries.** When building queries that include dynamic values (column names, filter values, breakdown dimensions), never interpolate them directly into the query string. Use parameterized queries where possible, or validate the value against an allowlist of known-safe values. This applies even when the value currently comes from a controlled source — the query function may be called from other contexts later. Pay special attention to identifiers like column aliases and `ORDER BY` clauses, which are commonly overlooked injection vectors.
+
+- **Check for iteration errors after row-scanning loops.** When iterating over query result rows, check for an iteration error after the loop completes (the idiom varies by language/driver). Iteration can terminate early due to a network timeout or deserialization failure; without the check, partial results are silently treated as complete. Match the pattern used by sibling functions in the same file.
+
+- **Follow the project's component/state conventions.** When writing or modifying components, follow the project's established conventions for ordering declarations, lifecycle/hooks, and state management. Before adding to a component, check the existing pattern and insert new code in the correct position. Convention violations are frequently flagged as blocking issues in review.
+
+- **When adding a new status/enum value, update ALL code paths that consume it.** When introducing a new status, enum value, or state, systematically search for ALL locations that switch on or filter by the existing values — including metrics queries, export functions, action menus, filter dropdowns, API responses, and scheduled jobs. Each consumer must handle the new value explicitly. A common failure mode is binary logic (e.g., a query that assumes a value is one of two options) breaking when a third value is added.
+
+- **Keep user-facing UI elements concise and dismissable — test visual co-existence with dynamic page states.** When adding alerts, banners, info messages, or any persistent UI element, keep text short (1-2 lines max) and make the element dismissable (closable). Before committing, verify how the element looks when other dynamic content is also visible on the same view — e.g., error banners, loading states, empty states, or validation messages. A verbose, non-dismissable alert that looks fine in isolation can make the page look cluttered or broken when combined with other contextual UI.
+
+- **Do not let detached background work depend on a request's lifecycle.** When spawning fire-and-forget background work from a request handler (e.g., for replication, logging, or background writes), do not tie that work to the request's cancellation/lifecycle, which ends when the response is sent. Give the background work its own independent timeout/lifecycle so it can outlive the request instead of being cancelled mid-flight.
+
+- **Include testing artifacts in bot-generated PR descriptions or comments.** When creating a PR, include evidence that the change was tested — screenshots, test command output, or a brief description of manual testing steps performed. Human reviewers explicitly request testing artifacts before merging bot-generated PRs. At minimum, add a "## Testing" section documenting: (1) what was tested, (2) how it was tested (e.g., manual testing on a preview deployment, unit tests pass), and (3) any screenshots or logs if applicable. If automated tests were run, include the output. For UI changes, include before/after screenshots when possible.
+
+- **Document concurrency and write-ordering implications for async replication patterns.** When implementing fire-and-forget background writes, dual-write replication, or any async worker pattern that processes writes concurrently, proactively document the write-ordering guarantees and data-consistency model in code comments. Address: (1) what happens when multiple workers write the same key concurrently, (2) whether the pattern is last-writer-wins, eventually consistent, or strictly ordered, (3) the impact of out-of-order writes on correctness, and (4) whether a replica serves reads during a migration. Reviewers will scrutinize concurrent write patterns for state-corruption risk — anticipate this. If the pattern has known consistency gaps (e.g., transient staleness during warmup), document them as accepted trade-offs rather than leaving them for reviewers to discover.
+
+- **When modifying a function's return signature, update ALL call sites to handle the new return values.** When asked to add return values to a function (e.g., so callers can distinguish "action skipped" from "action failed"), systematically find ALL call sites and update each one to consume the new values. Some languages do not enforce that extra return values are consumed — callers can silently discard them. After changing a signature, search the codebase for every call site and verify each either uses the new values or explicitly documents why they are discarded. Never leave call sites silently ignoring new return values — it defeats the purpose of adding them.
+
+- **Exclude structured string values (URLs, file paths, base64, JSON) from text-level transformations.** When applying string transformations to record fields — such as encoding, escaping, regex replacements, or character insertion — validate the semantic type of each value before transforming it. URLs, file paths, base64 data, and serialized JSON must be excluded because text-level modifications corrupt their structure (e.g., inserting characters into a URL breaks parsing, causing images to fail to load). Before implementing any bulk text transformation, add explicit detection logic (e.g., regex for `http(s)://`, `data:`, file extensions) to skip non-prose values. Test with real data that mixes value types (text + URLs + media references) to catch edge cases.
+
+---
+
+## Cross-Platform Bug Fixes
+
+When fixing a bug reported on a specific platform, do NOT assume which platforms are affected based on code reading alone. Before implementing fixes across multiple SDKs (Android, iOS, Web, React Native, Flutter):
+
+1. Check available QA data, crash reports, user agent strings, or platform-specific logs to identify which platforms actually exhibit the bug
+2. Enumerate ALL platform SDKs and systematically verify which ones are impacted
+3. Only implement fixes for confirmed affected platforms
+4. If unsure, implement for the reported platform first and note which other platforms need verification

--- a/seed/skills/improve-skill/SKILL.md
+++ b/seed/skills/improve-skill/SKILL.md
@@ -1,0 +1,833 @@
+---
+name: improve-skill
+description: Skill creation and improvement playbook — use when creating a new skill, improving an existing skill, or migrating curl-based skills to tool-based patterns
+user-invocable: false
+---
+
+# Skill Creation & Improvement Playbook
+
+This skill is the definitive guide for creating new Loma skills and improving existing ones. It codifies the patterns from the best skills and explicitly calls out anti-patterns to avoid.
+
+---
+
+> **Cross-references to related skills:**
+> - For MCP server development patterns (Python FastMCP, TypeScript SDK), load the **mcp-builder** skill.
+
+> **CRITICAL: How Loma Skills Are Stored & Edited**
+>
+> Loma skills live in **MongoDB**, not in a git repo. There is no clone/branch/PR flow. Every skill is a `slug` with a `SKILL.md` (YAML frontmatter plus body) and optional extra files and binary assets. All reads and writes go through the first-party CLI:
+>
+> ```bash
+> python3 tools/loma_skills.py <subcommand> [flags]
+> ```
+>
+> Each write is versioned automatically in the database, so there is no separate deployment step — a successful `create`, `import-dir`, or `update-file` is live.
+>
+> **CLI subcommands:**
+>
+> | Subcommand | Purpose |
+> |---|---|
+> | `list` | List all skills |
+> | `search --query "<q>"` | Search skills |
+> | `get --slug <slug>` | Fetch a skill (SKILL.md + metadata) |
+> | `file --slug <slug> --path <path>` | Fetch one file's content |
+> | `asset --slug <slug> --path <path>` | Fetch a binary asset |
+> | `create --slug <slug> --skill-md <file> --user-email <email> --auth-token <token>` | Create a new skill |
+> | `import-dir --source <dir> --user-email <email> --auth-token <token>` | Import a skill directory (SKILL.md + scripts/assets) |
+> | `update-file --slug <slug> --path SKILL.md --content-file <file> --user-email <email> --auth-token <token>` | Update or add a file |
+>
+> Write subcommands (`create`, `import-dir`, `update-file`) require `--user-email` and `--auth-token`. Read subcommands (`list`, `search`, `get`, `file`, `asset`) do not.
+
+---
+
+## When to Use
+
+Load this skill when:
+- Asked to create a brand new skill for Loma
+- Asked to improve or refactor an existing skill
+- Asked to migrate a curl-based skill to a tool-based pattern
+- Asked to add a new external API integration
+- Discussing how skills work or best practices for structuring them
+
+---
+
+## 1. Skill Anatomy
+
+### Directory Structure
+
+When authoring a skill locally before importing it, lay it out as a directory:
+
+```
+<skill-name>/
+  SKILL.md          # Required. The skill definition.
+  scripts/          # Optional. Helper scripts.
+  assets/           # Optional. Binary assets (images, templates).
+```
+
+You import this directory into the database with `import-dir`. A skill can also be created from a single SKILL.md file with `create`, then have additional files added with `update-file`.
+
+### YAML Frontmatter (required at top of SKILL.md)
+
+```yaml
+---
+name: <skill-name>              # Must match the slug
+description: <1-line> — use when <trigger conditions>  # Used for trigger matching
+tags: [<optional>, <tags>]      # Optional
+user-invocable: false           # true only if users can invoke via a /command
+---
+```
+
+The `description` field is critical — it determines when the skill loads. Be specific about trigger conditions.
+
+**Good descriptions:**
+- `"Pylon support ticket API integration — use when fetching ticket messages, posting internal notes, or handling Pylon webhook-triggered support issues"`
+- `"Database debugging workflows for MongoDB and ClickHouse — use when investigating customer data, campaign states, events, SDK issues"`
+
+**Bad descriptions:**
+- `"Pylon tool"` — too vague, trigger matching will fail
+- `"Handles billing"` — doesn't specify what triggers loading
+
+### Required Sections in SKILL.md
+
+Every skill should have these sections (adapt as needed):
+
+1. **Title** (H1) — concise name
+2. **When to Use** — explicit trigger conditions (bulleted list)
+3. **Tool Reference** — which tool/MCP server to use, how to invoke it
+4. **Commands / API Reference** — one subsection per command with exact bash invocation
+5. **Common Workflows** — step-by-step playbooks for typical use cases
+6. **Error Handling** — what errors look like and how to handle them
+7. **Safety / Guardrails** — what the agent must never do
+
+---
+
+## 2. Decision Tree: Choose Your Tool Type
+
+When creating or improving a skill, use this decision tree:
+
+### Does the skill need to call an external API?
+
+**No** → Create a **pure-workflow skill** (no tool needed).
+- The SKILL.md contains step-by-step playbooks and decision trees.
+- Examples: `self-improvement`, `bug-triage`, `feature-request-triage`, `campaign-visibility`
+
+**Yes** → Continue below.
+
+### Is there already a configured MCP server for this service?
+
+Check `.mcp.json` for existing servers: MongoDB, ClickHouse, GitHub, Linear, Notion, Athena, GitLab.
+
+**Yes** → Reference the existing MCP tools in your SKILL.md.
+- Example: `debugging` uses MongoDB and ClickHouse MCP servers
+- Example: `code-review` uses GitHub MCP tools
+
+**No** → **Create a CLI tool in `tools/<service>.py`** (this is the default for all new API integrations).
+
+### Rules
+
+- **ALWAYS prefer CLI tools** for new API integrations. This is the standard pattern.
+- **NEVER add new MCP servers** to `.mcp.json`. MCP servers are managed via deployment config and not added through skills.
+- **NEVER embed raw curl commands in SKILL.md.** This is the single most important rule. See Section 6 for why.
+
+---
+
+## 3. Creating a CLI Tool
+
+When a skill needs to call an external API, create a Python CLI tool in `tools/`. Follow the established pattern from the best existing tools.
+
+### Reference Implementations
+
+Study these before writing a new tool:
+- `tools/pylon.py` — best overall example (manual flag parsing, stdin for HTML, clean structure)
+- `tools/gmail.py` — argparse-based alternative (good for tools with many flags per command)
+- `tools/dataroom.py` — similar to pylon, many subcommands
+- `tools/apollo.py` — argparse with subparsers
+
+### Tool File Structure
+
+Every CLI tool follows this structure:
+
+```python
+"""<Service> API client.
+
+Provides CLI commands for the agent:
+  1. <tool>.py <command1> <args>     — Description
+  2. <tool>.py <command2> <args>     — Description
+  3. echo '<body>' | <tool>.py <command3> <args>  — Description (stdin)
+
+Requires <ENV_VAR> environment variable.
+
+Usage (called by the agent via Bash):
+  python3 tools/<tool>.py <command1> arg1
+  python3 tools/<tool>.py <command2> --flag value
+"""
+
+import asyncio
+import json
+import os
+import sys
+import logging
+from typing import Any
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://api.service.com"
+
+
+# --- Configuration helpers ---
+
+def _get_api_key() -> str:
+    key = os.environ.get("SERVICE_API_KEY", "")
+    if not key:
+        raise ValueError(
+            "SERVICE_API_KEY environment variable is not set. "
+            "Please configure it before using this tool."
+        )
+    return key
+
+
+def _headers() -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {_get_api_key()}",
+        "Content-Type": "application/json",
+        "Accept": "*/*",
+    }
+
+
+# --- Shared HTTP helpers ---
+
+async def _api_get(path: str) -> dict[str, Any]:
+    """GET helper. Returns parsed JSON or {"error": "..."}."""
+    url = f"{BASE_URL}{path}"
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                url, headers=_headers(), timeout=aiohttp.ClientTimeout(total=30)
+            ) as resp:
+                if resp.status == 401:
+                    return {"error": "API key is invalid or expired."}
+                if resp.status == 404:
+                    return {"error": f"Not found: {path}"}
+                if resp.status == 429:
+                    return {"error": "Rate limit reached. Try again shortly."}
+                if resp.status != 200:
+                    text = await resp.text()
+                    return {"error": f"API error (HTTP {resp.status}): {text[:500]}"}
+                return await resp.json()
+    except aiohttp.ClientError as e:
+        return {"error": f"Failed to connect to API: {e}"}
+
+
+async def _api_post(path: str, body: dict[str, Any]) -> dict[str, Any]:
+    """POST helper. Returns parsed JSON or {"error": "..."}."""
+    url = f"{BASE_URL}{path}"
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                url, headers=_headers(), json=body,
+                timeout=aiohttp.ClientTimeout(total=30),
+            ) as resp:
+                if resp.status not in (200, 201):
+                    text = await resp.text()
+                    return {"error": f"API error (HTTP {resp.status}): {text[:500]}"}
+                return await resp.json()
+    except aiohttp.ClientError as e:
+        return {"error": f"Failed to connect to API: {e}"}
+
+
+# --- Public async functions (one per API operation) ---
+
+async def search_items(query: str) -> dict[str, Any]:
+    return await _api_get(f"/items?search={query}")
+
+
+async def get_item(item_id: str) -> dict[str, Any]:
+    return await _api_get(f"/items/{item_id}")
+
+
+# --- CLI entry point ---
+
+if __name__ == "__main__":
+    from dotenv import load_dotenv
+    load_dotenv()
+
+    args = sys.argv[1:]
+    if not args:
+        print(json.dumps({"error": "Usage: python3 tools/<tool>.py <command> [args]"}))
+        sys.exit(1)
+
+    command = args[0]
+
+    if command == "search":
+        query = args[1] if len(args) > 1 else ""
+        result = asyncio.run(search_items(query))
+    elif command == "get":
+        item_id = args[1] if len(args) > 1 else ""
+        result = asyncio.run(get_item(item_id))
+    else:
+        result = {"error": f"Unknown command: {command}"}
+
+    print(json.dumps(result, indent=2))
+```
+
+### Local Development & Testing Workflow
+
+**NEVER ship a CLI tool without testing it first.** Follow this workflow:
+
+1. **Research the official API documentation.** Use `WebSearch` and `WebFetch` to find and read the **official API documentation** from the service's website. Look for: auth method, base URL, endpoint paths, request/response formats, pagination, rate limits, error formats. Do NOT look at existing SKILL.md files yet — they may have wrong API patterns.
+
+2. **STOP — Ask yourself: "Do I have usable API docs?"** This is a mandatory checkpoint. You MUST send a message to the user before continuing. There are only two valid outcomes for this step:
+
+   **If you GOT usable docs** (you can see endpoint paths, auth format, response shapes from an official source): Tell the user what you found and proceed to step 3.
+
+   **If you DID NOT get usable docs** (for ANY reason — login wall, empty page, search found nothing, WebFetch returned junk, docs lack detail): You MUST send this message to the user and WAIT for their response:
+
+   *"I couldn't get usable API documentation from the web. Could you either share the exact docs URL or paste the relevant API reference here? I don't want to proceed by guessing."*
+
+   STOP. WAIT. Do not continue until the user replies. The user will either: (a) give you a URL, (b) paste docs, or (c) say to proceed without docs.
+
+   **This step is ONLY complete when you have sent a message AND received a user response.** You cannot complete this step by reasoning about it internally. The following are NOT substitutes for official docs and do NOT count as "having usable docs":
+   - The existing SKILL.md (even if it says "validated" or "tested" — it's the thing you're fixing)
+   - Trial-and-error against the live API
+   - Guessing based on similar APIs
+   - Any source other than official vendor documentation or user-provided documentation
+
+3. **Write the tool file** in a local working directory, e.g. `tools/<service>.py`.
+
+4. **Source environment variables** from the project's `.env`:
+   ```bash
+   source /path/to/project/.env
+   ```
+   Check the existing `.env` for required variables first. Only ask the user for variables that are **not already present** in `.env`. If new env vars are needed, ask the user for the values and export them for the test session.
+
+5. **Syntax check:**
+   ```bash
+   python3 -m py_compile tools/<service>.py
+   ```
+
+6. **Test each subcommand** with real data:
+   ```bash
+   python3 tools/<service>.py <command1> <test-args>
+   python3 tools/<service>.py <command2> <test-args>
+   ```
+   Verify:
+   - JSON output on success (valid JSON, expected fields)
+   - `{"error": "..."}` output on expected failures (invalid ID, missing auth)
+   - No crashes or unhandled exceptions
+
+7. **Iterate and fix** — if any command fails, fix the tool and re-test. Repeat until all commands work.
+
+8. **Only after all tests pass** — package the tool with its SKILL.md and import the skill into the database (see Section 9).
+
+### Key Patterns
+
+1. **JSON output always.** Every command prints JSON to stdout. Success returns the API response; failure returns `{"error": "description"}`. Never print unstructured text.
+
+2. **Stdin for long content.** When a command accepts HTML or multi-line text, read from stdin. This avoids shell escaping nightmares. Example from `pylon.py`:
+   ```bash
+   cat <<'EOF' | python3 tools/pylon.py note ISSUE_ID
+   <p>This is an internal note with <b>HTML</b> formatting.</p>
+   EOF
+   ```
+
+3. **Environment variables for secrets.** All API keys, tokens, and base URLs come from env vars. Never hardcode them in the tool or the SKILL.md.
+
+4. **Async internals, sync CLI.** Functions are `async def` internally (using `aiohttp`), called via `asyncio.run()` from the CLI entry point.
+
+5. **Dual-purpose design.** Public async functions can be imported by other Python modules (e.g., webhook handlers in the server code), not just called from CLI.
+
+6. **Structured error handling.** Every HTTP helper handles status codes explicitly (401, 404, 429, etc.) and catches `aiohttp.ClientError`. Never let exceptions crash the tool — return `{"error": "..."}`.
+
+### Auth Patterns
+
+Choose the pattern that matches the API:
+
+- **API key in header:** `_get_api_key()` + `_headers()` (like `pylon.py`)
+- **Custom header name:** e.g., `x-api-key: TOKEN` instead of `Authorization: Bearer`
+- **OAuth with refresh:** Create a helper that handles token refresh internally. See `tools/_google_auth.py` for the pattern — tokens stored in MongoDB, auto-refreshed when expired. The caller never deals with token management.
+- **User-scoped auth:** Add `--auth-token` and `--user-email` flags, verify via `tools/_auth_token.py` (like `gmail.py`, `google_calendar.py`)
+
+---
+
+## 4. Writing the SKILL.md
+
+### Template: Tool-Based Skill
+
+```markdown
+---
+name: <name>
+description: <description> — use when <trigger conditions>
+user-invocable: false
+---
+
+# <Title>
+
+<1-2 sentence overview.>
+
+**Tool**: `tools/<name>.py` — Python CLI called via Bash
+**Auth**: `<ENV_VAR>` environment variable (loaded automatically by the tool)
+
+---
+
+## When to Use
+
+- <trigger condition 1>
+- <trigger condition 2>
+
+---
+
+## Commands
+
+### <Command Name>
+
+\`\`\`bash
+python3 tools/<name>.py <command> [FLAGS]
+\`\`\`
+
+<Description of what this does. Document the response shape.>
+
+### <Another Command>
+
+\`\`\`bash
+cat <<'EOF' | python3 tools/<name>.py <command> ARGS
+<body content here>
+EOF
+\`\`\`
+
+---
+
+## Common Workflows
+
+### <Workflow Name>
+
+1. <Step 1 — which command to run>
+2. <Step 2 — what to do with the result>
+3. <Step 3 — next action>
+
+---
+
+## Error Handling
+
+- **401**: API key invalid or expired — check `<ENV_VAR>`
+- **404**: Resource not found
+- **429**: Rate limit — wait and retry
+
+---
+
+## Safety / Guardrails
+
+- <Rule 1: e.g., "Read-only — never create, update, or delete resources">
+- <Rule 2: e.g., "Always confirm with user before sending external communications">
+```
+
+### Template: Workflow-Only Skill
+
+```markdown
+---
+name: <name>
+description: <description> — use when <trigger conditions>
+user-invocable: false
+---
+
+# <Title> Playbook
+
+<1-2 sentence overview.>
+
+---
+
+## When to Use
+
+- <trigger condition 1>
+- <trigger condition 2>
+
+---
+
+## Step 1: <First Step>
+
+<Instructions, decision points, what tools/MCP servers to query.>
+
+## Step 2: <Second Step>
+
+<Instructions...>
+
+---
+
+## Edge Cases
+
+- <Edge case 1>
+- <Edge case 2>
+```
+
+---
+
+## 5. Using Existing MCP Servers
+
+Skills may reference MCP servers that are already configured in `.mcp.json`:
+
+| Server | Use For |
+|--------|---------|
+| MongoDB | Customer data, product configs, campaign state |
+| ClickHouse | Analytics, events, campaign metrics |
+| GitHub | Code search, PR operations, file reads/writes |
+| Linear | Issue tracking, project management |
+| Notion | Internal runbooks, operational docs |
+| Athena | API request/response logs |
+| Docs search | Product/help documentation lookups |
+
+**NEVER add new MCP servers to `.mcp.json`.** MCP servers are managed via deployment configuration. If you need a new API integration, create a CLI tool instead.
+
+When referencing MCP tools in a SKILL.md, use the tool name directly with the relevant arguments, for example a GitHub file read with `owner`, `repo`, and `path`.
+
+---
+
+## 6. Anti-Patterns — What NOT to Do
+
+### Anti-Pattern 1: Raw curl commands in SKILL.md
+
+This is the **most common and most damaging** mistake. The `monetize-now` and `zoho-books` skills both embed raw curl commands, causing frequent agent errors.
+
+**Bad — from `monetize-now/SKILL.md`:**
+```bash
+# Agent must construct the full curl each time, getting headers wrong frequently
+curl -s -H "x-api-key: $MONETIZE_NOW_API_KEY" \
+  "$MONETIZE_NOW_BASE_URL/accounts?search=CUSTOMER_NAME"
+```
+
+Problems observed:
+- Agent uses `Authorization: Bearer` instead of `x-api-key` (returns 401)
+- Agent doubles the URL path: `$MONETIZE_NOW_BASE_URL/api/accounts` → `/api/api/accounts` (returns 404)
+- Every curl block repeats the same headers, multiplying error surface
+
+**Bad — from `zoho-books/SKILL.md`:**
+```bash
+# Two-step OAuth dance that must be manually performed every time
+# Step 1: Refresh token
+curl -s -X POST "https://accounts.zoho.in/oauth/v2/token" \
+  -d "refresh_token=$ZOHO_REFRESH_TOKEN_IN" \
+  -d "client_id=$ZOHO_CLIENT_ID_IN" \
+  -d "client_secret=$ZOHO_CLIENT_SECRET_IN" \
+  -d "grant_type=refresh_token"
+
+# Step 2: Use the token (agent must extract and paste it)
+curl -s -H "Authorization: Zoho-oauthtoken ACCESS_TOKEN" \
+  "https://books.zoho.in/api/v3/invoices?organization_id=$ZOHO_ORGANIZATION_ID_IN"
+```
+
+Problems observed:
+- Agent forgets to refresh the token
+- Agent uses the wrong region's credentials (India vs US)
+- Token expires mid-session and agent doesn't notice
+- Massive SKILL.md (300+ lines of curl templates)
+
+**Correct approach:** Create `tools/monetize_now.py` and `tools/zoho_books.py` that handle auth, URLs, and errors internally. The SKILL.md then just documents clean CLI commands:
+```bash
+python3 tools/monetize_now.py search-accounts "CustomerName"
+python3 tools/zoho_books.py list-invoices --region in --customer-id ZOHO_ID
+```
+
+### Anti-Pattern 2: Duplicating auth logic
+
+Never repeat authentication setup in every command block. Put it in the tool's `_headers()` function once.
+
+### Anti-Pattern 3: Hardcoding API URLs
+
+Never hardcode URLs like `https://api.monetizeplatform.com/api`. Use env vars in the tool code, and reference the tool from SKILL.md.
+
+### Anti-Pattern 4: Vague skill descriptions
+
+The `description` in frontmatter drives trigger matching. Vague descriptions = skill never loads or loads incorrectly.
+
+### Anti-Pattern 5: Missing error handling
+
+Every skill that calls an external service must document error scenarios. Without this, the agent silently fails or hallucinates recovery steps.
+
+### Anti-Pattern 6: Embedding secrets in SKILL.md
+
+Never put actual API keys, tokens, or credentials in SKILL.md. Reference environment variable names only (e.g., `$SERVICE_API_KEY`).
+
+### Anti-Pattern 7: Shipping untested CLI tools
+
+Never import a CLI tool into the skills database without testing it first. This results in broken tools that fail at runtime. Always follow the local dev/test workflow (Section 3): write the tool, source env vars, test every subcommand, iterate until it works, THEN import.
+
+---
+
+## 7. Improving an Existing Skill — Migration Playbook
+
+Use this step-by-step workflow to migrate a curl-based skill to a tool-based pattern.
+
+### Step 1: Fetch Official API Documentation
+
+**Before looking at the existing SKILL.md**, use `WebSearch` and `WebFetch` to find and read the **official API documentation** from the service's website. The official docs are your primary source of truth for: auth method/headers, base URL, endpoint paths, request/response formats, pagination, error codes.
+
+### Step 2: STOP — Confirm You Have API Docs
+
+This is a mandatory checkpoint. You MUST send a message to the user before continuing. There are only two valid outcomes for this step:
+
+**If you GOT usable docs** (you can see endpoint paths, auth format, response shapes from an official source): Tell the user what you found and proceed to Step 3.
+
+**If you DID NOT get usable docs** (for ANY reason — login wall, empty page, search found nothing, WebFetch returned junk, docs lack detail): You MUST send this message to the user and WAIT for their response:
+
+*"I couldn't get usable API documentation from the web. Could you either share the exact docs URL or paste the relevant API reference here? I don't want to proceed by guessing."*
+
+STOP. WAIT. Do not continue until the user replies. The user will either: (a) give you a URL, (b) paste docs, or (c) say to proceed without docs.
+
+**This step is ONLY complete when you have sent a message AND received a user response.** You cannot complete this step by reasoning about it internally. The following are NOT substitutes for official docs and do NOT count as "having usable docs":
+- The existing SKILL.md (even if it says "validated" or "tested" — it's the thing you're fixing)
+- Trial-and-error against the live API
+- Guessing based on similar APIs
+- Any source other than official vendor documentation or user-provided documentation
+
+### Step 3: Audit the Existing Skill
+
+Fetch the current SKILL.md from the database:
+```bash
+python3 tools/loma_skills.py get --slug <skill-name>
+```
+
+To inspect a specific extra file in the skill:
+```bash
+python3 tools/loma_skills.py file --slug <skill-name> --path <path>
+```
+
+Catalog (cross-reference against the official API docs from Steps 1-2):
+- Every curl command pattern (endpoints, HTTP methods) — note any that differ from official docs
+- The auth mechanism — check if the SKILL.md has it right vs what the official docs say
+- Any multi-step workflows (e.g., Zoho's token refresh → API call)
+- Pagination patterns
+- Business logic and workflows that must be preserved (these are the valuable parts)
+
+### Step 4: Design the CLI Tool
+
+Map each curl command to a CLI subcommand:
+
+| Curl Pattern | CLI Subcommand |
+|---|---|
+| `GET /accounts?search=NAME` | `search-accounts NAME` |
+| `GET /accounts/{id}` | `get-account ID` |
+| `GET /contracts/{id}` | `get-contract ID` |
+| `POST /items` + JSON body | `echo JSON \| create-item` |
+
+Decide on:
+- Argument parsing approach: manual `sys.argv` parsing (simpler, good for few flags) or `argparse` (better for many flags)
+- Which env vars the tool needs
+- Whether OAuth refresh should be automatic (yes — always handle it in the tool)
+
+### Step 5: Create and Test the CLI Tool Locally
+
+**Do NOT import untested code.** Follow the local development workflow from Section 3:
+
+1. Write the tool following the template from Section 3, using the **official API docs from Steps 1-2** (not the existing SKILL.md) for auth headers, URL paths, and endpoint syntax.
+2. Key design points:
+   - Handle auth internally — the SKILL.md should never mention auth headers
+   - Handle OAuth token refresh automatically if applicable
+   - Handle region/environment switching via flags (e.g., `--region in|us` for Zoho)
+   - Return structured JSON always
+
+3. Source env vars from the project's existing `.env`. Check what's already available:
+   ```bash
+   grep -i "<SERVICE_NAME>" /path/to/project/.env
+   ```
+   Only ask the user for variables that are **not already present**. If new env vars are needed, note them — you'll tell the user to add them at the end.
+
+4. Test every subcommand with real data:
+   ```bash
+   python3 tools/<service>.py <command1> <test-args>
+   python3 tools/<service>.py <command2> <test-args>
+   ```
+
+5. Iterate and fix until all commands work correctly. Do not proceed to Step 6 until the tool is fully tested.
+
+### Step 6: Rewrite the SKILL.md
+
+- **Replace** all curl command blocks with `python3 tools/<service>.py` invocations
+- **Remove** auth header documentation (handled by tool)
+- **Remove** base URL documentation (handled by tool)
+- **Remove** the "Standard Curl Template" section (no longer needed)
+- **Keep** workflow/playbook sections and business logic (e.g. a billing-query workflow, a contact-lookup workflow, edge-case handling)
+- **Keep** data model documentation and status value references
+- **Keep** safety/guardrail rules
+- **Add** an Error Handling section referencing tool output format
+
+### Step 7: Update Settings if Needed
+
+- `Bash(python3:*)` is already allowed in `settings.local.json`, so new `python3 tools/*.py` calls are covered
+- If the tool introduces new pip dependencies, add them to `requirements.txt`
+
+### Step 8: Import the Updated Skill
+
+Once the tool is tested and working locally, update the skill in the database via the CLI (see Section 9).
+
+If the tool requires new environment variables that weren't in `.env`, tell the user:
+> "The new `tools/<service>.py` requires these environment variables that aren't in your `.env` yet: `SERVICE_API_KEY`, `SERVICE_BASE_URL`. Please add them before using the skill."
+
+### Worked Example: Migrating `monetize-now`
+
+Current curl patterns → proposed `tools/monetize_now.py` subcommands:
+
+| Current Curl | New CLI Command |
+|---|---|
+| `GET /accounts?search=NAME` | `python3 tools/monetize_now.py search-accounts "NAME"` |
+| `GET /accounts/{id}` | `python3 tools/monetize_now.py get-account ACCOUNT_ID` |
+| `GET /contracts/{id}` | `python3 tools/monetize_now.py get-contract CONTRACT_ID` |
+| `GET /contracts?status=ACTIVE` | `python3 tools/monetize_now.py list-contracts --status ACTIVE` |
+| `GET /accounts/{id}/billGroups` | `python3 tools/monetize_now.py list-bill-groups ACCOUNT_ID` |
+| `GET /.../billGroups/{bgId}/invoices` | `python3 tools/monetize_now.py list-invoices ACCOUNT_ID BILL_GROUP_ID` |
+| `GET /accounts/{id}/subscriptions` | `python3 tools/monetize_now.py list-subscriptions ACCOUNT_ID` |
+| `GET /accounts/{id}/payments` | `python3 tools/monetize_now.py list-payments ACCOUNT_ID` |
+| `GET /accounts/{id}/credits` | `python3 tools/monetize_now.py list-credits ACCOUNT_ID` |
+| `GET /accounts/{id}/creditNotes` | `python3 tools/monetize_now.py list-credit-notes ACCOUNT_ID` |
+
+Auth: `x-api-key: $MONETIZE_NOW_API_KEY` handled internally in `_headers()`.
+Base URL: `$MONETIZE_NOW_BASE_URL` read from env var in the tool.
+
+### Worked Example: Migrating `zoho-books`
+
+Key complexity: dual-region OAuth token refresh.
+
+The tool should:
+1. Accept `--region in|us` on every command
+2. Internally call `_refresh_token(region)` before each API call
+3. Cache the refreshed token for the duration of the CLI invocation
+4. Map region → correct Zoho domain (`zoho.in` vs `zoho.com`), org ID env var, and OAuth credentials
+
+Proposed `tools/zoho_books.py` subcommands:
+
+| Current Curl | New CLI Command |
+|---|---|
+| Token refresh + `GET /contacts/{id}` | `python3 tools/zoho_books.py get-contact --region in CONTACT_ID` |
+| Token refresh + `GET /contacts?contact_name=NAME` | `python3 tools/zoho_books.py search-contacts --region in --name "NAME"` |
+| Token refresh + `GET /invoices?customer_id=ID` | `python3 tools/zoho_books.py list-invoices --region in --customer-id ID` |
+| Token refresh + `GET /estimates?customer_id=ID` | `python3 tools/zoho_books.py list-estimates --region in --customer-id ID` |
+| Token refresh + `POST /invoices/{id}/email` | `echo JSON \| python3 tools/zoho_books.py send-invoice --region in INVOICE_ID` |
+| Token refresh + `GET /customerpayments?customer_id=ID` | `python3 tools/zoho_books.py list-payments --region in --customer-id ID` |
+| Token refresh + `GET /creditnotes?customer_id=ID` | `python3 tools/zoho_books.py list-credit-notes --region in --customer-id ID` |
+
+The agent never sees OAuth tokens, refresh flows, or region-specific URLs.
+
+---
+
+## 8. Registration & Permissions
+
+### 8.1 Settings Permissions (`.claude/settings.local.json`)
+
+- New `python3 tools/*.py` calls: already covered by existing `Bash(python3:*)` permission — no change needed
+- New pip dependencies: add to `requirements.txt`
+
+### 8.2 Trigger Matching
+
+Skills are loaded on-demand based on the `description` in their frontmatter — there is no separate prompt-registration step. Make the `description` specific about trigger conditions (see Section 1) so the skill loads at the right times.
+
+---
+
+## 9. Saving the Skill to the Database
+
+> **Prerequisites:** If the skill includes a CLI tool, it MUST be fully tested locally before this step (see Section 3 or Section 7 Step 5). Never import untested tools.
+
+All writes go through `tools/loma_skills.py` and require `--user-email` and `--auth-token`. Each write is versioned automatically in the database; a successful command makes the change live.
+
+### Creating a New Skill
+
+**Option A — single SKILL.md file:**
+
+```bash
+python3 tools/loma_skills.py create \
+  --slug <skill-name> \
+  --skill-md /path/to/SKILL.md \
+  --user-email <email> \
+  --auth-token <token>
+```
+
+Then add any extra files (scripts, additional docs) one at a time:
+
+```bash
+python3 tools/loma_skills.py update-file \
+  --slug <skill-name> \
+  --path tools/<name>.py \
+  --content-file /path/to/local/<name>.py \
+  --user-email <email> \
+  --auth-token <token>
+```
+
+**Option B — import a full skill directory** (SKILL.md + scripts/assets in one shot):
+
+```bash
+python3 tools/loma_skills.py import-dir \
+  --source /path/to/<skill-name>/ \
+  --user-email <email> \
+  --auth-token <token>
+```
+
+### Updating an Existing Skill
+
+Editing is per-file. Update the SKILL.md (or any other file) by pointing `--path` at the file within the skill and `--content-file` at your local edited copy:
+
+```bash
+python3 tools/loma_skills.py update-file \
+  --slug <skill-name> \
+  --path SKILL.md \
+  --content-file /path/to/edited/SKILL.md \
+  --user-email <email> \
+  --auth-token <token>
+```
+
+Use the same command with a different `--path` to add or replace additional files.
+
+### Verify the Change
+
+Fetch the skill back to confirm the new content landed:
+
+```bash
+python3 tools/loma_skills.py get --slug <skill-name>
+```
+
+### Notify About New Environment Variables
+
+If the new tool requires environment variables that are **not already in `.env`**, tell the user:
+
+> "The new `tools/<service>.py` requires these environment variables that aren't in your `.env` yet: `VAR_1`, `VAR_2`. Please add them to the environment before using the skill."
+
+---
+
+## 10. Quick Reference — Existing Skills by Type
+
+### Tool-Based Skills (CLI tool in `tools/`) — GOOD PATTERN
+
+| Skill | Tool | Notes |
+|-------|------|-------|
+| `pylon-support` | `tools/pylon.py` | Best reference — manual flag parsing, stdin for HTML |
+| `apollo` | `tools/apollo.py` | Argparse, many subcommands |
+| `grain` | `tools/grain.py` | Simple subcommands |
+| `slack-reader` | `tools/slack_reader.py` | Argparse with subparsers |
+| `dataroom` | `tools/dataroom.py` | Manual flag parsing |
+| `phantombuster` | `tools/phantombuster.py` | Simple CLI |
+| `gmail` (personal) | `tools/gmail.py` | Argparse, user-scoped OAuth |
+
+### MCP-Based Skills — GOOD PATTERN
+
+| Skill | MCP Server(s) |
+|-------|---------------|
+| `debugging` | MongoDB, ClickHouse, Athena |
+| `code-review` | GitHub |
+| `improve-docs` | GitHub, Notion |
+| `self-improvement` | GitHub |
+| `implement-ticket` | Linear, GitHub |
+
+### Workflow-Only Skills — GOOD PATTERN
+
+| Skill | Purpose |
+|-------|---------|
+| `bug-triage` | Bug investigation playbook |
+| `feature-request-triage` | Feature request analysis |
+| `campaign-visibility` | Campaign debugging playbook |
+| `integration-check` | SDK integration assessment |
+| `database-reference` | Schema documentation |
+| `infosec` | Security questionnaire filling |
+
+### Curl-Based Skills — MIGRATE THESE
+
+| Skill | Primary Issue | Migration Priority |
+|-------|--------------|-------------------|
+| `monetize-now` | Wrong auth headers, URL path doubling | High |
+| `zoho-books` | Manual OAuth refresh, massive curl blocks | High |

--- a/seed/skills/mcp-builder/SKILL.md
+++ b/seed/skills/mcp-builder/SKILL.md
@@ -1,0 +1,236 @@
+---
+name: mcp-builder
+description: Guide for creating high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. Use when building MCP servers to integrate external APIs or services, whether in Python (FastMCP) or Node/TypeScript (MCP SDK).
+user-invocable: false
+---
+
+# MCP Server Development Guide
+
+## Overview
+
+Create MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. The quality of an MCP server is measured by how well it enables LLMs to accomplish real-world tasks.
+
+---
+
+# Process
+
+## 🚀 High-Level Workflow
+
+Creating a high-quality MCP server involves four main phases:
+
+### Phase 1: Deep Research and Planning
+
+#### 1.1 Understand Modern MCP Design
+
+**API Coverage vs. Workflow Tools:**
+Balance comprehensive API endpoint coverage with specialized workflow tools. Workflow tools can be more convenient for specific tasks, while comprehensive coverage gives agents flexibility to compose operations. Performance varies by client—some clients benefit from code execution that combines basic tools, while others work better with higher-level workflows. When uncertain, prioritize comprehensive API coverage.
+
+**Tool Naming and Discoverability:**
+Clear, descriptive tool names help agents find the right tools quickly. Use consistent prefixes (e.g., `github_create_issue`, `github_list_repos`) and action-oriented naming.
+
+**Context Management:**
+Agents benefit from concise tool descriptions and the ability to filter/paginate results. Design tools that return focused, relevant data. Some clients support code execution which can help agents filter and process data efficiently.
+
+**Actionable Error Messages:**
+Error messages should guide agents toward solutions with specific suggestions and next steps.
+
+#### 1.2 Study MCP Protocol Documentation
+
+**Navigate the MCP specification:**
+
+Start with the sitemap to find relevant pages: `https://modelcontextprotocol.io/sitemap.xml`
+
+Then fetch specific pages with `.md` suffix for markdown format (e.g., `https://modelcontextprotocol.io/specification/draft.md`).
+
+Key pages to review:
+- Specification overview and architecture
+- Transport mechanisms (streamable HTTP, stdio)
+- Tool, resource, and prompt definitions
+
+#### 1.3 Study Framework Documentation
+
+**Recommended stack:**
+- **Language**: TypeScript (high-quality SDK support and good compatibility in many execution environments e.g. MCPB. Plus AI models are good at generating TypeScript code, benefiting from its broad usage, static typing and good linting tools)
+- **Transport**: Streamable HTTP for remote servers, using stateless JSON (simpler to scale and maintain, as opposed to stateful sessions and streaming responses). stdio for local servers.
+
+**Load framework documentation:**
+
+- **MCP Best Practices**: [📋 View Best Practices](./reference/mcp_best_practices.md) - Core guidelines
+
+**For TypeScript (recommended):**
+- **TypeScript SDK**: Use WebFetch to load `https://raw.githubusercontent.com/modelcontextprotocol/typescript-sdk/main/README.md`
+- [⚡ TypeScript Guide](./reference/node_mcp_server.md) - TypeScript patterns and examples
+
+**For Python:**
+- **Python SDK**: Use WebFetch to load `https://raw.githubusercontent.com/modelcontextprotocol/python-sdk/main/README.md`
+- [🐍 Python Guide](./reference/python_mcp_server.md) - Python patterns and examples
+
+#### 1.4 Plan Your Implementation
+
+**Understand the API:**
+Review the service's API documentation to identify key endpoints, authentication requirements, and data models. Use web search and WebFetch as needed.
+
+**Tool Selection:**
+Prioritize comprehensive API coverage. List endpoints to implement, starting with the most common operations.
+
+---
+
+### Phase 2: Implementation
+
+#### 2.1 Set Up Project Structure
+
+See language-specific guides for project setup:
+- [⚡ TypeScript Guide](./reference/node_mcp_server.md) - Project structure, package.json, tsconfig.json
+- [🐍 Python Guide](./reference/python_mcp_server.md) - Module organization, dependencies
+
+#### 2.2 Implement Core Infrastructure
+
+Create shared utilities:
+- API client with authentication
+- Error handling helpers
+- Response formatting (JSON/Markdown)
+- Pagination support
+
+#### 2.3 Implement Tools
+
+For each tool:
+
+**Input Schema:**
+- Use Zod (TypeScript) or Pydantic (Python)
+- Include constraints and clear descriptions
+- Add examples in field descriptions
+
+**Output Schema:**
+- Define `outputSchema` where possible for structured data
+- Use `structuredContent` in tool responses (TypeScript SDK feature)
+- Helps clients understand and process tool outputs
+
+**Tool Description:**
+- Concise summary of functionality
+- Parameter descriptions
+- Return type schema
+
+**Implementation:**
+- Async/await for I/O operations
+- Proper error handling with actionable messages
+- Support pagination where applicable
+- Return both text content and structured data when using modern SDKs
+
+**Annotations:**
+- `readOnlyHint`: true/false
+- `destructiveHint`: true/false
+- `idempotentHint`: true/false
+- `openWorldHint`: true/false
+
+---
+
+### Phase 3: Review and Test
+
+#### 3.1 Code Quality
+
+Review for:
+- No duplicated code (DRY principle)
+- Consistent error handling
+- Full type coverage
+- Clear tool descriptions
+
+#### 3.2 Build and Test
+
+**TypeScript:**
+- Run `npm run build` to verify compilation
+- Test with MCP Inspector: `npx @modelcontextprotocol/inspector`
+
+**Python:**
+- Verify syntax: `python -m py_compile your_server.py`
+- Test with MCP Inspector
+
+See language-specific guides for detailed testing approaches and quality checklists.
+
+---
+
+### Phase 4: Create Evaluations
+
+After implementing your MCP server, create comprehensive evaluations to test its effectiveness.
+
+**Load [✅ Evaluation Guide](./reference/evaluation.md) for complete evaluation guidelines.**
+
+#### 4.1 Understand Evaluation Purpose
+
+Use evaluations to test whether LLMs can effectively use your MCP server to answer realistic, complex questions.
+
+#### 4.2 Create 10 Evaluation Questions
+
+To create effective evaluations, follow the process outlined in the evaluation guide:
+
+1. **Tool Inspection**: List available tools and understand their capabilities
+2. **Content Exploration**: Use READ-ONLY operations to explore available data
+3. **Question Generation**: Create 10 complex, realistic questions
+4. **Answer Verification**: Solve each question yourself to verify answers
+
+#### 4.3 Evaluation Requirements
+
+Ensure each question is:
+- **Independent**: Not dependent on other questions
+- **Read-only**: Only non-destructive operations required
+- **Complex**: Requiring multiple tool calls and deep exploration
+- **Realistic**: Based on real use cases humans would care about
+- **Verifiable**: Single, clear answer that can be verified by string comparison
+- **Stable**: Answer won't change over time
+
+#### 4.4 Output Format
+
+Create an XML file with this structure:
+
+```xml
+<evaluation>
+  <qa_pair>
+    <question>Find discussions about AI model launches with animal codenames. One model needed a specific safety designation that uses the format ASL-X. What number X was being determined for the model named after a spotted wild cat?</question>
+    <answer>3</answer>
+  </qa_pair>
+<!-- More qa_pairs... -->
+</evaluation>
+```
+
+---
+
+# Reference Files
+
+## 📚 Documentation Library
+
+Load these resources as needed during development:
+
+### Core MCP Documentation (Load First)
+- **MCP Protocol**: Start with sitemap at `https://modelcontextprotocol.io/sitemap.xml`, then fetch specific pages with `.md` suffix
+- [📋 MCP Best Practices](./reference/mcp_best_practices.md) - Universal MCP guidelines including:
+  - Server and tool naming conventions
+  - Response format guidelines (JSON vs Markdown)
+  - Pagination best practices
+  - Transport selection (streamable HTTP vs stdio)
+  - Security and error handling standards
+
+### SDK Documentation (Load During Phase 1/2)
+- **Python SDK**: Fetch from `https://raw.githubusercontent.com/modelcontextprotocol/python-sdk/main/README.md`
+- **TypeScript SDK**: Fetch from `https://raw.githubusercontent.com/modelcontextprotocol/typescript-sdk/main/README.md`
+
+### Language-Specific Implementation Guides (Load During Phase 2)
+- [🐍 Python Implementation Guide](./reference/python_mcp_server.md) - Complete Python/FastMCP guide with:
+  - Server initialization patterns
+  - Pydantic model examples
+  - Tool registration with `@mcp.tool`
+  - Complete working examples
+  - Quality checklist
+
+- [⚡ TypeScript Implementation Guide](./reference/node_mcp_server.md) - Complete TypeScript guide with:
+  - Project structure
+  - Zod schema patterns
+  - Tool registration with `server.registerTool`
+  - Complete working examples
+  - Quality checklist
+
+### Evaluation Guide (Load During Phase 4)
+- [✅ Evaluation Guide](./reference/evaluation.md) - Complete evaluation creation guide with:
+  - Question creation guidelines
+  - Answer verification strategies
+  - XML format specifications
+  - Example questions and answers
+  - Running an evaluation with the provided scripts

--- a/seed/skills/pdf-reading/REFERENCE.md
+++ b/seed/skills/pdf-reading/REFERENCE.md
@@ -1,0 +1,196 @@
+# PDF Processing Advanced Reference
+
+This document contains advanced PDF processing features, detailed examples, and additional libraries not covered in the main skill instructions.
+
+## pypdfium2 Library (Apache/BSD License)
+
+### Overview
+pypdfium2 is a Python binding for PDFium (Chromium's PDF library). It's excellent for fast PDF rendering, image generation, and serves as a PyMuPDF replacement.
+
+### Render PDF to Images
+```python
+import pypdfium2 as pdfium
+from PIL import Image
+
+# Load PDF
+pdf = pdfium.PdfDocument("document.pdf")
+
+# Render page to image
+page = pdf[0]  # First page
+bitmap = page.render(
+    scale=2.0,  # Higher resolution
+    rotation=0  # No rotation
+)
+
+# Convert to PIL Image
+img = bitmap.to_pil()
+img.save("page_1.png", "PNG")
+
+# Process multiple pages
+for i, page in enumerate(pdf):
+    bitmap = page.render(scale=1.5)
+    img = bitmap.to_pil()
+    img.save(f"page_{i+1}.jpg", "JPEG", quality=90)
+```
+
+### Extract Text with pypdfium2
+```python
+import pypdfium2 as pdfium
+
+pdf = pdfium.PdfDocument("document.pdf")
+for i, page in enumerate(pdf):
+    textpage = page.get_textpage()
+    text = textpage.get_text_range()
+    print(f"Page {i+1} text length: {len(text)} chars")
+```
+
+## Advanced Command-Line Operations
+
+### poppler-utils Advanced Features
+
+#### Extract Text with Bounding Box Coordinates
+```bash
+# Extract text with bounding box coordinates (essential for structured data)
+pdftotext -bbox-layout document.pdf output.xml
+
+# The XML output contains precise coordinates for each text element
+```
+
+#### Advanced Image Conversion
+```bash
+# Convert to PNG images with specific resolution
+pdftoppm -png -r 300 document.pdf output_prefix
+
+# Convert specific page range with high resolution
+pdftoppm -png -r 600 -f 1 -l 3 document.pdf high_res_pages
+
+# Convert to JPEG with quality setting
+pdftoppm -jpeg -jpegopt quality=85 -r 200 document.pdf jpeg_output
+```
+
+#### Extract Embedded Images
+```bash
+# Extract all embedded images with metadata
+pdfimages -j -p document.pdf page_images
+
+# List image info without extracting
+pdfimages -list document.pdf
+
+# Extract images in their original format
+pdfimages -all document.pdf images/img
+```
+
+### qpdf Advanced Features
+
+For qpdf page manipulation, optimization, encryption, and repair,
+see `/mnt/skills/public/pdf/SKILL.md`.
+
+Useful qpdf reading/inspection commands:
+```bash
+# Check PDF structure for errors
+qpdf --check input.pdf
+
+# Show detailed PDF structure for debugging
+qpdf --show-pages input.pdf > structure.txt
+
+# Check encryption status
+qpdf --show-encryption encrypted.pdf
+
+# Remove password protection (requires password) for reading
+qpdf --password=secret123 --decrypt encrypted.pdf decrypted.pdf
+```
+
+## Advanced Python Techniques
+
+### pdfplumber Advanced Features
+
+#### Extract Text with Precise Coordinates
+```python
+import pdfplumber
+
+with pdfplumber.open("document.pdf") as pdf:
+    page = pdf.pages[0]
+    
+    # Extract all text with coordinates
+    chars = page.chars
+    for char in chars[:10]:  # First 10 characters
+        print(f"Char: '{char['text']}' at x:{char['x0']:.1f} y:{char['y0']:.1f}")
+    
+    # Extract text by bounding box (left, top, right, bottom)
+    bbox_text = page.within_bbox((100, 100, 400, 200)).extract_text()
+```
+
+#### Advanced Table Extraction with Custom Settings
+```python
+import pdfplumber
+import pandas as pd
+
+with pdfplumber.open("complex_table.pdf") as pdf:
+    page = pdf.pages[0]
+    
+    # Extract tables with custom settings for complex layouts
+    table_settings = {
+        "vertical_strategy": "lines",
+        "horizontal_strategy": "lines",
+        "snap_tolerance": 3,
+        "intersection_tolerance": 15
+    }
+    tables = page.extract_tables(table_settings)
+    
+    # Visual debugging for table extraction
+    img = page.to_image(resolution=150)
+    img.save("debug_layout.png")
+```
+
+## Performance Optimization Tips
+
+- `pdftotext` (CLI) is fastest for plain text extraction (`-layout` for spatial positioning)
+- Use pdfplumber for structured data and tables; avoid `pypdf.extract_text()` on very large documents
+- `pdfimages` is much faster than rendering pages for image extraction
+- For large PDFs, process pages individually rather than loading everything into memory
+
+## Troubleshooting Common Issues
+
+### Encrypted PDFs
+```python
+# Handle password-protected PDFs
+from pypdf import PdfReader
+
+try:
+    reader = PdfReader("encrypted.pdf")
+    if reader.is_encrypted:
+        reader.decrypt("password")
+except Exception as e:
+    print(f"Failed to decrypt: {e}")
+```
+
+### Corrupted PDFs
+```bash
+# Use qpdf to repair
+qpdf --check corrupted.pdf
+qpdf --replace-input corrupted.pdf
+```
+
+### Text Extraction Issues
+```python
+# Fallback to OCR for scanned PDFs
+import pytesseract
+from pdf2image import convert_from_path
+
+def extract_text_with_ocr(pdf_path):
+    images = convert_from_path(pdf_path)
+    text = ""
+    for i, image in enumerate(images):
+        text += pytesseract.image_to_string(image)
+    return text
+```
+
+## License Information
+
+- **pypdf**: BSD License
+- **pdfplumber**: MIT License
+- **pypdfium2**: Apache/BSD License
+- **PyMuPDF (fitz)**: AGPL-3.0 License — copyleft; commercial licenses available from Artifex
+- **poppler-utils**: GPL-2 License
+- **qpdf**: Apache License
+- **pytesseract**: Apache License (Tesseract engine: Apache License)

--- a/seed/skills/pdf-reading/SKILL.md
+++ b/seed/skills/pdf-reading/SKILL.md
@@ -1,0 +1,305 @@
+---
+name: pdf-reading
+description: "Use this skill when you need to read, inspect, or extract content from PDF files — especially when file content is NOT in your context and you need to read it from disk. Covers content inventory, text extraction, page rasterization for visual inspection, embedded image/attachment/table/form-field extraction, and choosing the right reading strategy for different document types (text-heavy, scanned, slide-decks, forms, data-heavy). Do NOT use this skill for PDF creation, form filling, merging, splitting, watermarking, or encryption — use the pdf skill instead."
+user-invocable: false
+---
+
+# PDF Processing Guide
+
+## Overview
+
+This guide covers essential PDF reading operations using Python libraries and command-line tools. For advanced features (pypdfium2 rendering, pdfplumber table settings, OCR fallback, encrypted/corrupted PDF handling), see REFERENCE.md.
+
+## Reading & Inspecting PDFs
+
+Before doing anything with a PDF, understand what you're working with.
+
+### Content inventory
+
+Run a quick diagnostic first. For simple tasks ("summarize this
+document"), `pdfinfo` + a text sample may suffice. For anything
+involving figures, attachments, or extraction issues, run the full set:
+
+```bash
+# Always: page count, file size, PDF version, metadata
+pdfinfo document.pdf
+
+# Always: quick text extraction check — is this a text PDF or a scan?
+pdftotext -f 1 -l 1 document.pdf - | head -20
+
+# If figures/charts may matter:
+pdfimages -list document.pdf
+
+# If the PDF might contain embedded files (reports, portfolios):
+pdfdetach -list document.pdf
+
+# If text extraction looks garbled:
+pdffonts document.pdf
+```
+
+This tells you:
+- **Page count and size** — how big is the job?
+- **Text extractability** — does `pdftotext` return real text, or is
+  it empty (scanned) or garbled (broken font encoding)?
+- **Embedded raster images** — are there photos or raster figures?
+  (Note: vector-drawn charts from matplotlib/Excel won't appear — see
+  "Extracting embedded images" below)
+- **Attachments** — are there embedded spreadsheets, data files, etc.?
+- **Font status** — are fonts embedded? If not, text extraction may
+  produce wrong characters.
+
+### Text extraction
+
+**pypdf** for basic text:
+```python
+from pypdf import PdfReader
+
+reader = PdfReader("document.pdf")
+print(f"Pages: {len(reader.pages)}")
+
+# Extract text
+text = ""
+for page in reader.pages:
+    text += page.extract_text()
+```
+
+**pdftotext** preserving layout (better for multi-column docs):
+```bash
+# Layout mode preserves spatial positioning
+pdftotext -layout document.pdf output.txt
+
+# Specific page range
+pdftotext -f 1 -l 5 document.pdf output.txt
+```
+
+**pdfplumber** for layout-aware extraction with positioning data:
+```python
+import pdfplumber
+
+with pdfplumber.open("document.pdf") as pdf:
+    for page in pdf.pages:
+        text = page.extract_text()
+        print(text)
+```
+
+### Visual inspection (rasterize pages)
+
+Text extraction is **blind** to charts, diagrams, figures, equations,
+multi-column layout, and form structures. When any of these matter,
+rasterize the relevant page and Read the image:
+
+```bash
+# Rasterize a single page (page 3 here) at 150 DPI
+pdftoppm -jpeg -r 150 -f 3 -l 3 document.pdf /tmp/page
+
+# pdftoppm zero-pads the output filename based on TOTAL page count
+# (e.g., page-03.jpg for a 50-page PDF, page-003.jpg for 200+ pages)
+# Don't guess the filename — find it:
+ls /tmp/page-*.jpg
+```
+
+Then Read the resulting image file. This gives you full visual
+understanding of that page — layout, charts, equations, everything.
+
+**When to rasterize vs. text-extract:**
+- **Content/data questions → text extraction** (cheaper, searchable)
+- **Figures, charts, visual layout → rasterize the page**
+- **Tables → try text extraction first, rasterize if garbled**
+- **Precision matters → do both** (extract text AND rasterize; use text
+  for data, image for context — this is what Claude's API does natively
+  with PDF uploads)
+
+**Token cost awareness:**
+- Text extraction: ~200–400 tokens per page
+- Rasterized image: ~1,600 tokens per page (at 150 DPI)
+- Both together: ~2,000–2,400 tokens per page
+
+For a 100-page PDF, rasterizing everything would consume ~160K tokens.
+Only rasterize pages that matter for the question at hand.
+
+### Choosing your reading strategy
+
+**Text-heavy documents** (reports, articles, books):
+→ Text extraction is primary. Rasterize only for specific figures or
+  pages where layout matters.
+
+**Scanned documents** (no extractable text):
+→ Rasterize pages at 150 DPI and Read them visually. For bulk text
+  extraction, use OCR (pytesseract after converting pages to images —
+  see REFERENCE.md for a complete example).
+
+**Slide-deck PDFs** (exported presentations):
+→ Every page is primarily visual. Rasterize individual pages on demand.
+  Text extraction gives you bullet-point text but loses all layout.
+
+**Form-heavy documents**:
+→ Extract form field values programmatically first (see below). Rasterize
+  the form page for visual context if needed.
+
+**Data-heavy documents** (tables, charts, figures):
+→ Use pdfplumber for tables. Rasterize pages with charts/figures.
+  Extract text for surrounding narrative. Consider both text AND image
+  for the same page when precision matters.
+
+### Extracting embedded images
+
+```bash
+# List all embedded images with metadata (size, color, compression)
+pdfimages -list document.pdf
+
+# Extract all images as PNG
+pdfimages -png document.pdf /tmp/img
+
+# Extract from specific pages only (pages 3-5)
+pdfimages -png -f 3 -l 5 document.pdf /tmp/img
+
+# Extract in original format (JPEG stays JPEG, etc.)
+pdfimages -all document.pdf /tmp/img
+```
+
+Then Read `/tmp/img-000.png` (etc.) to see each extracted image.
+
+**Gotcha — vector graphics:** `pdfimages` extracts only raster image
+data. Charts and diagrams drawn as vector graphics (common in
+matplotlib, Excel, and R exports) will NOT appear — they are page
+content operators, not image objects. For these, rasterize the whole
+page with `pdftoppm` instead.
+
+**Gotcha — empty images:** `pdfimages` sometimes produces many tiny or
+empty image files — these are typically background masks, transparency
+layers, or decorative elements. Filter by file size to find the real
+content images.
+
+Programmatic extraction with position data:
+```python
+import fitz  # PyMuPDF
+
+doc = fitz.open("document.pdf")
+for page in doc:
+    for img in page.get_images():
+        xref = img[0]
+        pix = fitz.Pixmap(doc, xref)
+        if pix.n - pix.alpha > 3:  # CMYK or other non-RGB
+            pix = fitz.Pixmap(fitz.csRGB, pix)
+        pix.save(f"/tmp/img_{xref}.png")
+```
+
+### Extracting file attachments
+
+PDFs can contain embedded files — spreadsheets, data files, other
+documents. Common in business reports, PDF portfolios, and PDF/A-3
+compliance documents.
+
+```bash
+# List all attachments
+pdfdetach -list document.pdf
+
+# Extract all attachments to a directory
+mkdir -p /tmp/attachments
+pdfdetach -saveall -o /tmp/attachments/ document.pdf
+
+# Extract a specific attachment by number (1-based index from -list output)
+pdfdetach -save 1 -o /tmp/attachment.pdf document.pdf
+```
+
+In Python:
+```python
+import os
+from pypdf import PdfReader
+
+reader = PdfReader("document.pdf")
+for name, content_list in reader.attachments.items():
+    safe_name = os.path.basename(name)  # sanitize — name comes from the PDF
+    for content in content_list:
+        with open(f"/tmp/{safe_name}", "wb") as f:
+            f.write(content)
+```
+
+**Two attachment mechanisms exist in PDFs:** page-level file annotation
+attachments (shown as paperclip icons in viewers) and document-level
+embedded files (in the EmbeddedFiles name tree). Both `pdfdetach` and
+pypdf handle the common cases. Rich media assets (3D, video) embedded
+as annotations may not appear in the attachment list — use PyMuPDF to
+iterate page annotations for those.
+
+### Extracting form field data
+
+PDFs with interactive forms (government forms, applications, contracts)
+have fillable fields whose values can be read programmatically:
+
+```python
+from pypdf import PdfReader
+
+reader = PdfReader("form.pdf")
+
+# Text input fields only:
+fields = reader.get_form_text_fields()
+for name, value in fields.items():
+    print(f"{name}: {value}")
+
+# All field types (checkboxes, radio buttons, dropdowns too):
+all_fields = reader.get_fields() or {}
+for name, field in all_fields.items():
+    print(f"{name}: {field.get('/V', '')} (type: {field.get('/FT', '')})")
+```
+
+`get_form_text_fields()` returns only text input fields. For
+government forms and contracts that use checkboxes, radio buttons,
+and dropdowns, use `get_fields()` instead to see all field types.
+
+For comprehensive field info (types, options, defaults):
+```bash
+pdftk form.pdf dump_data_fields
+```
+
+For anything beyond reading form data — filling forms, creating forms —
+use the pdf skill at `/mnt/skills/public/pdf/SKILL.md`.
+
+### Audio, video, and other rare embedded content
+
+PDFs can occasionally embed audio, video, or 3D models. Check
+`pdfdetach -list` first — if the media appears as an attachment,
+extract with `pdfdetach -saveall`. If not, it may be a Rich Media
+annotation (harder to extract; requires PyMuPDF to iterate page
+annotations). This is very rare in practice. Most PDF viewers outside
+Adobe Acrobat do not support media playback.
+
+### Font diagnostics
+
+If text extraction produces garbled output (wrong characters, missing
+text, mojibake), check the font situation:
+
+```bash
+pdffonts document.pdf
+```
+
+Look at the "emb" column — if fonts show "no" (not embedded) with
+custom encodings, the PDF's character mapping may be broken for text
+extraction. In that case, rasterize the page and use vision instead.
+
+Also check encoding: fonts with "Custom" or "Identity-H" encoding
+without embedded CIDToGID maps can cause character substitution issues
+even when the font is technically embedded.
+
+---
+
+## Quick Reference
+
+| Task | Best Tool | Command/Code |
+|------|-----------|--------------|
+| Inspect PDF | poppler-utils | `pdfinfo`, `pdfimages -list`, `pdfdetach -list`, `pdffonts` |
+| Extract text | pdfplumber | `page.extract_text()` |
+| Extract text (CLI) | pdftotext | `pdftotext -layout input.pdf output.txt` |
+| Extract tables | pdfplumber | `page.extract_tables()` |
+| See page visually | pdftoppm | `pdftoppm -jpeg -r 150 -f N -l N` |
+| Extract images | pdfimages | `pdfimages -png input.pdf prefix` |
+| Extract attachments | pdfdetach | `pdfdetach -saveall -o /tmp/` |
+| Read form fields | pypdf | `reader.get_fields()` |
+| OCR scanned PDFs | pytesseract | Convert to image first |
+
+## PDF Form Filling, Creation, Merging, Splitting, and Other Operations
+
+This skill covers **reading and inspection** only. For filling forms,
+creating, merging, splitting, rotating, watermarking, encrypting, or
+other PDF manipulation tasks, use the public pdf skill at
+`/mnt/skills/public/pdf/SKILL.md`.

--- a/seed/skills/pdf/FORMS.md
+++ b/seed/skills/pdf/FORMS.md
@@ -1,0 +1,294 @@
+**CRITICAL: You MUST complete these steps in order. Do not skip ahead to writing code.**
+
+If you need to fill out a PDF form, first check to see if the PDF has fillable form fields. Run this script from this file's directory:
+ `python scripts/check_fillable_fields <file.pdf>`, and depending on the result go to either the "Fillable fields" or "Non-fillable fields" and follow those instructions.
+
+# Fillable fields
+If the PDF has fillable form fields:
+- Run this script from this file's directory: `python scripts/extract_form_field_info.py <input.pdf> <field_info.json>`. It will create a JSON file with a list of fields in this format:
+```
+[
+  {
+    "field_id": (unique ID for the field),
+    "page": (page number, 1-based),
+    "rect": ([left, bottom, right, top] bounding box in PDF coordinates, y=0 is the bottom of the page),
+    "type": ("text", "checkbox", "radio_group", or "choice"),
+  },
+  // Checkboxes have "checked_value" and "unchecked_value" properties:
+  {
+    "field_id": (unique ID for the field),
+    "page": (page number, 1-based),
+    "type": "checkbox",
+    "checked_value": (Set the field to this value to check the checkbox),
+    "unchecked_value": (Set the field to this value to uncheck the checkbox),
+  },
+  // Radio groups have a "radio_options" list with the possible choices.
+  {
+    "field_id": (unique ID for the field),
+    "page": (page number, 1-based),
+    "type": "radio_group",
+    "radio_options": [
+      {
+        "value": (set the field to this value to select this radio option),
+        "rect": (bounding box for the radio button for this option)
+      },
+      // Other radio options
+    ]
+  },
+  // Multiple choice fields have a "choice_options" list with the possible choices:
+  {
+    "field_id": (unique ID for the field),
+    "page": (page number, 1-based),
+    "type": "choice",
+    "choice_options": [
+      {
+        "value": (set the field to this value to select this option),
+        "text": (display text of the option)
+      },
+      // Other choice options
+    ],
+  }
+]
+```
+- Convert the PDF to PNGs (one image for each page) with this script (run from this file's directory):
+`python scripts/convert_pdf_to_images.py <file.pdf> <output_directory>`
+Then analyze the images to determine the purpose of each form field (make sure to convert the bounding box PDF coordinates to image coordinates).
+- Create a `field_values.json` file in this format with the values to be entered for each field:
+```
+[
+  {
+    "field_id": "last_name", // Must match the field_id from `extract_form_field_info.py`
+    "description": "The user's last name",
+    "page": 1, // Must match the "page" value in field_info.json
+    "value": "Simpson"
+  },
+  {
+    "field_id": "Checkbox12",
+    "description": "Checkbox to be checked if the user is 18 or over",
+    "page": 1,
+    "value": "/On" // If this is a checkbox, use its "checked_value" value to check it. If it's a radio button group, use one of the "value" values in "radio_options".
+  },
+  // more fields
+]
+```
+- Run the `fill_fillable_fields.py` script from this file's directory to create a filled-in PDF:
+`python scripts/fill_fillable_fields.py <input pdf> <field_values.json> <output pdf>`
+This script will verify that the field IDs and values you provide are valid; if it prints error messages, correct the appropriate fields and try again.
+
+# Non-fillable fields
+If the PDF doesn't have fillable form fields, you'll add text annotations. First try to extract coordinates from the PDF structure (more accurate), then fall back to visual estimation if needed.
+
+## Step 1: Try Structure Extraction First
+
+Run this script to extract text labels, lines, and checkboxes with their exact PDF coordinates:
+`python scripts/extract_form_structure.py <input.pdf> form_structure.json`
+
+This creates a JSON file containing:
+- **labels**: Every text element with exact coordinates (x0, top, x1, bottom in PDF points)
+- **lines**: Horizontal lines that define row boundaries
+- **checkboxes**: Small square rectangles that are checkboxes (with center coordinates)
+- **row_boundaries**: Row top/bottom positions calculated from horizontal lines
+
+**Check the results**: If `form_structure.json` has meaningful labels (text elements that correspond to form fields), use **Approach A: Structure-Based Coordinates**. If the PDF is scanned/image-based and has few or no labels, use **Approach B: Visual Estimation**.
+
+---
+
+## Approach A: Structure-Based Coordinates (Preferred)
+
+Use this when `extract_form_structure.py` found text labels in the PDF.
+
+### A.1: Analyze the Structure
+
+Read form_structure.json and identify:
+
+1. **Label groups**: Adjacent text elements that form a single label (e.g., "Last" + "Name")
+2. **Row structure**: Labels with similar `top` values are in the same row
+3. **Field columns**: Entry areas start after label ends (x0 = label.x1 + gap)
+4. **Checkboxes**: Use the checkbox coordinates directly from the structure
+
+**Coordinate system**: PDF coordinates where y=0 is at TOP of page, y increases downward.
+
+### A.2: Check for Missing Elements
+
+The structure extraction may not detect all form elements. Common cases:
+- **Circular checkboxes**: Only square rectangles are detected as checkboxes
+- **Complex graphics**: Decorative elements or non-standard form controls
+- **Faded or light-colored elements**: May not be extracted
+
+If you see form fields in the PDF images that aren't in form_structure.json, you'll need to use **visual analysis** for those specific fields (see "Hybrid Approach" below).
+
+### A.3: Create fields.json with PDF Coordinates
+
+For each field, calculate entry coordinates from the extracted structure:
+
+**Text fields:**
+- entry x0 = label x1 + 5 (small gap after label)
+- entry x1 = next label's x0, or row boundary
+- entry top = same as label top
+- entry bottom = row boundary line below, or label bottom + row_height
+
+**Checkboxes:**
+- Use the checkbox rectangle coordinates directly from form_structure.json
+- entry_bounding_box = [checkbox.x0, checkbox.top, checkbox.x1, checkbox.bottom]
+
+Create fields.json using `pdf_width` and `pdf_height` (signals PDF coordinates):
+```json
+{
+  "pages": [
+    {"page_number": 1, "pdf_width": 612, "pdf_height": 792}
+  ],
+  "form_fields": [
+    {
+      "page_number": 1,
+      "description": "Last name entry field",
+      "field_label": "Last Name",
+      "label_bounding_box": [43, 63, 87, 73],
+      "entry_bounding_box": [92, 63, 260, 79],
+      "entry_text": {"text": "Smith", "font_size": 10}
+    },
+    {
+      "page_number": 1,
+      "description": "US Citizen Yes checkbox",
+      "field_label": "Yes",
+      "label_bounding_box": [260, 200, 280, 210],
+      "entry_bounding_box": [285, 197, 292, 205],
+      "entry_text": {"text": "X"}
+    }
+  ]
+}
+```
+
+**Important**: Use `pdf_width`/`pdf_height` and coordinates directly from form_structure.json.
+
+### A.4: Validate Bounding Boxes
+
+Before filling, check your bounding boxes for errors:
+`python scripts/check_bounding_boxes.py fields.json`
+
+This checks for intersecting bounding boxes and entry boxes that are too small for the font size. Fix any reported errors before filling.
+
+---
+
+## Approach B: Visual Estimation (Fallback)
+
+Use this when the PDF is scanned/image-based and structure extraction found no usable text labels (e.g., all text shows as "(cid:X)" patterns).
+
+### B.1: Convert PDF to Images
+
+`python scripts/convert_pdf_to_images.py <input.pdf> <images_dir/>`
+
+### B.2: Initial Field Identification
+
+Examine each page image to identify form sections and get **rough estimates** of field locations:
+- Form field labels and their approximate positions
+- Entry areas (lines, boxes, or blank spaces for text input)
+- Checkboxes and their approximate locations
+
+For each field, note approximate pixel coordinates (they don't need to be precise yet).
+
+### B.3: Zoom Refinement (CRITICAL for accuracy)
+
+For each field, crop a region around the estimated position to refine coordinates precisely.
+
+**Create a zoomed crop using ImageMagick:**
+```bash
+magick <page_image> -crop <width>x<height>+<x>+<y> +repage <crop_output.png>
+```
+
+Where:
+- `<x>, <y>` = top-left corner of crop region (use your rough estimate minus padding)
+- `<width>, <height>` = size of crop region (field area plus ~50px padding on each side)
+
+**Example:** To refine a "Name" field estimated around (100, 150):
+```bash
+magick images_dir/page_1.png -crop 300x80+50+120 +repage crops/name_field.png
+```
+
+(Note: if the `magick` command isn't available, try `convert` with the same arguments).
+
+**Examine the cropped image** to determine precise coordinates:
+1. Identify the exact pixel where the entry area begins (after the label)
+2. Identify where the entry area ends (before next field or edge)
+3. Identify the top and bottom of the entry line/box
+
+**Convert crop coordinates back to full image coordinates:**
+- full_x = crop_x + crop_offset_x
+- full_y = crop_y + crop_offset_y
+
+Example: If the crop started at (50, 120) and the entry box starts at (52, 18) within the crop:
+- entry_x0 = 52 + 50 = 102
+- entry_top = 18 + 120 = 138
+
+**Repeat for each field**, grouping nearby fields into single crops when possible.
+
+### B.4: Create fields.json with Refined Coordinates
+
+Create fields.json using `image_width` and `image_height` (signals image coordinates):
+```json
+{
+  "pages": [
+    {"page_number": 1, "image_width": 1700, "image_height": 2200}
+  ],
+  "form_fields": [
+    {
+      "page_number": 1,
+      "description": "Last name entry field",
+      "field_label": "Last Name",
+      "label_bounding_box": [120, 175, 242, 198],
+      "entry_bounding_box": [255, 175, 720, 218],
+      "entry_text": {"text": "Smith", "font_size": 10}
+    }
+  ]
+}
+```
+
+**Important**: Use `image_width`/`image_height` and the refined pixel coordinates from the zoom analysis.
+
+### B.5: Validate Bounding Boxes
+
+Before filling, check your bounding boxes for errors:
+`python scripts/check_bounding_boxes.py fields.json`
+
+This checks for intersecting bounding boxes and entry boxes that are too small for the font size. Fix any reported errors before filling.
+
+---
+
+## Hybrid Approach: Structure + Visual
+
+Use this when structure extraction works for most fields but misses some elements (e.g., circular checkboxes, unusual form controls).
+
+1. **Use Approach A** for fields that were detected in form_structure.json
+2. **Convert PDF to images** for visual analysis of missing fields
+3. **Use zoom refinement** (from Approach B) for the missing fields
+4. **Combine coordinates**: For fields from structure extraction, use `pdf_width`/`pdf_height`. For visually-estimated fields, you must convert image coordinates to PDF coordinates:
+   - pdf_x = image_x * (pdf_width / image_width)
+   - pdf_y = image_y * (pdf_height / image_height)
+5. **Use a single coordinate system** in fields.json - convert all to PDF coordinates with `pdf_width`/`pdf_height`
+
+---
+
+## Step 2: Validate Before Filling
+
+**Always validate bounding boxes before filling:**
+`python scripts/check_bounding_boxes.py fields.json`
+
+This checks for:
+- Intersecting bounding boxes (which would cause overlapping text)
+- Entry boxes that are too small for the specified font size
+
+Fix any reported errors in fields.json before proceeding.
+
+## Step 3: Fill the Form
+
+The fill script auto-detects the coordinate system and handles conversion:
+`python scripts/fill_pdf_form_with_annotations.py <input.pdf> fields.json <output.pdf>`
+
+## Step 4: Verify Output
+
+Convert the filled PDF to images and verify text placement:
+`python scripts/convert_pdf_to_images.py <output.pdf> <verify_images/>`
+
+If text is mispositioned:
+- **Approach A**: Check that you're using PDF coordinates from form_structure.json with `pdf_width`/`pdf_height`
+- **Approach B**: Check that image dimensions match and coordinates are accurate pixels
+- **Hybrid**: Ensure coordinate conversions are correct for visually-estimated fields

--- a/seed/skills/pdf/REFERENCE.md
+++ b/seed/skills/pdf/REFERENCE.md
@@ -1,0 +1,612 @@
+# PDF Processing Advanced Reference
+
+This document contains advanced PDF processing features, detailed examples, and additional libraries not covered in the main skill instructions.
+
+## pypdfium2 Library (Apache/BSD License)
+
+### Overview
+pypdfium2 is a Python binding for PDFium (Chromium's PDF library). It's excellent for fast PDF rendering, image generation, and serves as a PyMuPDF replacement.
+
+### Render PDF to Images
+```python
+import pypdfium2 as pdfium
+from PIL import Image
+
+# Load PDF
+pdf = pdfium.PdfDocument("document.pdf")
+
+# Render page to image
+page = pdf[0]  # First page
+bitmap = page.render(
+    scale=2.0,  # Higher resolution
+    rotation=0  # No rotation
+)
+
+# Convert to PIL Image
+img = bitmap.to_pil()
+img.save("page_1.png", "PNG")
+
+# Process multiple pages
+for i, page in enumerate(pdf):
+    bitmap = page.render(scale=1.5)
+    img = bitmap.to_pil()
+    img.save(f"page_{i+1}.jpg", "JPEG", quality=90)
+```
+
+### Extract Text with pypdfium2
+```python
+import pypdfium2 as pdfium
+
+pdf = pdfium.PdfDocument("document.pdf")
+for i, page in enumerate(pdf):
+    text = page.get_text()
+    print(f"Page {i+1} text length: {len(text)} chars")
+```
+
+## JavaScript Libraries
+
+### pdf-lib (MIT License)
+
+pdf-lib is a powerful JavaScript library for creating and modifying PDF documents in any JavaScript environment.
+
+#### Load and Manipulate Existing PDF
+```javascript
+import { PDFDocument } from 'pdf-lib';
+import fs from 'fs';
+
+async function manipulatePDF() {
+    // Load existing PDF
+    const existingPdfBytes = fs.readFileSync('input.pdf');
+    const pdfDoc = await PDFDocument.load(existingPdfBytes);
+
+    // Get page count
+    const pageCount = pdfDoc.getPageCount();
+    console.log(`Document has ${pageCount} pages`);
+
+    // Add new page
+    const newPage = pdfDoc.addPage([600, 400]);
+    newPage.drawText('Added by pdf-lib', {
+        x: 100,
+        y: 300,
+        size: 16
+    });
+
+    // Save modified PDF
+    const pdfBytes = await pdfDoc.save();
+    fs.writeFileSync('modified.pdf', pdfBytes);
+}
+```
+
+#### Create Complex PDFs from Scratch
+```javascript
+import { PDFDocument, rgb, StandardFonts } from 'pdf-lib';
+import fs from 'fs';
+
+async function createPDF() {
+    const pdfDoc = await PDFDocument.create();
+
+    // Add fonts
+    const helveticaFont = await pdfDoc.embedFont(StandardFonts.Helvetica);
+    const helveticaBold = await pdfDoc.embedFont(StandardFonts.HelveticaBold);
+
+    // Add page
+    const page = pdfDoc.addPage([595, 842]); // A4 size
+    const { width, height } = page.getSize();
+
+    // Add text with styling
+    page.drawText('Invoice #12345', {
+        x: 50,
+        y: height - 50,
+        size: 18,
+        font: helveticaBold,
+        color: rgb(0.2, 0.2, 0.8)
+    });
+
+    // Add rectangle (header background)
+    page.drawRectangle({
+        x: 40,
+        y: height - 100,
+        width: width - 80,
+        height: 30,
+        color: rgb(0.9, 0.9, 0.9)
+    });
+
+    // Add table-like content
+    const items = [
+        ['Item', 'Qty', 'Price', 'Total'],
+        ['Widget', '2', '$50', '$100'],
+        ['Gadget', '1', '$75', '$75']
+    ];
+
+    let yPos = height - 150;
+    items.forEach(row => {
+        let xPos = 50;
+        row.forEach(cell => {
+            page.drawText(cell, {
+                x: xPos,
+                y: yPos,
+                size: 12,
+                font: helveticaFont
+            });
+            xPos += 120;
+        });
+        yPos -= 25;
+    });
+
+    const pdfBytes = await pdfDoc.save();
+    fs.writeFileSync('created.pdf', pdfBytes);
+}
+```
+
+#### Advanced Merge and Split Operations
+```javascript
+import { PDFDocument } from 'pdf-lib';
+import fs from 'fs';
+
+async function mergePDFs() {
+    // Create new document
+    const mergedPdf = await PDFDocument.create();
+
+    // Load source PDFs
+    const pdf1Bytes = fs.readFileSync('doc1.pdf');
+    const pdf2Bytes = fs.readFileSync('doc2.pdf');
+
+    const pdf1 = await PDFDocument.load(pdf1Bytes);
+    const pdf2 = await PDFDocument.load(pdf2Bytes);
+
+    // Copy pages from first PDF
+    const pdf1Pages = await mergedPdf.copyPages(pdf1, pdf1.getPageIndices());
+    pdf1Pages.forEach(page => mergedPdf.addPage(page));
+
+    // Copy specific pages from second PDF (pages 0, 2, 4)
+    const pdf2Pages = await mergedPdf.copyPages(pdf2, [0, 2, 4]);
+    pdf2Pages.forEach(page => mergedPdf.addPage(page));
+
+    const mergedPdfBytes = await mergedPdf.save();
+    fs.writeFileSync('merged.pdf', mergedPdfBytes);
+}
+```
+
+### pdfjs-dist (Apache License)
+
+PDF.js is Mozilla's JavaScript library for rendering PDFs in the browser.
+
+#### Basic PDF Loading and Rendering
+```javascript
+import * as pdfjsLib from 'pdfjs-dist';
+
+// Configure worker (important for performance)
+pdfjsLib.GlobalWorkerOptions.workerSrc = './pdf.worker.js';
+
+async function renderPDF() {
+    // Load PDF
+    const loadingTask = pdfjsLib.getDocument('document.pdf');
+    const pdf = await loadingTask.promise;
+
+    console.log(`Loaded PDF with ${pdf.numPages} pages`);
+
+    // Get first page
+    const page = await pdf.getPage(1);
+    const viewport = page.getViewport({ scale: 1.5 });
+
+    // Render to canvas
+    const canvas = document.createElement('canvas');
+    const context = canvas.getContext('2d');
+    canvas.height = viewport.height;
+    canvas.width = viewport.width;
+
+    const renderContext = {
+        canvasContext: context,
+        viewport: viewport
+    };
+
+    await page.render(renderContext).promise;
+    document.body.appendChild(canvas);
+}
+```
+
+#### Extract Text with Coordinates
+```javascript
+import * as pdfjsLib from 'pdfjs-dist';
+
+async function extractText() {
+    const loadingTask = pdfjsLib.getDocument('document.pdf');
+    const pdf = await loadingTask.promise;
+
+    let fullText = '';
+
+    // Extract text from all pages
+    for (let i = 1; i <= pdf.numPages; i++) {
+        const page = await pdf.getPage(i);
+        const textContent = await page.getTextContent();
+
+        const pageText = textContent.items
+            .map(item => item.str)
+            .join(' ');
+
+        fullText += `\n--- Page ${i} ---\n${pageText}`;
+
+        // Get text with coordinates for advanced processing
+        const textWithCoords = textContent.items.map(item => ({
+            text: item.str,
+            x: item.transform[4],
+            y: item.transform[5],
+            width: item.width,
+            height: item.height
+        }));
+    }
+
+    console.log(fullText);
+    return fullText;
+}
+```
+
+#### Extract Annotations and Forms
+```javascript
+import * as pdfjsLib from 'pdfjs-dist';
+
+async function extractAnnotations() {
+    const loadingTask = pdfjsLib.getDocument('annotated.pdf');
+    const pdf = await loadingTask.promise;
+
+    for (let i = 1; i <= pdf.numPages; i++) {
+        const page = await pdf.getPage(i);
+        const annotations = await page.getAnnotations();
+
+        annotations.forEach(annotation => {
+            console.log(`Annotation type: ${annotation.subtype}`);
+            console.log(`Content: ${annotation.contents}`);
+            console.log(`Coordinates: ${JSON.stringify(annotation.rect)}`);
+        });
+    }
+}
+```
+
+## Advanced Command-Line Operations
+
+### poppler-utils Advanced Features
+
+#### Extract Text with Bounding Box Coordinates
+```bash
+# Extract text with bounding box coordinates (essential for structured data)
+pdftotext -bbox-layout document.pdf output.xml
+
+# The XML output contains precise coordinates for each text element
+```
+
+#### Advanced Image Conversion
+```bash
+# Convert to PNG images with specific resolution
+pdftoppm -png -r 300 document.pdf output_prefix
+
+# Convert specific page range with high resolution
+pdftoppm -png -r 600 -f 1 -l 3 document.pdf high_res_pages
+
+# Convert to JPEG with quality setting
+pdftoppm -jpeg -jpegopt quality=85 -r 200 document.pdf jpeg_output
+```
+
+#### Extract Embedded Images
+```bash
+# Extract all embedded images with metadata
+pdfimages -j -p document.pdf page_images
+
+# List image info without extracting
+pdfimages -list document.pdf
+
+# Extract images in their original format
+pdfimages -all document.pdf images/img
+```
+
+### qpdf Advanced Features
+
+#### Complex Page Manipulation
+```bash
+# Split PDF into groups of pages
+qpdf --split-pages=3 input.pdf output_group_%02d.pdf
+
+# Extract specific pages with complex ranges
+qpdf input.pdf --pages input.pdf 1,3-5,8,10-end -- extracted.pdf
+
+# Merge specific pages from multiple PDFs
+qpdf --empty --pages doc1.pdf 1-3 doc2.pdf 5-7 doc3.pdf 2,4 -- combined.pdf
+```
+
+#### PDF Optimization and Repair
+```bash
+# Optimize PDF for web (linearize for streaming)
+qpdf --linearize input.pdf optimized.pdf
+
+# Remove unused objects and compress
+qpdf --optimize-level=all input.pdf compressed.pdf
+
+# Attempt to repair corrupted PDF structure
+qpdf --check input.pdf
+qpdf --fix-qdf damaged.pdf repaired.pdf
+
+# Show detailed PDF structure for debugging
+qpdf --show-all-pages input.pdf > structure.txt
+```
+
+#### Advanced Encryption
+```bash
+# Add password protection with specific permissions
+qpdf --encrypt user_pass owner_pass 256 --print=none --modify=none -- input.pdf encrypted.pdf
+
+# Check encryption status
+qpdf --show-encryption encrypted.pdf
+
+# Remove password protection (requires password)
+qpdf --password=secret123 --decrypt encrypted.pdf decrypted.pdf
+```
+
+## Advanced Python Techniques
+
+### pdfplumber Advanced Features
+
+#### Extract Text with Precise Coordinates
+```python
+import pdfplumber
+
+with pdfplumber.open("document.pdf") as pdf:
+    page = pdf.pages[0]
+    
+    # Extract all text with coordinates
+    chars = page.chars
+    for char in chars[:10]:  # First 10 characters
+        print(f"Char: '{char['text']}' at x:{char['x0']:.1f} y:{char['y0']:.1f}")
+    
+    # Extract text by bounding box (left, top, right, bottom)
+    bbox_text = page.within_bbox((100, 100, 400, 200)).extract_text()
+```
+
+#### Advanced Table Extraction with Custom Settings
+```python
+import pdfplumber
+import pandas as pd
+
+with pdfplumber.open("complex_table.pdf") as pdf:
+    page = pdf.pages[0]
+    
+    # Extract tables with custom settings for complex layouts
+    table_settings = {
+        "vertical_strategy": "lines",
+        "horizontal_strategy": "lines",
+        "snap_tolerance": 3,
+        "intersection_tolerance": 15
+    }
+    tables = page.extract_tables(table_settings)
+    
+    # Visual debugging for table extraction
+    img = page.to_image(resolution=150)
+    img.save("debug_layout.png")
+```
+
+### reportlab Advanced Features
+
+#### Create Professional Reports with Tables
+```python
+from reportlab.platypus import SimpleDocTemplate, Table, TableStyle, Paragraph
+from reportlab.lib.styles import getSampleStyleSheet
+from reportlab.lib import colors
+
+# Sample data
+data = [
+    ['Product', 'Q1', 'Q2', 'Q3', 'Q4'],
+    ['Widgets', '120', '135', '142', '158'],
+    ['Gadgets', '85', '92', '98', '105']
+]
+
+# Create PDF with table
+doc = SimpleDocTemplate("report.pdf")
+elements = []
+
+# Add title
+styles = getSampleStyleSheet()
+title = Paragraph("Quarterly Sales Report", styles['Title'])
+elements.append(title)
+
+# Add table with advanced styling
+table = Table(data)
+table.setStyle(TableStyle([
+    ('BACKGROUND', (0, 0), (-1, 0), colors.grey),
+    ('TEXTCOLOR', (0, 0), (-1, 0), colors.whitesmoke),
+    ('ALIGN', (0, 0), (-1, -1), 'CENTER'),
+    ('FONTNAME', (0, 0), (-1, 0), 'Helvetica-Bold'),
+    ('FONTSIZE', (0, 0), (-1, 0), 14),
+    ('BOTTOMPADDING', (0, 0), (-1, 0), 12),
+    ('BACKGROUND', (0, 1), (-1, -1), colors.beige),
+    ('GRID', (0, 0), (-1, -1), 1, colors.black)
+]))
+elements.append(table)
+
+doc.build(elements)
+```
+
+## Complex Workflows
+
+### Extract Figures/Images from PDF
+
+#### Method 1: Using pdfimages (fastest)
+```bash
+# Extract all images with original quality
+pdfimages -all document.pdf images/img
+```
+
+#### Method 2: Using pypdfium2 + Image Processing
+```python
+import pypdfium2 as pdfium
+from PIL import Image
+import numpy as np
+
+def extract_figures(pdf_path, output_dir):
+    pdf = pdfium.PdfDocument(pdf_path)
+    
+    for page_num, page in enumerate(pdf):
+        # Render high-resolution page
+        bitmap = page.render(scale=3.0)
+        img = bitmap.to_pil()
+        
+        # Convert to numpy for processing
+        img_array = np.array(img)
+        
+        # Simple figure detection (non-white regions)
+        mask = np.any(img_array != [255, 255, 255], axis=2)
+        
+        # Find contours and extract bounding boxes
+        # (This is simplified - real implementation would need more sophisticated detection)
+        
+        # Save detected figures
+        # ... implementation depends on specific needs
+```
+
+### Batch PDF Processing with Error Handling
+```python
+import os
+import glob
+from pypdf import PdfReader, PdfWriter
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+def batch_process_pdfs(input_dir, operation='merge'):
+    pdf_files = glob.glob(os.path.join(input_dir, "*.pdf"))
+    
+    if operation == 'merge':
+        writer = PdfWriter()
+        for pdf_file in pdf_files:
+            try:
+                reader = PdfReader(pdf_file)
+                for page in reader.pages:
+                    writer.add_page(page)
+                logger.info(f"Processed: {pdf_file}")
+            except Exception as e:
+                logger.error(f"Failed to process {pdf_file}: {e}")
+                continue
+        
+        with open("batch_merged.pdf", "wb") as output:
+            writer.write(output)
+    
+    elif operation == 'extract_text':
+        for pdf_file in pdf_files:
+            try:
+                reader = PdfReader(pdf_file)
+                text = ""
+                for page in reader.pages:
+                    text += page.extract_text()
+                
+                output_file = pdf_file.replace('.pdf', '.txt')
+                with open(output_file, 'w', encoding='utf-8') as f:
+                    f.write(text)
+                logger.info(f"Extracted text from: {pdf_file}")
+                
+            except Exception as e:
+                logger.error(f"Failed to extract text from {pdf_file}: {e}")
+                continue
+```
+
+### Advanced PDF Cropping
+```python
+from pypdf import PdfWriter, PdfReader
+
+reader = PdfReader("input.pdf")
+writer = PdfWriter()
+
+# Crop page (left, bottom, right, top in points)
+page = reader.pages[0]
+page.mediabox.left = 50
+page.mediabox.bottom = 50
+page.mediabox.right = 550
+page.mediabox.top = 750
+
+writer.add_page(page)
+with open("cropped.pdf", "wb") as output:
+    writer.write(output)
+```
+
+## Performance Optimization Tips
+
+### 1. For Large PDFs
+- Use streaming approaches instead of loading entire PDF in memory
+- Use `qpdf --split-pages` for splitting large files
+- Process pages individually with pypdfium2
+
+### 2. For Text Extraction
+- `pdftotext -bbox-layout` is fastest for plain text extraction
+- Use pdfplumber for structured data and tables
+- Avoid `pypdf.extract_text()` for very large documents
+
+### 3. For Image Extraction
+- `pdfimages` is much faster than rendering pages
+- Use low resolution for previews, high resolution for final output
+
+### 4. For Form Filling
+- pdf-lib maintains form structure better than most alternatives
+- Pre-validate form fields before processing
+
+### 5. Memory Management
+```python
+# Process PDFs in chunks
+def process_large_pdf(pdf_path, chunk_size=10):
+    reader = PdfReader(pdf_path)
+    total_pages = len(reader.pages)
+    
+    for start_idx in range(0, total_pages, chunk_size):
+        end_idx = min(start_idx + chunk_size, total_pages)
+        writer = PdfWriter()
+        
+        for i in range(start_idx, end_idx):
+            writer.add_page(reader.pages[i])
+        
+        # Process chunk
+        with open(f"chunk_{start_idx//chunk_size}.pdf", "wb") as output:
+            writer.write(output)
+```
+
+## Troubleshooting Common Issues
+
+### Encrypted PDFs
+```python
+# Handle password-protected PDFs
+from pypdf import PdfReader
+
+try:
+    reader = PdfReader("encrypted.pdf")
+    if reader.is_encrypted:
+        reader.decrypt("password")
+except Exception as e:
+    print(f"Failed to decrypt: {e}")
+```
+
+### Corrupted PDFs
+```bash
+# Use qpdf to repair
+qpdf --check corrupted.pdf
+qpdf --replace-input corrupted.pdf
+```
+
+### Text Extraction Issues
+```python
+# Fallback to OCR for scanned PDFs
+import pytesseract
+from pdf2image import convert_from_path
+
+def extract_text_with_ocr(pdf_path):
+    images = convert_from_path(pdf_path)
+    text = ""
+    for i, image in enumerate(images):
+        text += pytesseract.image_to_string(image)
+    return text
+```
+
+## License Information
+
+- **pypdf**: BSD License
+- **pdfplumber**: MIT License
+- **pypdfium2**: Apache/BSD License
+- **reportlab**: BSD License
+- **poppler-utils**: GPL-2 License
+- **qpdf**: Apache License
+- **pdf-lib**: MIT License
+- **pdfjs-dist**: Apache License

--- a/seed/skills/pdf/SKILL.md
+++ b/seed/skills/pdf/SKILL.md
@@ -1,0 +1,326 @@
+---
+name: pdf
+description: Use this skill whenever the user wants to do anything with PDF files. This includes reading or extracting text/tables from PDFs, combining or merging multiple PDFs into one, splitting PDFs apart, rotating pages, adding watermarks, creating new PDFs, filling PDF forms, encrypting/decrypting PDFs, extracting images, and OCR on scanned PDFs to make them searchable. If the user mentions a .pdf file or asks to produce one, use this skill.
+user-invocable: false
+---
+
+# PDF Processing Guide
+
+## Overview
+
+This guide covers essential PDF processing operations using Python libraries and command-line tools. For advanced features, JavaScript libraries, and detailed examples, see REFERENCE.md. If you need to fill out a PDF form, read FORMS.md and follow its instructions.
+
+## Quick Start
+
+```python
+from pypdf import PdfReader, PdfWriter
+
+# Read a PDF
+reader = PdfReader("document.pdf")
+print(f"Pages: {len(reader.pages)}")
+
+# Extract text
+text = ""
+for page in reader.pages:
+    text += page.extract_text()
+```
+
+## Python Libraries
+
+### pypdf - Basic Operations
+
+#### Merge PDFs
+```python
+from pypdf import PdfWriter, PdfReader
+
+writer = PdfWriter()
+for pdf_file in ["doc1.pdf", "doc2.pdf", "doc3.pdf"]:
+    reader = PdfReader(pdf_file)
+    for page in reader.pages:
+        writer.add_page(page)
+
+with open("merged.pdf", "wb") as output:
+    writer.write(output)
+```
+
+#### Split PDF
+```python
+reader = PdfReader("input.pdf")
+for i, page in enumerate(reader.pages):
+    writer = PdfWriter()
+    writer.add_page(page)
+    with open(f"page_{i+1}.pdf", "wb") as output:
+        writer.write(output)
+```
+
+#### Extract Metadata
+```python
+reader = PdfReader("document.pdf")
+meta = reader.metadata
+print(f"Title: {meta.title}")
+print(f"Author: {meta.author}")
+print(f"Subject: {meta.subject}")
+print(f"Creator: {meta.creator}")
+```
+
+#### Rotate Pages
+```python
+reader = PdfReader("input.pdf")
+writer = PdfWriter()
+
+page = reader.pages[0]
+page.rotate(90)  # Rotate 90 degrees clockwise
+writer.add_page(page)
+
+with open("rotated.pdf", "wb") as output:
+    writer.write(output)
+```
+
+### pdfplumber - Text and Table Extraction
+
+#### Extract Text with Layout
+```python
+import pdfplumber
+
+with pdfplumber.open("document.pdf") as pdf:
+    for page in pdf.pages:
+        text = page.extract_text()
+        print(text)
+```
+
+#### Extract Tables
+```python
+with pdfplumber.open("document.pdf") as pdf:
+    for i, page in enumerate(pdf.pages):
+        tables = page.extract_tables()
+        for j, table in enumerate(tables):
+            print(f"Table {j+1} on page {i+1}:")
+            for row in table:
+                print(row)
+```
+
+#### Advanced Table Extraction
+```python
+import pandas as pd
+
+with pdfplumber.open("document.pdf") as pdf:
+    all_tables = []
+    for page in pdf.pages:
+        tables = page.extract_tables()
+        for table in tables:
+            if table:  # Check if table is not empty
+                df = pd.DataFrame(table[1:], columns=table[0])
+                all_tables.append(df)
+
+# Combine all tables
+if all_tables:
+    combined_df = pd.concat(all_tables, ignore_index=True)
+    combined_df.to_excel("extracted_tables.xlsx", index=False)
+```
+
+### reportlab - Create PDFs
+
+#### Basic PDF Creation
+```python
+from reportlab.lib.pagesizes import letter
+from reportlab.pdfgen import canvas
+
+c = canvas.Canvas("hello.pdf", pagesize=letter)
+width, height = letter
+
+# Add text
+c.drawString(100, height - 100, "Hello World!")
+c.drawString(100, height - 120, "This is a PDF created with reportlab")
+
+# Add a line
+c.line(100, height - 140, 400, height - 140)
+
+# Save
+c.save()
+```
+
+#### Create PDF with Multiple Pages
+```python
+from reportlab.lib.pagesizes import letter
+from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer, PageBreak
+from reportlab.lib.styles import getSampleStyleSheet
+
+doc = SimpleDocTemplate("report.pdf", pagesize=letter)
+styles = getSampleStyleSheet()
+story = []
+
+# Add content
+title = Paragraph("Report Title", styles['Title'])
+story.append(title)
+story.append(Spacer(1, 12))
+
+body = Paragraph("This is the body of the report. " * 20, styles['Normal'])
+story.append(body)
+story.append(PageBreak())
+
+# Page 2
+story.append(Paragraph("Page 2", styles['Heading1']))
+story.append(Paragraph("Content for page 2", styles['Normal']))
+
+# Build PDF
+doc.build(story)
+```
+
+#### Subscripts and Superscripts
+
+**IMPORTANT**: Never use Unicode subscript/superscript characters (₀₁₂₃₄₅₆₇₈₉, ⁰¹²³⁴⁵⁶⁷⁸⁹) in ReportLab PDFs. The built-in fonts do not include these glyphs, causing them to render as solid black boxes.
+
+Instead, use ReportLab's XML markup tags in Paragraph objects:
+```python
+from reportlab.platypus import Paragraph
+from reportlab.lib.styles import getSampleStyleSheet
+
+styles = getSampleStyleSheet()
+
+# Subscripts: use <sub> tag
+chemical = Paragraph("H<sub>2</sub>O", styles['Normal'])
+
+# Superscripts: use <super> tag
+squared = Paragraph("x<super>2</super> + y<super>2</super>", styles['Normal'])
+```
+
+For canvas-drawn text (not Paragraph objects), manually adjust font the size and position rather than using Unicode subscripts/superscripts.
+
+## Command-Line Tools
+
+### pdftotext (poppler-utils)
+```bash
+# Extract text
+pdftotext input.pdf output.txt
+
+# Extract text preserving layout
+pdftotext -layout input.pdf output.txt
+
+# Extract specific pages
+pdftotext -f 1 -l 5 input.pdf output.txt  # Pages 1-5
+```
+
+### qpdf
+```bash
+# Merge PDFs
+qpdf --empty --pages file1.pdf file2.pdf -- merged.pdf
+
+# Split pages
+qpdf input.pdf --pages . 1-5 -- pages1-5.pdf
+qpdf input.pdf --pages . 6-10 -- pages6-10.pdf
+
+# Rotate pages
+qpdf input.pdf output.pdf --rotate=+90:1  # Rotate page 1 by 90 degrees
+
+# Remove password
+qpdf --password=mypassword --decrypt encrypted.pdf decrypted.pdf
+```
+
+### pdftk (if available)
+```bash
+# Merge
+pdftk file1.pdf file2.pdf cat output merged.pdf
+
+# Split
+pdftk input.pdf burst
+
+# Rotate
+pdftk input.pdf rotate 1east output rotated.pdf
+```
+
+## Common Tasks
+
+### Extract Text from Scanned PDFs
+```python
+# Requires: pip install pytesseract pdf2image
+import pytesseract
+from pdf2image import convert_from_path
+
+# Convert PDF to images
+images = convert_from_path('scanned.pdf')
+
+# OCR each page
+text = ""
+for i, image in enumerate(images):
+    text += f"Page {i+1}:\n"
+    text += pytesseract.image_to_string(image)
+    text += "\n\n"
+
+print(text)
+```
+
+### Add Watermark
+```python
+from pypdf import PdfReader, PdfWriter
+
+# Create watermark (or load existing)
+watermark = PdfReader("watermark.pdf").pages[0]
+
+# Apply to all pages
+reader = PdfReader("document.pdf")
+writer = PdfWriter()
+
+for page in reader.pages:
+    page.merge_page(watermark)
+    writer.add_page(page)
+
+with open("watermarked.pdf", "wb") as output:
+    writer.write(output)
+```
+
+### Extract Images
+```bash
+# Using pdfimages (poppler-utils)
+pdfimages -j input.pdf output_prefix
+
+# This extracts all images as output_prefix-000.jpg, output_prefix-001.jpg, etc.
+```
+
+### Password Protection
+```python
+from pypdf import PdfReader, PdfWriter
+
+reader = PdfReader("input.pdf")
+writer = PdfWriter()
+
+for page in reader.pages:
+    writer.add_page(page)
+
+# Add password
+writer.encrypt("userpassword", "ownerpassword")
+
+with open("encrypted.pdf", "wb") as output:
+    writer.write(output)
+```
+
+## File Delivery
+
+When delivering a .pdf file to the user, follow the **preview-first** principle:
+
+1. **Write to `/tmp/`**: Save the generated .pdf file to `/tmp/` (e.g., `/tmp/report.pdf`). The chat UI automatically previews .pdf files using the native browser PDF viewer — the user sees the full PDF in the right-side preview panel.
+2. **Share the file path**: Reference the `/tmp/` path in your response so the chat UI can render the preview.
+3. **Upload to Google Drive**: After the user sees the preview, upload to Google Drive as a persistent backup and share the link.
+
+**Never skip the preview step** by jumping straight to a Google Drive link. The user should see the PDF content in-chat before getting an external link.
+
+---
+
+## Quick Reference
+
+| Task | Best Tool | Command/Code |
+|------|-----------|--------------|
+| Merge PDFs | pypdf | `writer.add_page(page)` |
+| Split PDFs | pypdf | One page per file |
+| Extract text | pdfplumber | `page.extract_text()` |
+| Extract tables | pdfplumber | `page.extract_tables()` |
+| Create PDFs | reportlab | Canvas or Platypus |
+| Command line merge | qpdf | `qpdf --empty --pages ...` |
+| OCR scanned PDFs | pytesseract | Convert to image first |
+| Fill PDF forms | pdf-lib or pypdf (see FORMS.md) | See FORMS.md |
+
+## Next Steps
+
+- For advanced pypdfium2 usage, see REFERENCE.md
+- For JavaScript libraries (pdf-lib), see REFERENCE.md
+- If you need to fill out a PDF form, follow the instructions in FORMS.md
+- For troubleshooting guides, see REFERENCE.md

--- a/seed/skills/pdf/scripts/check_bounding_boxes.py
+++ b/seed/skills/pdf/scripts/check_bounding_boxes.py
@@ -1,0 +1,65 @@
+from dataclasses import dataclass
+import json
+import sys
+
+
+
+
+@dataclass
+class RectAndField:
+    rect: list[float]
+    rect_type: str
+    field: dict
+
+
+def get_bounding_box_messages(fields_json_stream) -> list[str]:
+    messages = []
+    fields = json.load(fields_json_stream)
+    messages.append(f"Read {len(fields['form_fields'])} fields")
+
+    def rects_intersect(r1, r2):
+        disjoint_horizontal = r1[0] >= r2[2] or r1[2] <= r2[0]
+        disjoint_vertical = r1[1] >= r2[3] or r1[3] <= r2[1]
+        return not (disjoint_horizontal or disjoint_vertical)
+
+    rects_and_fields = []
+    for f in fields["form_fields"]:
+        rects_and_fields.append(RectAndField(f["label_bounding_box"], "label", f))
+        rects_and_fields.append(RectAndField(f["entry_bounding_box"], "entry", f))
+
+    has_error = False
+    for i, ri in enumerate(rects_and_fields):
+        for j in range(i + 1, len(rects_and_fields)):
+            rj = rects_and_fields[j]
+            if ri.field["page_number"] == rj.field["page_number"] and rects_intersect(ri.rect, rj.rect):
+                has_error = True
+                if ri.field is rj.field:
+                    messages.append(f"FAILURE: intersection between label and entry bounding boxes for `{ri.field['description']}` ({ri.rect}, {rj.rect})")
+                else:
+                    messages.append(f"FAILURE: intersection between {ri.rect_type} bounding box for `{ri.field['description']}` ({ri.rect}) and {rj.rect_type} bounding box for `{rj.field['description']}` ({rj.rect})")
+                if len(messages) >= 20:
+                    messages.append("Aborting further checks; fix bounding boxes and try again")
+                    return messages
+        if ri.rect_type == "entry":
+            if "entry_text" in ri.field:
+                font_size = ri.field["entry_text"].get("font_size", 14)
+                entry_height = ri.rect[3] - ri.rect[1]
+                if entry_height < font_size:
+                    has_error = True
+                    messages.append(f"FAILURE: entry bounding box height ({entry_height}) for `{ri.field['description']}` is too short for the text content (font size: {font_size}). Increase the box height or decrease the font size.")
+                    if len(messages) >= 20:
+                        messages.append("Aborting further checks; fix bounding boxes and try again")
+                        return messages
+
+    if not has_error:
+        messages.append("SUCCESS: All bounding boxes are valid")
+    return messages
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: check_bounding_boxes.py [fields.json]")
+        sys.exit(1)
+    with open(sys.argv[1]) as f:
+        messages = get_bounding_box_messages(f)
+    for msg in messages:
+        print(msg)

--- a/seed/skills/pdf/scripts/check_fillable_fields.py
+++ b/seed/skills/pdf/scripts/check_fillable_fields.py
@@ -1,0 +1,11 @@
+import sys
+from pypdf import PdfReader
+
+
+
+
+reader = PdfReader(sys.argv[1])
+if (reader.get_fields()):
+    print("This PDF has fillable form fields")
+else:
+    print("This PDF does not have fillable form fields; you will need to visually determine where to enter data")

--- a/seed/skills/pdf/scripts/convert_pdf_to_images.py
+++ b/seed/skills/pdf/scripts/convert_pdf_to_images.py
@@ -1,0 +1,33 @@
+import os
+import sys
+
+from pdf2image import convert_from_path
+
+
+
+
+def convert(pdf_path, output_dir, max_dim=1000):
+    images = convert_from_path(pdf_path, dpi=200)
+
+    for i, image in enumerate(images):
+        width, height = image.size
+        if width > max_dim or height > max_dim:
+            scale_factor = min(max_dim / width, max_dim / height)
+            new_width = int(width * scale_factor)
+            new_height = int(height * scale_factor)
+            image = image.resize((new_width, new_height))
+        
+        image_path = os.path.join(output_dir, f"page_{i+1}.png")
+        image.save(image_path)
+        print(f"Saved page {i+1} as {image_path} (size: {image.size})")
+
+    print(f"Converted {len(images)} pages to PNG images")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: convert_pdf_to_images.py [input pdf] [output directory]")
+        sys.exit(1)
+    pdf_path = sys.argv[1]
+    output_directory = sys.argv[2]
+    convert(pdf_path, output_directory)

--- a/seed/skills/pdf/scripts/create_validation_image.py
+++ b/seed/skills/pdf/scripts/create_validation_image.py
@@ -1,0 +1,37 @@
+import json
+import sys
+
+from PIL import Image, ImageDraw
+
+
+
+
+def create_validation_image(page_number, fields_json_path, input_path, output_path):
+    with open(fields_json_path, 'r') as f:
+        data = json.load(f)
+
+        img = Image.open(input_path)
+        draw = ImageDraw.Draw(img)
+        num_boxes = 0
+        
+        for field in data["form_fields"]:
+            if field["page_number"] == page_number:
+                entry_box = field['entry_bounding_box']
+                label_box = field['label_bounding_box']
+                draw.rectangle(entry_box, outline='red', width=2)
+                draw.rectangle(label_box, outline='blue', width=2)
+                num_boxes += 2
+        
+        img.save(output_path)
+        print(f"Created validation image at {output_path} with {num_boxes} bounding boxes")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 5:
+        print("Usage: create_validation_image.py [page number] [fields.json file] [input image path] [output image path]")
+        sys.exit(1)
+    page_number = int(sys.argv[1])
+    fields_json_path = sys.argv[2]
+    input_image_path = sys.argv[3]
+    output_image_path = sys.argv[4]
+    create_validation_image(page_number, fields_json_path, input_image_path, output_image_path)

--- a/seed/skills/pdf/scripts/extract_form_field_info.py
+++ b/seed/skills/pdf/scripts/extract_form_field_info.py
@@ -1,0 +1,122 @@
+import json
+import sys
+
+from pypdf import PdfReader
+
+
+
+
+def get_full_annotation_field_id(annotation):
+    components = []
+    while annotation:
+        field_name = annotation.get('/T')
+        if field_name:
+            components.append(field_name)
+        annotation = annotation.get('/Parent')
+    return ".".join(reversed(components)) if components else None
+
+
+def make_field_dict(field, field_id):
+    field_dict = {"field_id": field_id}
+    ft = field.get('/FT')
+    if ft == "/Tx":
+        field_dict["type"] = "text"
+    elif ft == "/Btn":
+        field_dict["type"] = "checkbox"  
+        states = field.get("/_States_", [])
+        if len(states) == 2:
+            if "/Off" in states:
+                field_dict["checked_value"] = states[0] if states[0] != "/Off" else states[1]
+                field_dict["unchecked_value"] = "/Off"
+            else:
+                print(f"Unexpected state values for checkbox `${field_id}`. Its checked and unchecked values may not be correct; if you're trying to check it, visually verify the results.")
+                field_dict["checked_value"] = states[0]
+                field_dict["unchecked_value"] = states[1]
+    elif ft == "/Ch":
+        field_dict["type"] = "choice"
+        states = field.get("/_States_", [])
+        field_dict["choice_options"] = [{
+            "value": state[0],
+            "text": state[1],
+        } for state in states]
+    else:
+        field_dict["type"] = f"unknown ({ft})"
+    return field_dict
+
+
+def get_field_info(reader: PdfReader):
+    fields = reader.get_fields()
+
+    field_info_by_id = {}
+    possible_radio_names = set()
+
+    for field_id, field in fields.items():
+        if field.get("/Kids"):
+            if field.get("/FT") == "/Btn":
+                possible_radio_names.add(field_id)
+            continue
+        field_info_by_id[field_id] = make_field_dict(field, field_id)
+
+
+    radio_fields_by_id = {}
+
+    for page_index, page in enumerate(reader.pages):
+        annotations = page.get('/Annots', [])
+        for ann in annotations:
+            field_id = get_full_annotation_field_id(ann)
+            if field_id in field_info_by_id:
+                field_info_by_id[field_id]["page"] = page_index + 1
+                field_info_by_id[field_id]["rect"] = ann.get('/Rect')
+            elif field_id in possible_radio_names:
+                try:
+                    on_values = [v for v in ann["/AP"]["/N"] if v != "/Off"]
+                except KeyError:
+                    continue
+                if len(on_values) == 1:
+                    rect = ann.get("/Rect")
+                    if field_id not in radio_fields_by_id:
+                        radio_fields_by_id[field_id] = {
+                            "field_id": field_id,
+                            "type": "radio_group",
+                            "page": page_index + 1,
+                            "radio_options": [],
+                        }
+                    radio_fields_by_id[field_id]["radio_options"].append({
+                        "value": on_values[0],
+                        "rect": rect,
+                    })
+
+    fields_with_location = []
+    for field_info in field_info_by_id.values():
+        if "page" in field_info:
+            fields_with_location.append(field_info)
+        else:
+            print(f"Unable to determine location for field id: {field_info.get('field_id')}, ignoring")
+
+    def sort_key(f):
+        if "radio_options" in f:
+            rect = f["radio_options"][0]["rect"] or [0, 0, 0, 0]
+        else:
+            rect = f.get("rect") or [0, 0, 0, 0]
+        adjusted_position = [-rect[1], rect[0]]
+        return [f.get("page"), adjusted_position]
+    
+    sorted_fields = fields_with_location + list(radio_fields_by_id.values())
+    sorted_fields.sort(key=sort_key)
+
+    return sorted_fields
+
+
+def write_field_info(pdf_path: str, json_output_path: str):
+    reader = PdfReader(pdf_path)
+    field_info = get_field_info(reader)
+    with open(json_output_path, "w") as f:
+        json.dump(field_info, f, indent=2)
+    print(f"Wrote {len(field_info)} fields to {json_output_path}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: extract_form_field_info.py [input pdf] [output json]")
+        sys.exit(1)
+    write_field_info(sys.argv[1], sys.argv[2])

--- a/seed/skills/pdf/scripts/extract_form_structure.py
+++ b/seed/skills/pdf/scripts/extract_form_structure.py
@@ -1,0 +1,115 @@
+"""
+Extract form structure from a non-fillable PDF.
+
+This script analyzes the PDF to find:
+- Text labels with their exact coordinates
+- Horizontal lines (row boundaries)
+- Checkboxes (small rectangles)
+
+Output: A JSON file with the form structure that can be used to generate
+accurate field coordinates for filling.
+
+Usage: python extract_form_structure.py <input.pdf> <output.json>
+"""
+
+import json
+import sys
+import pdfplumber
+
+
+def extract_form_structure(pdf_path):
+    structure = {
+        "pages": [],
+        "labels": [],
+        "lines": [],
+        "checkboxes": [],
+        "row_boundaries": []
+    }
+
+    with pdfplumber.open(pdf_path) as pdf:
+        for page_num, page in enumerate(pdf.pages, 1):
+            structure["pages"].append({
+                "page_number": page_num,
+                "width": float(page.width),
+                "height": float(page.height)
+            })
+
+            words = page.extract_words()
+            for word in words:
+                structure["labels"].append({
+                    "page": page_num,
+                    "text": word["text"],
+                    "x0": round(float(word["x0"]), 1),
+                    "top": round(float(word["top"]), 1),
+                    "x1": round(float(word["x1"]), 1),
+                    "bottom": round(float(word["bottom"]), 1)
+                })
+
+            for line in page.lines:
+                if abs(float(line["x1"]) - float(line["x0"])) > page.width * 0.5:
+                    structure["lines"].append({
+                        "page": page_num,
+                        "y": round(float(line["top"]), 1),
+                        "x0": round(float(line["x0"]), 1),
+                        "x1": round(float(line["x1"]), 1)
+                    })
+
+            for rect in page.rects:
+                width = float(rect["x1"]) - float(rect["x0"])
+                height = float(rect["bottom"]) - float(rect["top"])
+                if 5 <= width <= 15 and 5 <= height <= 15 and abs(width - height) < 2:
+                    structure["checkboxes"].append({
+                        "page": page_num,
+                        "x0": round(float(rect["x0"]), 1),
+                        "top": round(float(rect["top"]), 1),
+                        "x1": round(float(rect["x1"]), 1),
+                        "bottom": round(float(rect["bottom"]), 1),
+                        "center_x": round((float(rect["x0"]) + float(rect["x1"])) / 2, 1),
+                        "center_y": round((float(rect["top"]) + float(rect["bottom"])) / 2, 1)
+                    })
+
+    lines_by_page = {}
+    for line in structure["lines"]:
+        page = line["page"]
+        if page not in lines_by_page:
+            lines_by_page[page] = []
+        lines_by_page[page].append(line["y"])
+
+    for page, y_coords in lines_by_page.items():
+        y_coords = sorted(set(y_coords))
+        for i in range(len(y_coords) - 1):
+            structure["row_boundaries"].append({
+                "page": page,
+                "row_top": y_coords[i],
+                "row_bottom": y_coords[i + 1],
+                "row_height": round(y_coords[i + 1] - y_coords[i], 1)
+            })
+
+    return structure
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("Usage: extract_form_structure.py <input.pdf> <output.json>")
+        sys.exit(1)
+
+    pdf_path = sys.argv[1]
+    output_path = sys.argv[2]
+
+    print(f"Extracting structure from {pdf_path}...")
+    structure = extract_form_structure(pdf_path)
+
+    with open(output_path, "w") as f:
+        json.dump(structure, f, indent=2)
+
+    print(f"Found:")
+    print(f"  - {len(structure['pages'])} pages")
+    print(f"  - {len(structure['labels'])} text labels")
+    print(f"  - {len(structure['lines'])} horizontal lines")
+    print(f"  - {len(structure['checkboxes'])} checkboxes")
+    print(f"  - {len(structure['row_boundaries'])} row boundaries")
+    print(f"Saved to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/seed/skills/pdf/scripts/fill_fillable_fields.py
+++ b/seed/skills/pdf/scripts/fill_fillable_fields.py
@@ -1,0 +1,98 @@
+import json
+import sys
+
+from pypdf import PdfReader, PdfWriter
+
+from extract_form_field_info import get_field_info
+
+
+
+
+def fill_pdf_fields(input_pdf_path: str, fields_json_path: str, output_pdf_path: str):
+    with open(fields_json_path) as f:
+        fields = json.load(f)
+    fields_by_page = {}
+    for field in fields:
+        if "value" in field:
+            field_id = field["field_id"]
+            page = field["page"]
+            if page not in fields_by_page:
+                fields_by_page[page] = {}
+            fields_by_page[page][field_id] = field["value"]
+    
+    reader = PdfReader(input_pdf_path)
+
+    has_error = False
+    field_info = get_field_info(reader)
+    fields_by_ids = {f["field_id"]: f for f in field_info}
+    for field in fields:
+        existing_field = fields_by_ids.get(field["field_id"])
+        if not existing_field:
+            has_error = True
+            print(f"ERROR: `{field['field_id']}` is not a valid field ID")
+        elif field["page"] != existing_field["page"]:
+            has_error = True
+            print(f"ERROR: Incorrect page number for `{field['field_id']}` (got {field['page']}, expected {existing_field['page']})")
+        else:
+            if "value" in field:
+                err = validation_error_for_field_value(existing_field, field["value"])
+                if err:
+                    print(err)
+                    has_error = True
+    if has_error:
+        sys.exit(1)
+
+    writer = PdfWriter(clone_from=reader)
+    for page, field_values in fields_by_page.items():
+        writer.update_page_form_field_values(writer.pages[page - 1], field_values, auto_regenerate=False)
+
+    writer.set_need_appearances_writer(True)
+    
+    with open(output_pdf_path, "wb") as f:
+        writer.write(f)
+
+
+def validation_error_for_field_value(field_info, field_value):
+    field_type = field_info["type"]
+    field_id = field_info["field_id"]
+    if field_type == "checkbox":
+        checked_val = field_info["checked_value"]
+        unchecked_val = field_info["unchecked_value"]
+        if field_value != checked_val and field_value != unchecked_val:
+            return f'ERROR: Invalid value "{field_value}" for checkbox field "{field_id}". The checked value is "{checked_val}" and the unchecked value is "{unchecked_val}"'
+    elif field_type == "radio_group":
+        option_values = [opt["value"] for opt in field_info["radio_options"]]
+        if field_value not in option_values:
+            return f'ERROR: Invalid value "{field_value}" for radio group field "{field_id}". Valid values are: {option_values}' 
+    elif field_type == "choice":
+        choice_values = [opt["value"] for opt in field_info["choice_options"]]
+        if field_value not in choice_values:
+            return f'ERROR: Invalid value "{field_value}" for choice field "{field_id}". Valid values are: {choice_values}'
+    return None
+
+
+def monkeypatch_pydpf_method():
+    from pypdf.generic import DictionaryObject
+    from pypdf.constants import FieldDictionaryAttributes
+
+    original_get_inherited = DictionaryObject.get_inherited
+
+    def patched_get_inherited(self, key: str, default = None):
+        result = original_get_inherited(self, key, default)
+        if key == FieldDictionaryAttributes.Opt:
+            if isinstance(result, list) and all(isinstance(v, list) and len(v) == 2 for v in result):
+                result = [r[0] for r in result]
+        return result
+
+    DictionaryObject.get_inherited = patched_get_inherited
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 4:
+        print("Usage: fill_fillable_fields.py [input pdf] [field_values.json] [output pdf]")
+        sys.exit(1)
+    monkeypatch_pydpf_method()
+    input_pdf = sys.argv[1]
+    fields_json = sys.argv[2]
+    output_pdf = sys.argv[3]
+    fill_pdf_fields(input_pdf, fields_json, output_pdf)

--- a/seed/skills/pdf/scripts/fill_pdf_form_with_annotations.py
+++ b/seed/skills/pdf/scripts/fill_pdf_form_with_annotations.py
@@ -1,0 +1,107 @@
+import json
+import sys
+
+from pypdf import PdfReader, PdfWriter
+from pypdf.annotations import FreeText
+
+
+
+
+def transform_from_image_coords(bbox, image_width, image_height, pdf_width, pdf_height):
+    x_scale = pdf_width / image_width
+    y_scale = pdf_height / image_height
+
+    left = bbox[0] * x_scale
+    right = bbox[2] * x_scale
+
+    top = pdf_height - (bbox[1] * y_scale)
+    bottom = pdf_height - (bbox[3] * y_scale)
+
+    return left, bottom, right, top
+
+
+def transform_from_pdf_coords(bbox, pdf_height):
+    left = bbox[0]
+    right = bbox[2]
+
+    pypdf_top = pdf_height - bbox[1]      
+    pypdf_bottom = pdf_height - bbox[3]   
+
+    return left, pypdf_bottom, right, pypdf_top
+
+
+def fill_pdf_form(input_pdf_path, fields_json_path, output_pdf_path):
+    
+    with open(fields_json_path, "r") as f:
+        fields_data = json.load(f)
+    
+    reader = PdfReader(input_pdf_path)
+    writer = PdfWriter()
+    
+    writer.append(reader)
+    
+    pdf_dimensions = {}
+    for i, page in enumerate(reader.pages):
+        mediabox = page.mediabox
+        pdf_dimensions[i + 1] = [mediabox.width, mediabox.height]
+    
+    annotations = []
+    for field in fields_data["form_fields"]:
+        page_num = field["page_number"]
+
+        page_info = next(p for p in fields_data["pages"] if p["page_number"] == page_num)
+        pdf_width, pdf_height = pdf_dimensions[page_num]
+
+        if "pdf_width" in page_info:
+            transformed_entry_box = transform_from_pdf_coords(
+                field["entry_bounding_box"],
+                float(pdf_height)
+            )
+        else:
+            image_width = page_info["image_width"]
+            image_height = page_info["image_height"]
+            transformed_entry_box = transform_from_image_coords(
+                field["entry_bounding_box"],
+                image_width, image_height,
+                float(pdf_width), float(pdf_height)
+            )
+        
+        if "entry_text" not in field or "text" not in field["entry_text"]:
+            continue
+        entry_text = field["entry_text"]
+        text = entry_text["text"]
+        if not text:
+            continue
+        
+        font_name = entry_text.get("font", "Arial")
+        font_size = str(entry_text.get("font_size", 14)) + "pt"
+        font_color = entry_text.get("font_color", "000000")
+
+        annotation = FreeText(
+            text=text,
+            rect=transformed_entry_box,
+            font=font_name,
+            font_size=font_size,
+            font_color=font_color,
+            border_color=None,
+            background_color=None,
+        )
+        annotations.append(annotation)
+        writer.add_annotation(page_number=page_num - 1, annotation=annotation)
+        
+    with open(output_pdf_path, "wb") as output:
+        writer.write(output)
+    
+    print(f"Successfully filled PDF form and saved to {output_pdf_path}")
+    print(f"Added {len(annotations)} text annotations")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 4:
+        print("Usage: fill_pdf_form_with_annotations.py [input pdf] [fields.json] [output pdf]")
+        sys.exit(1)
+    input_pdf = sys.argv[1]
+    fields_json = sys.argv[2]
+    output_pdf = sys.argv[3]
+    
+    fill_pdf_form(input_pdf, fields_json, output_pdf)

--- a/seed/skills/product-manager/SKILL.md
+++ b/seed/skills/product-manager/SKILL.md
@@ -1,0 +1,593 @@
+---
+name: product-manager
+description: Product management playbook — use when discovering recurring customer problems, writing user stories, prioritizing features with RICE scoring, planning roadmaps (Now/Next/Later), or drafting structured Linear tickets from cross-channel data (Pylon, Linear, Grain, Slack, HubSpot)
+user-invocable: true
+---
+
+# Product Manager Playbook
+
+A unified product management skill with 5 modes: Problem Discovery, User Story Writing, Prioritization, Roadmap Planning, and Linear Ticket Operations.
+
+**Scope boundary**: This skill handles the *strategic product layer* — discovering patterns across channels, writing stories, prioritizing, and planning. It complements (does not replace):
+- **feature-request-triage**: Investigates individual feature requests (docs/code lookup, workaround detection)
+- **bug-triage**: Investigates individual bugs (root cause analysis, code search)
+- **use-case-advisory**: Designs specific campaign/journey configurations for customers
+
+---
+
+## Mode Selection
+
+Determine the mode based on the user's request:
+
+| User Says | Mode |
+|---|---|
+| "What are the top problems?", "recurring issues", "what are customers asking for?", "pain points" | Problem Discovery |
+| "Write a user story", "create stories for X", "acceptance criteria" | User Story Writing |
+| "Prioritize these", "RICE score", "what should we build next?", "rank these features" | Prioritization |
+| "Plan the roadmap", "what goes in next sprint?", "Now/Next/Later", "quarterly plan" | Roadmap Planning |
+| "Create a ticket for X", "draft a Linear issue", "turn this into a ticket" | Linear Ticket Ops |
+| "Help me plan what to build" (general) | Start with Problem Discovery, then flow through all modes |
+
+If the mode is ambiguous, ask:
+
+```
+Which product management activity do you need help with?
+
+1. *Problem Discovery* — Mine Pylon, Linear, Grain, Slack, and HubSpot for recurring customer pain points
+2. *User Story Writing* — Write structured user stories with acceptance criteria
+3. *Prioritization* — RICE-score and rank a set of features/problems
+4. *Roadmap Planning* — Sequence priorities into Now/Next/Later buckets
+5. *Linear Ticket Ops* — Draft and create structured Linear tickets
+```
+
+---
+
+## Mode 1: Problem Discovery
+
+### Purpose
+Mine all available data channels to identify recurring customer problems, rank them by frequency and impact, and surface the top problems worth solving.
+
+### Step 1: Gather Data from All Channels
+
+Run these data-gathering queries in parallel:
+
+#### 1a. Pylon Support Tickets
+Load the **pylon-support** skill and search for recent tickets. Look for:
+- Recurring themes in ticket subjects and messages
+- Tickets tagged with specific categories
+- High-volume ticket patterns over the last 30/60/90 days
+
+#### 1b. Linear Issues
+Use **Linear MCP** tools:
+- Search for issues in "Product Backlog" team with state "Triage" or "Backlog"
+- Search for issues labeled "feature-request" or "customer-request"
+- Look for issues with multiple customer references or duplicates
+- Check comment threads for additional context and customer names
+
+```
+Search queries to run:
+- list_issues with team "Product Backlog", states: Triage, Backlog
+- list_issues with label "feature-request"
+- search for issues with high comment counts (indicates discussion/demand)
+```
+
+#### 1c. Grain Meeting Recordings
+Load the **grain** skill and search for:
+- Meetings mentioning "feature request", "pain point", "blocker", "need", "want"
+- Customer call recordings from the last 30-60 days
+- Action items from customer calls that reference product gaps
+
+#### 1d. Slack Channels
+Load the **slack-reader** skill and read recent messages from:
+- `#feature-requests-clients` — direct customer feature requests
+- `#bugs` — recurring bugs that indicate product gaps
+- `#customer-feedback` — general customer feedback
+- `#sales` or `#deals` — feature gaps blocking deals
+
+#### 1e. HubSpot
+Use **HubSpot MCP** tools to check:
+- Deal notes mentioning "missing feature", "blocker", "competitor"
+- Lost deal reasons related to product gaps
+- Customer feedback logged in contact/company notes
+
+### Step 2: Aggregate and Deduplicate
+
+Group findings into problem themes. For each theme:
+
+1. **Problem Statement** (use the format below):
+   ```
+   [Customer segment] struggles with [problem]
+   when trying to [goal/job-to-be-done],
+   which results in [negative outcome].
+   ```
+
+2. **Evidence**:
+   - Number of unique customers mentioning it
+   - Channels where it appeared (Pylon, Linear, Grain, Slack, HubSpot)
+   - Specific customer names and quotes
+   - Related Linear ticket IDs
+
+3. **Frequency Score** (1-5):
+   - 5: 10+ customers, multiple channels
+   - 4: 5-9 customers, 2+ channels
+   - 3: 3-4 customers, any channel
+   - 2: 2 customers
+   - 1: Single customer request
+
+4. **Intensity Score** (1-5):
+   - 5: Blocking revenue / causing churn
+   - 4: Significant workflow disruption
+   - 3: Moderate inconvenience, workaround exists
+   - 2: Minor annoyance
+   - 1: Nice-to-have
+
+### Step 3: Rank Problems
+
+Calculate **Impact Score** = Frequency x Intensity (max 25).
+
+Present the top problems in a ranked table:
+
+```
+*Top Customer Problems — [Date Range]*
+
+| # | Problem | Impact | Freq | Intensity | Customers | Channels | Linear |
+|---|---------|--------|------|-----------|-----------|----------|--------|
+| 1 | [problem] | 20 | 5 | 4 | [names] | Support, Calls, Slack | TICKET-123 |
+| 2 | [problem] | 16 | 4 | 4 | [names] | Tracker, Slack | TICKET-456 |
+| ... | ... | ... | ... | ... | ... | ... | ... |
+
+*Data sources queried*: Pylon (last 60 days), Linear (Backlog), Grain (last 30 days), Slack (#feature-requests-clients, #bugs), HubSpot (open deals)
+```
+
+### Step 4: Deep-Dive (Optional)
+
+If the user asks to go deeper on a specific problem:
+- Pull all related Pylon tickets and summarize the thread
+- Read full Grain transcripts mentioning the problem
+- Search the codebase for related feature flags or partial implementations
+- Check if any workaround exists (load **feature-request-triage** or **use-case-advisory**)
+
+---
+
+## Mode 2: User Story Writing
+
+### Format: Mike Cohn + Gherkin
+
+Write every user story in this structure:
+
+```markdown
+### [Story Title]
+
+**As a** [specific user persona],
+**I want to** [action/capability],
+**So that** [measurable business outcome].
+
+#### Acceptance Criteria (Gherkin)
+
+**Scenario 1: [Happy path name]**
+Given [precondition]
+When [action]
+Then [expected result]
+And [additional expectation]
+
+**Scenario 2: [Edge case name]**
+Given [precondition]
+When [action]
+Then [expected result]
+
+#### Notes
+- [Implementation hints, constraints, or dependencies]
+- [Related stories or tickets]
+```
+
+### INVEST Validation Checklist
+
+Before finalizing any story, validate against INVEST:
+
+| Criterion | Check | Pass? |
+|---|---|---|
+| **I**ndependent | Can be developed without depending on other stories in the same sprint | |
+| **N**egotiable | Details can be discussed — not a rigid spec | |
+| **V**aluable | Delivers value to the user or business | |
+| **E**stimable | Team can estimate the effort | |
+| **S**mall | Completable within one sprint (1-2 weeks) | |
+| **T**estable | Acceptance criteria are verifiable | |
+
+If a story fails the **S** (Small) check, split it using the 9 Splitting Patterns below.
+
+### 9 Story Splitting Patterns
+
+When a story is too large, apply these patterns (in order of preference):
+
+1. **Workflow Steps**: Split by sequential steps in a user workflow
+   - Example: "User completes checkout" -> "User adds to cart", "User enters shipping", "User pays"
+
+2. **Business Rule Variations**: Split by different business rules
+   - Example: "Apply discount" -> "Apply percentage discount", "Apply flat discount", "Apply BOGO"
+
+3. **Happy Path / Edge Cases**: Separate the core flow from error handling
+   - Example: "Upload file" -> "Upload valid file", "Handle invalid file type", "Handle oversized file"
+
+4. **Input Methods / Channels**: Split by platform or input method
+   - Example: "Send notification" -> "Send push (Android)", "Send push (iOS)", "Send email"
+
+5. **Data Variations**: Split by data type or format
+   - Example: "Import users" -> "Import from CSV", "Import from API", "Import from segment sync"
+
+6. **Interface Variations**: Split UI from API from backend
+   - Example: "Add webhook retry" -> "Backend retry logic", "Dashboard retry config UI", "Retry analytics"
+
+7. **Operations (CRUD)**: Split by create, read, update, delete
+   - Example: "Manage cohorts" -> "Create cohort", "View cohort members", "Edit cohort rules", "Delete cohort"
+
+8. **Performance / Scale**: Separate basic functionality from performance optimization
+   - Example: "Load dashboard" -> "Load dashboard (basic)", "Optimize dashboard for 10K+ campaigns"
+
+9. **Spike / Research**: Extract unknowns into a research spike
+   - Example: "Integrate with CleverTap" -> "Spike: Evaluate CleverTap API capabilities", "Implement CleverTap event sync"
+
+### Epic Hypothesis Format
+
+When creating epics (groups of related stories), use this hypothesis structure:
+
+```markdown
+## Epic: [Epic Name]
+
+**We believe that** [building this capability]
+**for** [target user segment]
+**will achieve** [expected outcome/metric].
+
+**We will know this is true when** [measurable signal/KPI].
+
+**Key risks**: [what could invalidate this hypothesis]
+```
+
+### Writing Guidelines
+
+- **Personas**: Use specific personas relevant to your product, not generic "user":
+  - *Growth Marketer*: Creates campaigns, analyzes metrics, runs A/B tests
+  - *Product Manager*: Defines targeting rules, plans journeys, reviews analytics
+  - *Developer*: Integrates SDK, configures events, manages technical setup
+  - *CSM (Customer Success Manager)*: Troubleshoots issues, monitors customer health
+  - *End User*: The customer's user who sees nudges, widgets, stories in the app
+
+- **Outcomes over outputs**: "So that conversion rate increases by X%" not "so that a button appears"
+
+- **One behavior per story**: Each story should describe exactly one user behavior change
+
+- **Include "so that"**: Never skip the business outcome — it drives prioritization
+
+---
+
+## Mode 3: Prioritization
+
+### Framework: RICE with Strategic Overrides
+
+Score each item on four dimensions:
+
+#### R — Reach (How many users/customers are affected?)
+
+| Score | Definition |
+|---|---|
+| 10 | All customers / platform-wide |
+| 7 | Most customers (70%+) |
+| 5 | Many customers (30-70%) |
+| 3 | Some customers (10-30%) |
+| 1 | Few customers (<10%) or single enterprise |
+
+*Data source*: Problem Discovery frequency data, HubSpot customer count, Pylon ticket volume.
+
+#### I — Impact (How much does it move the needle per user?)
+
+| Score | Definition |
+|---|---|
+| 3 | Massive — unlocks new revenue, prevents churn, competitive must-have |
+| 2 | High — significant workflow improvement, measurable metric lift |
+| 1 | Medium — nice improvement, moderate time savings |
+| 0.5 | Low — minor quality-of-life, cosmetic |
+| 0.25 | Minimal — very slight improvement |
+
+*Data source*: Problem Discovery intensity data, deal values at risk (HubSpot), customer segment (enterprise vs SMB).
+
+#### C — Confidence (How sure are we about R, I, and effort?)
+
+| Score | Definition |
+|---|---|
+| 100% | High — validated by data, multiple customer confirmations, clear requirements |
+| 80% | Medium — some data, reasonable assumptions, partially validated |
+| 50% | Low — gut feel, single customer request, unclear scope |
+
+*Boost confidence by*: More customer evidence, prototype/spike results, competitive analysis.
+
+#### E — Effort (Person-weeks to ship)
+
+Estimate in person-weeks. Include: design, development, testing, documentation, rollout.
+
+| Estimate | Typical Scope |
+|---|---|
+| 0.5 | Config change, small UI tweak |
+| 1 | Single feature, 1 developer |
+| 2 | Medium feature, 1-2 developers |
+| 4 | Large feature, multiple developers |
+| 8+ | Epic-level, cross-team |
+
+### RICE Score Formula
+
+```
+RICE Score = (Reach x Impact x Confidence) / Effort
+```
+
+### Strategic Overrides
+
+After calculating RICE scores, apply these multipliers:
+
+| Override | Multiplier | When to Apply |
+|---|---|---|
+| Revenue blocker | 2x | Feature gap blocking signed deals (check HubSpot) |
+| Churn risk | 2x | Existing customer threatening to leave without this |
+| Competitive threat | 1.5x | Competitor just shipped this, customers are comparing |
+| Platform bet | 1.5x | Aligns with a strategic platform direction (e.g., off-app expansion) |
+| Tech debt paydown | 0.75x | Important but no direct customer value |
+| Single-customer request | 0.5x | Only one customer wants it, no strategic alignment |
+
+### Output Format
+
+Present the prioritized backlog:
+
+```
+*Prioritized Backlog — [Date]*
+
+| # | Item | Reach | Impact | Confidence | Effort | RICE | Override | Final |
+|---|------|-------|--------|------------|--------|------|----------|-------|
+| 1 | [feature] | 7 | 3 | 80% | 2 | 8.4 | Revenue 2x | 16.8 |
+| 2 | [feature] | 10 | 2 | 100% | 4 | 5.0 | — | 5.0 |
+| ... | ... | ... | ... | ... | ... | ... | ... | ... |
+
+*Top 3 Recommendation*:
+1. [Feature] — [1-line rationale]
+2. [Feature] — [1-line rationale]
+3. [Feature] — [1-line rationale]
+```
+
+---
+
+## Mode 4: Roadmap Planning
+
+### Framework: Now / Next / Later
+
+Sequence the prioritized backlog into time horizons:
+
+| Horizon | Timeframe | Criteria |
+|---|---|---|
+| **Now** | This sprint / next 2 weeks | High RICE, clear requirements, no blockers, team capacity available |
+| **Next** | Next 2-6 weeks (1-3 sprints) | High RICE but needs design/spike, or blocked by a "Now" item |
+| **Later** | 1-3 months out | Medium RICE, needs research, strategic but not urgent |
+| **Icebox** | No timeline | Low RICE, single-customer, or superseded by other items |
+
+### Step 1: Capacity Check
+
+Ask the user:
+- How many developers are available this sprint?
+- Any ongoing commitments that reduce capacity? (on-call, tech debt sprints, etc.)
+- Any hard deadlines? (customer commitments, regulatory, partnership launches)
+
+### Step 2: Dependency Mapping
+
+For each "Now" item, check:
+- Does it depend on another item being completed first?
+- Does it block other high-priority items?
+- Does it require coordination across teams (SDK + Backend + Dashboard)?
+
+Present dependencies as a simple list:
+
+```
+*Dependencies*:
+- [Feature A] blocks [Feature B] — A must ship first
+- [Feature C] requires SDK release — coordinate with SDK team
+- [Feature D] and [Feature E] are independent — can parallelize
+```
+
+### Step 3: Theme Grouping
+
+Group related items into themes for stakeholder communication:
+
+```
+*Roadmap Themes*
+
+*Theme 1: [Theme Name]* (e.g., "Off-App Channel Expansion")
+- Now: [item 1], [item 2]
+- Next: [item 3]
+- Later: [item 4]
+
+*Theme 2: [Theme Name]* (e.g., "Gamification Enhancements")
+- Now: [item 5]
+- Next: [item 6], [item 7]
+```
+
+### Step 4: Present the Roadmap
+
+```
+*Roadmap — [Quarter / Sprint]*
+
+*NOW (This Sprint)*
+| Item | Owner | Est. | Dependencies | Status |
+|------|-------|------|-------------|--------|
+| [feature] | [team] | [weeks] | None | Not started |
+| [feature] | [team] | [weeks] | Blocked by X | Waiting |
+
+*NEXT (Next 1-3 Sprints)*
+| Item | Owner | Est. | Why Not Now? |
+|------|-------|------|-------------|
+| [feature] | [team] | [weeks] | Needs design spike |
+| [feature] | [team] | [weeks] | Blocked by [Now item] |
+
+*LATER (This Quarter)*
+| Item | Owner | Est. | Notes |
+|------|-------|------|-------|
+| [feature] | [team] | [weeks] | Needs research |
+
+*ICEBOX*
+- [item] — [reason for deprioritization]
+```
+
+---
+
+## Mode 5: Linear Ticket Operations
+
+### Purpose
+Draft and create well-structured Linear tickets from any of the above modes, or from ad-hoc requests.
+
+### Ticket Structure
+
+Every Linear ticket created by this skill must follow this template:
+
+```markdown
+## Problem Statement
+
+[Customer segment] struggles with [problem]
+when trying to [goal/job-to-be-done],
+which results in [negative outcome].
+
+**Evidence**: [X customers across Y channels — list names and ticket/call refs]
+
+## User Stories
+
+### Story 1: [Title]
+**As a** [persona], **I want to** [action], **So that** [outcome].
+
+#### Acceptance Criteria
+- [ ] Given [context], When [action], Then [result]
+- [ ] Given [context], When [action], Then [result]
+
+### Story 2: [Title] (if applicable)
+...
+
+## Scope
+
+**In scope**:
+- [Specific deliverable 1]
+- [Specific deliverable 2]
+
+**Out of scope**:
+- [Explicitly excluded item]
+
+## Technical Notes
+- [Affected repos/services]
+- [Related tickets: TICKET-xxx, TICKET-yyy]
+- [Known constraints or dependencies]
+
+## Success Metrics
+- [How we'll measure if this solved the problem]
+- [Target metric and timeframe]
+
+---
+*Generated by Product Manager skill from: [data sources used]*
+```
+
+### Creating the Ticket
+
+1. **Determine the team**: Ask the user, or default based on context:
+   - Feature requests -> "Product Backlog" team
+   - Bugs -> "Engineering" team
+   - If unsure, ask
+
+2. **Determine the state**: Default to "Triage" unless the user specifies otherwise
+
+3. **Set priority**: Use RICE score if available, otherwise ask:
+   - Urgent (P0): Blocking revenue or causing outage
+   - High (P1): Significant impact, needed this quarter
+   - Medium (P2): Important but not urgent
+   - Low (P3): Nice-to-have
+
+4. **Add labels**: Based on content:
+   - "feature-request" for new features
+   - "customer-request" if tied to specific customer asks
+   - "improvement" for enhancements to existing features
+   - "tech-debt" for internal improvements
+
+5. **Create via Linear MCP**:
+   ```
+   Use mcp__linear__save_issue with:
+   - title: Concise, action-oriented (e.g., "Add webhook retry with configurable backoff")
+   - description: Full template above in Markdown
+   - teamId: [resolved team ID]
+   - stateId: [resolved "Triage" state ID]
+   - priority: [1-4 mapping]
+   - labelIds: [resolved label IDs]
+   ```
+
+6. **Confirm with user**: Share the created ticket URL and summary
+
+### Bulk Ticket Creation
+
+When the user wants to create multiple tickets (e.g., from a Problem Discovery session):
+
+1. Draft all tickets first and present them in a summary table
+2. Ask for confirmation: "I've drafted X tickets. Want me to create all of them, or review individually?"
+3. Create on confirmation, reporting each created ticket's URL
+
+---
+
+## Cross-Mode Workflows
+
+### Full Planning Cycle
+
+When a user asks for end-to-end planning help (e.g., "help me plan what to build next quarter"):
+
+1. **Problem Discovery** -> Surface top 10 problems
+2. **User Story Writing** -> Write stories for top 5 problems
+3. **Prioritization** -> RICE-score all items
+4. **Roadmap Planning** -> Sequence into Now/Next/Later
+5. **Linear Ticket Ops** -> Create tickets for "Now" items
+
+At each transition, present findings and ask if the user wants to continue to the next mode.
+
+### From Individual Triage to Strategic
+
+When feature-request-triage or bug-triage identifies a pattern (e.g., "this is the 5th request for X"):
+- Suggest running Problem Discovery mode to validate the pattern
+- If confirmed, flow into User Story Writing and Prioritization
+
+---
+
+## Guardrails
+
+### Data-Driven Decisions
+- Never prioritize based on intuition alone — always cite evidence from at least one data source
+- When data is insufficient, say so: "I found evidence from X customers, but this may not represent the full picture. Consider validating with [suggested method]."
+
+### Avoid Scope Creep
+- Each user story must describe exactly one behavior change
+- If a story covers multiple behaviors, split it using the 9 patterns
+- "Out of scope" section is mandatory in every ticket
+
+### Customer Attribution
+- Always attribute problems to specific customers when possible
+- Never fabricate customer names — only use names found in actual data sources
+- Use customer names from Pylon tickets, Linear issues, Grain recordings, or HubSpot
+
+### Bias Awareness
+- Recency bias: Don't over-weight problems from the last week — check historical data
+- Loudness bias: A vocal customer doesn't mean a common problem — verify frequency
+- Sales bias: Features requested by prospects in active deals may not serve the broader customer base — flag this
+
+### Effort Estimation
+- This skill provides rough estimates only — always note that engineering team should refine estimates
+- When in doubt, estimate higher (it's better to over-estimate than under-estimate)
+
+---
+
+## Quick Reference: Adapting to Your Product
+
+The modes above are product-agnostic. To get the most out of this skill, keep a
+short product-specific cheat sheet handy (or add it to this skill) covering:
+
+- **Common problem categories** — the recurring themes your customers' problems
+  cluster into (e.g. targeting, display/UX, analytics, integration, performance),
+  so discovery can tag and group them quickly.
+- **Tracker teams** — which team in your issue tracker owns which kind of work
+  (e.g. Engineering for bugs, a Product Backlog for features), so tickets route
+  correctly.
+- **Key success metrics** — the metrics you reference when writing ticket success
+  criteria (e.g. support-ticket volume, activation rate, time-to-value, NPS/CSAT,
+  churn, feature adoption).

--- a/seed/skills/slack-reader/SKILL.md
+++ b/seed/skills/slack-reader/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: slack-reader
+description: Slack channel history, listing, and messaging — use when reading Slack conversations, listing channels, checking channel activity, finding messages, sending or posting messages to Slack channels, or replying in Slack threads.
+user-invocable: false
+---
+
+# Slack — Channel History, Listing & Messaging
+
+Read Slack channel messages, list accessible channels, and send messages to channels. Use when asked about what was discussed in a channel, recent activity, finding a specific channel, or when needing to send/post a message to a Slack channel.
+
+## Available Commands
+
+This is a **CLI tool** — invoke via Bash. Do NOT look for MCP tools.
+
+### `channels` — List accessible channels
+
+```bash
+python3 tools/slack_reader.py channels
+python3 tools/slack_reader.py channels --query engineering
+python3 tools/slack_reader.py channels --query bugs
+```
+
+Returns channel name, ID, member count, purpose, and whether it's private. Use `--query` to filter by name or purpose.
+
+### `history` — Read recent messages from a channel
+
+```bash
+python3 tools/slack_reader.py history "#general"
+python3 tools/slack_reader.py history "#general" --limit 20
+python3 tools/slack_reader.py history C12345ABC --limit 100
+```
+
+- Accepts channel name (with or without `#`) or channel ID
+- Default: 50 messages, max: 200
+- Messages are returned in chronological order (oldest first)
+- Includes: user names, timestamps, text, reactions, file attachments, thread reply counts
+
+### `send` — Send a message to a channel
+
+```bash
+python3 tools/slack_reader.py send "#general" --text "Hello from the bot!"
+python3 tools/slack_reader.py send C12345ABC --text "Message using channel ID"
+python3 tools/slack_reader.py send "#general" --thread-ts 1234567890.123456 --text "Thread reply"
+python3 tools/slack_reader.py send "#general" --text "Here's the report" --file /tmp/report.pdf --file-title "Monthly Report"
+```
+
+For long or multiline messages, pipe via stdin:
+
+```bash
+cat <<'EOF' | python3 tools/slack_reader.py send "#general"
+This is a longer message
+with multiple lines
+and *Slack mrkdwn* formatting.
+EOF
+```
+
+- Accepts channel name (with or without `#`) or channel ID
+- Message text via `--text` flag or stdin (stdin is preferred for long/multiline content)
+- Optional `--thread-ts` to reply in a thread (use a message timestamp from `history` output)
+- Optional `--file /path/to/file` to upload and attach a file to the message
+- Optional `--file-title TITLE` to set a custom title for the uploaded file
+- Supports Slack mrkdwn formatting in message text
+- Returns the sent message timestamp (useful for threading follow-up replies)
+- Bot must be a member of the channel and have `chat:write` scope
+
+---
+
+## Sending Direct Messages (DMs)
+
+The `send` command works with channels, not DMs directly. To send a DM via the bot, use the Slack API directly via curl:
+
+### Step 1: Find the user's Slack ID
+
+```bash
+curl -s -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+  "https://slack.com/api/users.list?limit=500" | \
+  python3 -c "import json,sys; users=json.load(sys.stdin)['members']; [print(f\"{u['id']} {u['real_name']}\") for u in users if 'TARGET_NAME'.lower() in u.get('real_name','').lower()]"
+```
+
+Replace `TARGET_NAME` with the person's name (case-insensitive partial match).
+
+### Step 2: Open a DM conversation
+
+```bash
+curl -s -X POST -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"users": "USER_ID"}' \
+  "https://slack.com/api/conversations.open" | \
+  python3 -c "import json,sys; r=json.load(sys.stdin); print(r['channel']['id'])"
+```
+
+Replace `USER_ID` with the Slack user ID from Step 1.
+
+### Step 3: Send the DM using the channel ID
+
+```bash
+curl -s -X POST -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"channel": "DM_CHANNEL_ID", "text": "Your message here"}' \
+  "https://slack.com/api/chat.postMessage"
+```
+
+Replace `DM_CHANNEL_ID` with the channel ID from Step 2.
+
+**Important notes for DMs:**
+- The DM channel ID looks like `D0XXXXXXXXX` (starts with `D`)
+- DO NOT pass the DM channel ID to `slack_reader.py send` with a `#` prefix — use the raw ID with the curl approach above
+- The bot must have `im:write` scope to send DMs
+- You can also use `conversations.open` with multiple user IDs to create a group DM (MPIM)
+
+---
+
+## Common Workflows
+
+### Check what was discussed in a channel
+1. Read history: `python3 tools/slack_reader.py history "#product" --limit 50`
+2. Summarize key topics and action items from the messages
+
+### Find a specific channel
+1. Search: `python3 tools/slack_reader.py channels --query onboarding`
+2. Use the channel ID or name from results in follow-up commands
+
+### Review recent activity in a channel
+1. Read history with a limit: `python3 tools/slack_reader.py history "#bugs" --limit 30`
+2. Identify patterns, recurring issues, or topics
+
+### Send a message to a channel
+1. Find the channel: `python3 tools/slack_reader.py channels --query alerts`
+2. Send: `python3 tools/slack_reader.py send "#product-alerts" --text "Daily report is ready."`
+
+### Reply in a thread
+1. Read history to find the parent message timestamp: `python3 tools/slack_reader.py history "#bugs" --limit 10`
+2. Reply in thread: `python3 tools/slack_reader.py send "#bugs" --thread-ts 1234567890.123456 --text "Following up on this."`
+
+### Send a DM to a specific person
+1. Find the user's Slack ID: `curl -s -H "Authorization: Bearer $SLACK_BOT_TOKEN" "https://slack.com/api/users.list?limit=500" | python3 -c "..."`
+2. Open a DM conversation: `curl -s -X POST ... conversations.open ...`
+3. Send the message: `curl -s -X POST ... chat.postMessage ...`
+4. See the **Sending Direct Messages (DMs)** section above for full commands.
+
+### Post a formatted update
+```bash
+cat <<'EOF' | python3 tools/slack_reader.py send "#engineering"
+*Daily Build Status* :white_check_mark:
+
+• All tests passing
+• Build deployed to staging
+• No new issues found
+EOF
+```
+
+## Important Notes
+
+- **Verify automated post timestamps**: When a user reports that automated posts have stopped appearing in a channel, NEVER claim the posts are 'still flowing in consistently' without first verifying the actual timestamps of recent posts. Before responding, query the channel history with a filter for the specific bot/message type and check the dates of the most recent posts. If you cannot verify with data, say "let me check" rather than asserting everything is working.
+- **Private channels**: The bot must be invited to a private channel to read or write to it. If you get a "not in channel" error, the bot hasn't been added.
+- **Thread replies**: The `thread_replies` count is shown in history but individual thread messages are not fetched. If a specific thread is important, note this limitation.
+- **Bot messages**: Bot messages are prefixed with `[bot]` and the bot's name.
+- **Rate limits**: Slack has rate limits (~50 requests/min for most endpoints). Avoid reading many channels or sending many messages in rapid succession. When using channel names (not IDs), prefer channel IDs to avoid extra API calls for resolution.
+- **chat:write scope**: The bot token must have `chat:write` scope to send messages. If you get a "missing_scope" error, the bot's OAuth permissions need updating.
+
+## Error Handling
+- **channel_not_found**: Channel doesn't exist or bot can't see it
+- **not_in_channel**: Bot needs to be invited to the channel
+- **missing_scope**: Bot needs `chat:write` permission (for send)
+- **invalid_auth**: Bot token is invalid or expired
+- **no_text**: Message text was empty
+- **ratelimited**: Too many API calls — wait and retry
+- **No results for query**: Try a broader search term with `channels --query`
+- **Missing token**: Ensure `SLACK_BOT_TOKEN` is set in `.env`
+
+## Configuration
+Requires `SLACK_BOT_TOKEN` environment variable (already configured for the bot).
+Bot needs `channels:read`, `channels:history`, `chat:write`, `im:write`, and `users:read` scopes.

--- a/seed/skills/web-artifacts-builder/SKILL.md
+++ b/seed/skills/web-artifacts-builder/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: web-artifacts-builder
+description: Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui). Use for complex artifacts requiring state management, routing, or shadcn/ui components - not for simple single-file HTML/JSX artifacts.
+user-invocable: false
+---
+
+# Web Artifacts Builder
+
+To build powerful frontend claude.ai artifacts, follow these steps:
+1. Initialize the frontend repo using `scripts/init-artifact.sh`
+2. Develop your artifact by editing the generated code
+3. Bundle all code into a single HTML file using `scripts/bundle-artifact.sh`
+4. Display artifact to user
+5. (Optional) Test the artifact
+
+**Stack**: React 18 + TypeScript + Vite + Parcel (bundling) + Tailwind CSS + shadcn/ui
+
+## Design & Style Guidelines
+
+VERY IMPORTANT: To avoid what is often referred to as "AI slop", avoid using excessive centered layouts, purple gradients, uniform rounded corners, and Inter font.
+
+## Quick Start
+
+### Step 1: Initialize Project
+
+Run the initialization script to create a new React project:
+```bash
+bash scripts/init-artifact.sh <project-name>
+cd <project-name>
+```
+
+This creates a fully configured project with:
+- ✅ React + TypeScript (via Vite)
+- ✅ Tailwind CSS 3.4.1 with shadcn/ui theming system
+- ✅ Path aliases (`@/`) configured
+- ✅ 40+ shadcn/ui components pre-installed
+- ✅ All Radix UI dependencies included
+- ✅ Parcel configured for bundling (via .parcelrc)
+- ✅ Node 18+ compatibility (auto-detects and pins Vite version)
+
+### Step 2: Develop Your Artifact
+
+To build the artifact, edit the generated files. See **Common Development Tasks** below for guidance.
+
+### Step 3: Bundle to Single HTML File
+
+To bundle the React app into a single HTML artifact:
+```bash
+bash scripts/bundle-artifact.sh
+```
+
+This creates `bundle.html` - a self-contained artifact with all JavaScript, CSS, and dependencies inlined. This file can be directly shared in Claude conversations as an artifact.
+
+**Requirements**: Your project must have an `index.html` in the root directory.
+
+**What the script does**:
+- Installs bundling dependencies (parcel, @parcel/config-default, parcel-resolver-tspaths, html-inline)
+- Creates `.parcelrc` config with path alias support
+- Builds with Parcel (no source maps)
+- Inlines all assets into single HTML using html-inline
+
+### Step 4: Share Artifact with User
+
+Finally, share the bundled HTML file in conversation with the user so they can view it as an artifact.
+
+### Step 5: Testing/Visualizing the Artifact (Optional)
+
+Note: This is a completely optional step. Only perform if necessary or requested.
+
+To test/visualize the artifact, use available tools (including other Skills or built-in tools like Playwright or Puppeteer). In general, avoid testing the artifact upfront as it adds latency between the request and when the finished artifact can be seen. Test later, after presenting the artifact, if requested or if issues arise.
+
+## Reference
+
+- **shadcn/ui components**: https://ui.shadcn.com/docs/components


### PR DESCRIPTION
## What

A freshly cloned Loma deployment starts with an **empty** skills collection, so the agent has nothing useful to draw on. This seeds a curated set of **13 generic, company-agnostic starter skills** on first boot — making a new deployment useful immediately.

## Safety: existing deployments are never touched

Seeding runs **only when `db.skills.count_documents({}) == 0`** (mirroring the existing first-run user auto-provision pattern). It is all-or-nothing on emptiness:
- A populated deployment (e.g. prod, or any upgrade) → `count > 0` → **no-op**. Existing skills are never read, modified, overwritten, or duplicated.
- A fresh/empty deployment → seeds the 13 skills.
- `LOMA_SEED_SKILLS=false` disables it entirely.

## How (reuses existing code)

- **`api/skill_seed.py`** — `seed_default_skills(db)`: empty-check guard, then loops `seed/skills/*/` calling the existing idempotent `skill_service.import_skill_directory(db, dir, actor="system")`. Wrapped so a seed failure never blocks startup.
- **`app.py`** — called right after `init_observability()` (before the skill-index refresh, so seeded skills show up in the agent's index).
- **`config/app_config.py` + `.env.example`** — `LOMA_SEED_SKILLS` (default true).

## Seed set (scrubbed of all internal references)

`diagrams, frontend-design, web-artifacts-builder, algorithmic-art, mcp-builder, doc-coauthoring, slack-reader, pdf, pdf-reading, code-review, product-manager, implement-ticket, improve-skill`

- `implement-ticket` — genericized (removed the `plotline-services` monorepo map → "determine the repo from the ticket/config"; `<owner>` placeholders).
- `improve-skill` — rewritten from the internal git-repo editing flow to Loma's `tools/loma_skills.py` (create/import-dir/update-file) model.
- `code-review` / `product-manager` — de-internalized (generic owners, removed the "Plotline-Specific" section).
- The remaining 9 were already generic.

The repo's existing **`public-content-scan`** CI job blocks the `plotline`/`usegogo`/`plotlinehq`/`PLO-` markers, so the scrub is enforced by CI, not just review.

## Dependencies

`pdf`/`pdf-reading` bundle helper scripts, so the backend image gains their toolchain: `pypdf, pdfplumber, pypdfium2, reportlab, pillow, pdf2image, pytesseract` (+ apt `poppler-utils`, `tesseract-ocr`). ~100 MB image bump; happy to drop `tesseract-ocr` and mark OCR flows optional if you'd prefer leaner.

## Test
- `check_public_content.py` + `check_secrets.py` pass (scrub enforced).
- All 13 SKILL.md frontmatters parse; all 13 packages pass `validate_skill_package`.
- `compileall` clean (vendored pdf scripts + changed modules); `app.py`/`skill_seed` import OK.
- First-run seed will exercise automatically on any fresh/empty DB (e.g. a new preview env); prod (populated) is a no-op.

## Caveat
A few seeded skills reference helper scripts under `tools/` (e.g. `slack-reader` → `tools/slack_reader.py`) that may not exist in a base Loma install; the skill text still guides the agent, which falls back to MCP/standard tools. Can follow up to align those references if desired.