### PR TITLE
feat: auto-detect data.issueId for webhook thread resolution

### DIFF
--- a/scheduler/webhook_executor.py
+++ b/scheduler/webhook_executor.py
@@ -83,7 +83,7 @@ def extract_thread_id(flow: dict, payload: dict) -> str | None:
             return str(value)
 
     # 2. Auto-detect for known webhook sources
-    for path in ("data.issue_id", "issue.id", "issue_id", "data.id"):
+    for path in ("data.issue_id", "issue.id", "issue_id", "data.issueId", "data.id"):
         value = _resolve_jsonpath(payload, path)
         if value is not None:
             return str(value)

--- a/tests/test_webhook_executor.py
+++ b/tests/test_webhook_executor.py
@@ -127,6 +127,24 @@ class TestExtractThreadId:
         payload = {"data": {"issue_id": "specific", "id": "generic"}}
         assert extract_thread_id(flow, payload) == "specific"
 
+    def test_autodetect_data_issue_id_camelcase(self):
+        """camelCase data.issueId is auto-detected."""
+        flow = {}
+        payload = {"data": {"issueId": "camel-123"}}
+        assert extract_thread_id(flow, payload) == "camel-123"
+
+    def test_priority_data_issueId_over_data_id(self):
+        """data.issueId should take precedence over data.id."""
+        flow = {}
+        payload = {"data": {"issueId": "specific", "id": "generic"}}
+        assert extract_thread_id(flow, payload) == "specific"
+
+    def test_priority_snake_case_over_data_issueId(self):
+        """Existing snake_case data.issue_id still beats camelCase data.issueId."""
+        flow = {}
+        payload = {"data": {"issue_id": "snake", "issueId": "camel"}}
+        assert extract_thread_id(flow, payload) == "snake"
+
 
 # ---------------------------------------------------------------------------
 # _build_conversation_context


### PR DESCRIPTION
## Summary
- Add camelCase `data.issueId` to the `extract_thread_id()` auto-detect list for webhook-triggered flows.
- Placed immediately **before** `data.id`, so when both are present `data.issueId` wins, while existing snake_case keys (`data.issue_id`, `issue.id`, `issue_id`) still take precedence over it.

## Context
Webhook-based flows resolve "same conversation" via a `thread_id` extracted from the payload (combined with `flow_id`). Previously the camelCase `data.issueId` shape was not recognized and such payloads fell through to `data.id`. This adds explicit support and gives `data.issueId` precedence over the generic `data.id`.

## Changes
- `scheduler/webhook_executor.py` — `extract_thread_id()` auto-detect tuple now includes `data.issueId` just before `data.id`.
- `tests/test_webhook_executor.py` — added tests for camelCase detection, precedence over `data.id`, and that snake_case `data.issue_id` still beats `data.issueId`.

## Testing
- Verified the new resolution logic with direct assertions (pytest is not installed in this environment):
  - `data.issueId` alone resolves to its value.
  - `data.issueId` beats `data.id` when both present.
  - `data.issue_id` (snake_case) still beats `data.issueId`.
  - Existing `data.id`-only resolution unchanged.
- Three matching unit tests added to `TestExtractThreadId`.

## Notes
- Both call sites that use `extract_thread_id` (conversation-resume lookup in `execute_webhook_flow()` and the in-flight supersede key in `dispatch_webhook_flow()`) pick up the new key automatically.
- The explicit `webhook_config.thread_id_path` config path is unchanged and still has top priority.
- This PR was generated by the Plotline IE Bot based on the request above. Please review carefully before merging.
