### PR TITLE
Fix terminal websocket auth subrequest headers

### DIFF
--- a/deploy/nginx/conf.d/loma.conf
+++ b/deploy/nginx/conf.d/loma.conf
@@ -47,6 +47,11 @@ server {
         proxy_pass http://loma_dashboard/api/whoami;
         proxy_pass_request_body off;
         proxy_set_header Content-Length "";
+        # auth_request is a plain HTTP subrequest, even when the original request
+        # is a WebSocket upgrade. Do not forward hop-by-hop upgrade headers to
+        # NextAuth's /api/whoami endpoint.
+        proxy_set_header Upgrade "";
+        proxy_set_header Connection "";
         # Cookie + Host are forwarded from the original request so NextAuth can
         # validate the session.
     }

--- a/deploy/nginx/templates/loma-tls.conf.template
+++ b/deploy/nginx/templates/loma-tls.conf.template
@@ -55,6 +55,11 @@ server {
         proxy_pass http://loma_dashboard/api/whoami;
         proxy_pass_request_body off;
         proxy_set_header Content-Length "";
+        # auth_request is a plain HTTP subrequest, even when the original request
+        # is a WebSocket upgrade. Do not forward hop-by-hop upgrade headers to
+        # NextAuth's /api/whoami endpoint.
+        proxy_set_header Upgrade "";
+        proxy_set_header Connection "";
     }
 
     # NextAuth and self-signup are served by the dashboard (no identity needed).


### PR DESCRIPTION
## Summary
- Clear hop-by-hop WebSocket upgrade headers on nginx's internal /_whoami auth_request subrequest
- Apply the same fix to the plain HTTP nginx config and TLS template
- Keeps websocket upgrade forwarding intact for the actual backend /api/terminal/ws request

## Root cause
The Manage Integrations Claude login terminal opens /api/terminal/ws through nginx. nginx was inheriting Upgrade and Connection headers into the internal /_whoami auth_request. That auth subrequest targets the dashboard's normal HTTP /api/whoami endpoint, so websocket upgrade headers could make the auth check fail with 400 before the backend PTY terminal was reached.

## Test Plan
- python scripts/check_public_content.py
- python scripts/check_secrets.py
- Targeted static assertion that both /_whoami blocks clear Upgrade and Connection headers
