### PR TITLE
feat(compose): mount host dev-secret store into loma-backend for closed-loop dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,12 @@ services:
       # Persist connected Claude Code accounts (CLAUDE_USERS_DIR) across container
       # recreation — otherwise `claude login` creds are lost on every rebuild/redeploy.
       - loma-claude-users:/opt/claude-users
+      # Host dev-secret store for closed-loop dev (run-plotline-services-local skill).
+      # The plotline-services env files + login.env live here on the EC2 host. Mounted
+      # READ-ONLY at the SAME path inside the container so the skill's /home/ubuntu/secrets
+      # references resolve unchanged. Path is env-overridable; on boxes without the dir
+      # (CI/preview), compose creates an empty dir and the skill simply finds nothing.
+      - ${LOMA_SECRETS_DIR:-/home/ubuntu/secrets}:/home/ubuntu/secrets:ro
     restart: unless-stopped
 
   loma-dashboard:


### PR DESCRIPTION
## Why

The `run-plotline-services-local` Loma skill boots `plotlinehq/plotline-services` on the host and expects the dev env files + login creds at **`/home/ubuntu/secrets`** (folders `server/`, `dashboard/`, `api-go/` + `login.env`).

But the agent that runs the skill executes as a Claude Code subprocess **inside the `loma-backend` container** (cwd `/app`). That container had no access to the host's `/home/ubuntu/secrets`, so the skill could clone + push a PR but could not boot the stack, log in, and screenshot the home page — the closed loop never closed.

## What

Add one read-only bind mount to `loma-backend` in `docker-compose.yml`:

```yaml
- ${LOMA_SECRETS_DIR:-/home/ubuntu/secrets}:/home/ubuntu/secrets:ro
```

Design choices:
- **Same path inside the container** (`/home/ubuntu/secrets`) so the skill's existing references resolve unchanged — no skill logic depends on a remapped path.
- **Read-only (`:ro`)** — the skill only *copies* env files out into its throwaway clone; it never writes back. Limits blast radius.
- **Env-overridable (`LOMA_SECRETS_DIR`)** — same pattern as the existing `BACKEND_HOST_PORT` / `NGINX_HOST_*` vars. Lets other hosts point elsewhere.
- **Safe on boxes without the dir** (CI / preview stacks): Docker Compose auto-creates an empty dir for a missing bind-mount source, so nothing breaks — the skill simply finds no secrets and reports that.

## Deploy note
After this merges, the EC2 host needs `/home/ubuntu/secrets` populated (already is, per ADA-25) and a `docker compose up -d` to recreate `loma-backend` with the new mount. No env var change is required on the EC2 host since the default path matches.

## Follow-up (separate, not in this PR)
The committed service-account key `apps/server/plotline-dev-d0b2460c4d92.json` in `plotline-services` should be rotated + gitignored. Tracked separately.

Relates to ADA-25 (Recursive Loop - 1 feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)