### PR TITLE
feat(deploy): mount host dev-secret store into loma-backend for closed-loop dev (ADA-25)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,11 +44,6 @@ OBSERVABILITY_DB_NAME=loma_observability
 # Local disk storage for non-text skill assets. Back this directory up with MongoDB.
 LOMA_SKILL_ASSET_DIR=/var/lib/loma/skill-assets
 
-# Host dev-secret store for closed-loop local dev. The loma-backend container
-# bind-mounts this host directory READ-ONLY at the identical in-container path
-# /home/ubuntu/secrets, so skills like run-plotline-services-local can read the
-# target repo's dev .env files + login.env to boot it locally. Unset →
-# /home/ubuntu/secrets. Point it elsewhere if your secrets live at another path.
 LOMA_SECRETS_DIR=/home/ubuntu/secrets
 
 # Feature flags

--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,13 @@ OBSERVABILITY_DB_NAME=loma_observability
 # Local disk storage for non-text skill assets. Back this directory up with MongoDB.
 LOMA_SKILL_ASSET_DIR=/var/lib/loma/skill-assets
 
+# Host dev-secret store for closed-loop local dev. The loma-backend container
+# bind-mounts this host directory READ-ONLY at the identical in-container path
+# /home/ubuntu/secrets, so skills like run-plotline-services-local can read the
+# target repo's dev .env files + login.env to boot it locally. Unset →
+# /home/ubuntu/secrets. Point it elsewhere if your secrets live at another path.
+LOMA_SECRETS_DIR=/home/ubuntu/secrets
+
 # Feature flags
 LOMA_ENABLE_SCHEDULER=false
 LOMA_ENABLE_WEBHOOKS=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,12 +17,6 @@ services:
       # Persist connected Claude Code accounts (CLAUDE_USERS_DIR) across container
       # recreation — otherwise `claude login` creds are lost on every rebuild/redeploy.
       - loma-claude-users:/opt/claude-users
-      # Host dev-secret store (plotline-services .env files + login.env), mounted
-      # READ-ONLY so the agent can boot target repos locally for closed-loop dev
-      # (see the run-plotline-services-local skill). The path is kept identical
-      # inside the container so the skill's /home/ubuntu/secrets references work
-      # unchanged. Override the host source via LOMA_SECRETS_DIR; unset →
-      # /home/ubuntu/secrets. Read-only: the agent only reads/copies these files.
       - ${LOMA_SECRETS_DIR:-/home/ubuntu/secrets}:/home/ubuntu/secrets:ro
     restart: unless-stopped
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,13 @@ services:
       # Persist connected Claude Code accounts (CLAUDE_USERS_DIR) across container
       # recreation — otherwise `claude login` creds are lost on every rebuild/redeploy.
       - loma-claude-users:/opt/claude-users
+      # Host dev-secret store (plotline-services .env files + login.env), mounted
+      # READ-ONLY so the agent can boot target repos locally for closed-loop dev
+      # (see the run-plotline-services-local skill). The path is kept identical
+      # inside the container so the skill's /home/ubuntu/secrets references work
+      # unchanged. Override the host source via LOMA_SECRETS_DIR; unset →
+      # /home/ubuntu/secrets. Read-only: the agent only reads/copies these files.
+      - ${LOMA_SECRETS_DIR:-/home/ubuntu/secrets}:/home/ubuntu/secrets:ro
     restart: unless-stopped
 
   loma-dashboard:


### PR DESCRIPTION
## What

Closes the last gap in the "recursive loop" for [ADA-25](https://linear.app/plotline/issue/ADA-25): the agent runs **inside the `loma-backend` container**, but the host dev-secret store at `/home/ubuntu/secrets` is not visible there. The `run-plotline-services-local` skill copies `plotline-services` dev `.env` files + `login.env` from that host path to boot the stack and log in — without a mount, that path doesn't exist in the container and the loop dies at "PR pushed, untested."

## How (deployment recap)

`docker-compose.yml` runs three services on the EC2 host: `loma-backend` (the agent, `app.py`, built from the root `Dockerfile`), `loma-dashboard`, and an `nginx` proxy. The backend already bind-mounts `./.env` and named volumes for skill-assets + claude-users. This PR adds one more **read-only** bind mount so the agent can read the dev secrets.

## Changes

- **`docker-compose.yml`** — add to `loma-backend.volumes`:
  ```yaml
  - ${LOMA_SECRETS_DIR:-/home/ubuntu/secrets}:/home/ubuntu/secrets:ro
  ```
  - **Read-only (`:ro`)** — the agent only reads/copies these files; the container can never mutate the host secret store.
  - **Identical in-container path** (`/home/ubuntu/secrets`) — the skill's hardcoded references work unchanged; no skill rewrite needed.
  - **Overridable** via `LOMA_SECRETS_DIR` for boxes where secrets live elsewhere; unset → `/home/ubuntu/secrets`.
- **`.env.example`** — document `LOMA_SECRETS_DIR`.

## Deploy note

Bind-mount changes require recreating the container, not just a restart:
```bash
docker compose up -d   # recreates loma-backend with the new mount
```
The host directory must exist on the box (it does: `/home/ubuntu/secrets/{server,dashboard,api-go}` + `login.env`). If it's missing, Docker would create it as an empty root-owned dir — so confirm the path before deploy.

## Security

- Mount is **read-only**; secrets stay on the host, never copied into the image or git.
- `:ro` plus the existing guardrail (never echo secret values, never paste into Linear/PRs) keeps blast radius to a single low-privilege test account on dev/staging data.

The companion `run-plotline-services-local` skill has been updated to document this mount as a precondition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)