### PR TITLE
Fix terminal websocket nginx forwarding

### DIFF
--- a/deploy/nginx/conf.d/loma.conf
+++ b/deploy/nginx/conf.d/loma.conf
@@ -65,6 +65,16 @@ server {
     location /api/ {
         auth_request /_whoami;
         auth_request_set $auth_email $upstream_http_x_auth_email;
+        # This location sets X-User-Email, so nginx will not inherit the
+        # proxy_set_header directives from the server block. Repeat the common
+        # headers here, including WebSocket upgrade headers for /api/terminal/ws.
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host  $host;
+        proxy_set_header Upgrade           $http_upgrade;
+        proxy_set_header Connection        $connection_upgrade;
         proxy_set_header X-User-Email $auth_email;   # overwrites any client value
         proxy_pass http://loma_backend;
     }

--- a/deploy/nginx/templates/loma-tls.conf.template
+++ b/deploy/nginx/templates/loma-tls.conf.template
@@ -70,6 +70,16 @@ server {
     location /api/ {
         auth_request /_whoami;
         auth_request_set $auth_email $upstream_http_x_auth_email;
+        # This location sets X-User-Email, so nginx will not inherit the
+        # proxy_set_header directives from the server block. Repeat the common
+        # headers here, including WebSocket upgrade headers for /api/terminal/ws.
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host  $host;
+        proxy_set_header Upgrade           $http_upgrade;
+        proxy_set_header Connection        $connection_upgrade;
         proxy_set_header X-User-Email $auth_email;   # overwrites any client value
         proxy_pass http://loma_backend;
     }

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -9,8 +9,14 @@ echo "Deploying $(git rev-parse --short HEAD)"
 
 docker compose up -d --build
 
-# The nginx reverse-proxy config is bind-mounted, so `up` may not reload it on a
-# config-only change. Reload it explicitly (no-op if nginx was just recreated).
+# The nginx reverse-proxy config is bind-mounted. In TLS mode the nginx image
+# renders /etc/nginx/templates/*.template into /etc/nginx/conf.d/ at container
+# start, so a reload is not enough for template-only changes. Force-recreate the
+# proxy after the stack is up; this is quick and preserves backend/dashboard.
+docker compose up -d --force-recreate --no-deps nginx
+
+# Reload after validation as a cheap safety net for plain bind-mounted config
+# changes and to fail loudly before the health check if the config is invalid.
 if docker compose exec -T nginx nginx -t >/dev/null 2>&1; then
   docker compose exec -T nginx nginx -s reload || true
 fi


### PR DESCRIPTION
## Summary
- Repeat common proxy headers inside nginx's /api/ location so /api/terminal/ws receives WebSocket Upgrade/Connection headers even though the location also injects X-User-Email
- Keep Upgrade/Connection cleared on the internal /_whoami auth_request subrequest
- Force-recreate nginx during deploy so TLS template changes are rendered into /etc/nginx/conf.d instead of only reloading stale generated config

## Root cause
There were two nginx issues:
1. The internal /_whoami auth_request should not receive WebSocket hop-by-hop headers.
2. After fixing that, /api/ still returned 400 because nginx does not inherit parent proxy_set_header directives once a child location defines any proxy_set_header. Since /api/ sets X-User-Email, it stopped inheriting Upgrade and Connection, so aiohttp never saw a valid WebSocket handshake.

## Test Plan
- python scripts/check_public_content.py
- python scripts/check_secrets.py
- bash -n scripts/deploy.sh
- Targeted static assertions for /_whoami cleared headers and /api/ WebSocket headers

## Production note
I hotfixed app.lomahq.com with these nginx config changes and force-recreated nginx so the active generated TLS config includes the /api/ websocket headers.
