### PR TITLE
fix: skills scroll + stream chat responses

### DIFF
--- a/agent/client.py
+++ b/agent/client.py
@@ -18,6 +18,7 @@ from claude_agent_sdk import (
     AssistantMessage,
     ClaudeSDKClient,
     ResultMessage,
+    StreamEvent,
     TextBlock,
     ToolUseBlock,
     ToolResultBlock,
@@ -916,7 +917,25 @@ async def stream_agent(
         try:
             await client.query(full_prompt)
 
+            streamed_in_turn = False
+            streamed_first_chunk = False
+
             async for message in client.receive_response():
+                if isinstance(message, StreamEvent) and include_steps:
+                    evt = message.event
+                    if evt.get("type") == "content_block_delta":
+                        delta = evt.get("delta", {})
+                        if delta.get("type") == "text_delta":
+                            chunk = delta.get("text", "")
+                            if chunk:
+                                if not streamed_first_chunk:
+                                    yield {"type": "text", "text": chunk}
+                                    streamed_first_chunk = True
+                                else:
+                                    yield {"type": "text", "text": chunk, "append": True}
+                                streamed_in_turn = True
+                    continue
+
                 if isinstance(message, AssistantMessage):
                     # Check for rate limit / billing errors before processing
                     if message.error in ("rate_limit", "billing_error", "authentication_error"):
@@ -946,6 +965,10 @@ async def stream_agent(
                     if include_steps:
                         yield {"type": "turn", "turn_number": turn_count}
 
+                    text_already_streamed = streamed_in_turn
+                    streamed_in_turn = False
+                    streamed_first_chunk = False
+
                     for block in message.content:
                         if isinstance(block, TextBlock):
                             text = block.text.strip()
@@ -961,11 +984,9 @@ async def stream_agent(
                                 if include_steps and source == "dashboard":
                                     detected = _detect_artifacts(text)
                                     if detected:
-                                        # Yield the text first (frontend will show it as a message)
-                                        yield text
-                                        # Then yield each artifact event
+                                        if not text_already_streamed:
+                                            yield text
                                         for art in detected:
-                                            # Skip if we already emitted this artifact (same content hash)
                                             if art["artifact_id"] in emitted_artifact_ids:
                                                 logger.info("[ARTIFACT SKIP] id=%s already emitted", art["artifact_id"])
                                                 continue
@@ -998,7 +1019,8 @@ async def stream_agent(
                                 if include_steps and source == "dashboard":
                                     file_paths = _detect_file_paths(text)
                                     if file_paths:
-                                        yield text  # yield text first
+                                        if not text_already_streamed:
+                                            yield text
                                         for fpath in file_paths:
                                             if fpath in emitted_file_paths:
                                                 continue
@@ -1023,7 +1045,8 @@ async def stream_agent(
                                                 logger.warning("[FILE] Failed to register %s: %s", fpath, fe)
                                         continue  # skip the plain yield below
 
-                                yield text
+                                if not text_already_streamed:
+                                    yield text
                         elif isinstance(block, ToolUseBlock):
                             logger.info("[TOOL CALL] %s (id: %s)", block.name, block.id)
                             logger.info("[TOOL INPUT] %s", _truncate_json(block.input))

--- a/agent/pool.py
+++ b/agent/pool.py
@@ -349,6 +349,7 @@ class ClientPool:
             setting_sources=["project"],
             cwd=str(Path(__file__).parent.parent),
             max_buffer_size=10 * 1024 * 1024,
+            include_partial_messages=True,
         )
 
     async def _create_client(self, account: dict, model_override: str | None = None) -> ClaudeSDKClient:

--- a/dashboard/src/app/skills/components/SkillTreeSidebar.tsx
+++ b/dashboard/src/app/skills/components/SkillTreeSidebar.tsx
@@ -106,7 +106,7 @@ export default function SkillTreeSidebar({
       </div>
 
       {/* Tree */}
-      <ScrollArea className="flex-1">
+      <ScrollArea className="flex-1 min-h-0">
         <div className="py-2">
           {SECTIONS.map(({ key, label, showInfo }) => {
             const sectionSkills = grouped[key];

--- a/tools/migrate_skills_to_workspace.py
+++ b/tools/migrate_skills_to_workspace.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""One-off: move all personal-scoped skills to workspace scope."""
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv(ROOT / ".env")
+except ImportError:
+    pass
+
+from motor.motor_asyncio import AsyncIOMotorClient
+from config.app_config import OBSERVABILITY_DB_NAME
+from api import skill_service
+
+
+async def main():
+    uri = os.environ.get("OBSERVABILITY_MONGODB_URI", "").strip()
+    if not uri:
+        print("OBSERVABILITY_MONGODB_URI not set")
+        sys.exit(1)
+
+    client = AsyncIOMotorClient(uri)
+    db = client[OBSERVABILITY_DB_NAME]
+
+    skills = await skill_service.list_skills(db)
+    personal = [s for s in skills if s.get("scope") == "personal"]
+
+    if not personal:
+        print("No personal-scoped skills found.")
+        return
+
+    print(f"Moving {len(personal)} personal skills to workspace scope:")
+    for s in personal:
+        slug = s["slug"]
+        try:
+            await skill_service.update_skill_scope(db, slug=slug, scope="workspace", actor="migration")
+            print(f"  ✓ {slug}")
+        except Exception as e:
+            print(f"  ✗ {slug}: {e}")
+
+    print("Done.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- **Skills pane scroll**: Added `min-h-0` to the ScrollArea flex item so the sidebar scrolls when skills overflow the viewport
- **Dashboard chat streaming**: Enabled `include_partial_messages` in the Claude SDK client and added `StreamEvent` handling to yield text deltas token-by-token instead of waiting for complete responses
- **Migration script**: One-off script to move all personal-scoped skills to workspace scope

## Test plan
- [ ] Open `/skills` with many skills — sidebar should scroll to show all items
- [ ] Send a message in dashboard chat — response text should stream in incrementally
- [ ] Verify artifact detection still works (code blocks should still extract as artifacts)
- [ ] Verify Slack responses still work (non-dashboard path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)