### PR TITLE
Redesign dashboard tables for clean, minimal aesthetic

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -300,7 +300,7 @@ async def _generate_title_llm(prompt: str, response_snippet: str = "") -> str:
         stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=15)
 
         if proc.returncode != 0:
-            logger.warning("Title generation CLI failed (rc=%d)", proc.returncode)
+            logger.warning("Title generation CLI failed (rc=%d): %s", proc.returncode, stderr.decode()[:500])
             return "Untitled conversation"
 
         output = stdout.decode().strip()
@@ -354,6 +354,7 @@ async def _classify_topic_llm(prompt: str, response_snippet: str = "") -> str:
         stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=15)
 
         if proc.returncode != 0:
+            logger.warning("Topic classification CLI failed (rc=%d): %s", proc.returncode, stderr.decode()[:500])
             return "other"
 
         output = stdout.decode().strip()

--- a/dashboard/DESIGN.md
+++ b/dashboard/DESIGN.md
@@ -1,0 +1,119 @@
+# Design Principles
+
+Every element on screen must earn its place. If removing something doesn't hurt comprehension, remove it.
+
+## Core Philosophy
+
+**Cognitive load is the enemy.** The dashboard exists to surface answers, not to display data. Users should leave knowing what happened, not still scanning rows.
+
+**Clean > Feature-rich.** A feature that adds clutter for 80% of users to help 20% belongs behind a hover, a tooltip, or a detail page — not on the default view.
+
+**Quiet confidence.** The UI should feel like it already made the decisions for you. No visual noise competing for attention. The important thing should be obvious without the user having to look for it.
+
+---
+
+## Rules
+
+### 1. Every word earns its place
+
+- No filler copy ("Browse and manage your..."). If the page title says **Conversations**, the user knows what they're looking at.
+- Labels should be 1-2 words. If you need a sentence, rethink the design.
+- Prefer verbs over nouns for actions: "Continue", not "Continue Conversation".
+- Status should be visual (dots, color), not textual ("completed", "running").
+
+### 2. Icons over text
+
+- Actions that have universally recognized icons get icons only. Add a tooltip for discoverability.
+- Source/type indicators are icons with tooltips, not colored text badges.
+- Buttons in table rows are always icon-only. Text labels go in toolbars, not inline.
+
+### 3. Tables are for scanning, not reading
+
+- **No row separators.** Whitespace and alignment create structure. Lines add noise.
+- **No table borders.** The table container blends into the page.
+- **No header backgrounds.** Column headers are uppercase, small, muted — they orient, they don't decorate.
+- **Fewer columns.** If a column is useful <30% of the time, it doesn't belong in the default view. Put it in a tooltip on hover, or on the detail page.
+- **Hover reveals actions.** Row actions (continue, delete, menu) are invisible until the user hovers. This keeps the resting state clean.
+- **Hover reveals detail.** Secondary data (turns, duration, savings, confidence) lives in a tooltip on a related visible cell (e.g., cost).
+
+### 4. Tuck away, don't remove
+
+- Infrequent filters collapse or sit behind a "Filters" toggle.
+- Bulk actions appear only when items are selected.
+- Settings and configuration live on dedicated pages, not inline panels.
+- "Power user" features (export, advanced filters, column customization) are behind a menu or secondary action.
+
+### 5. One line, not two panels
+
+- Search and filters share a single row. Search is narrow and left-aligned. Filters flow to the right.
+- No wrapper cards around toolbars. Borders around controls add nothing.
+- Action buttons (refresh, clear) are icon-only, right-aligned, and muted until hovered.
+
+### 6. shadcn defaults, not custom styling
+
+- Use shadcn/ui components as-is. Don't override their internals with random border/color classes.
+- If shadcn's `Table` has no row borders by default, don't add them back.
+- If shadcn's `Badge` has a style, use it. Don't invent new badge color schemes per-page.
+- Custom styling is a bug unless it solves a real problem that the component library doesn't.
+
+### 7. Color is meaning, not decoration
+
+- **Green** = positive (savings, success, connected)
+- **Blue** = active/running
+- **Red** = error/destructive
+- **Amber** = warning/pending
+- **Gray/muted** = secondary information
+- Don't use color to "make things pop." If everything pops, nothing does.
+
+### 8. Status is a dot, not a badge
+
+- Running = pulsing blue dot
+- Completed = solid green dot
+- Error = solid red dot
+- A 2px circle communicates status faster than a 60px colored badge with text.
+
+### 9. Typography hierarchy
+
+- **Page title**: `text-lg font-semibold` — one per page, top-left.
+- **Section headers**: `text-[13px] font-semibold` — inside cards or panels.
+- **Table headers**: `text-[11px] uppercase tracking-wider text-muted-foreground` — orient, don't decorate.
+- **Body text**: `text-[13px]` — the default. Readable without being large.
+- **Secondary/metadata**: `text-xs text-muted-foreground` — timestamps, counts, subtle context.
+- No `text-base` or larger in data views. This is a dashboard, not a marketing page.
+
+### 10. Spacing is structure
+
+- Use consistent `space-y-2` between page sections.
+- Table cells use `px-3 py-1.5` — tight but readable.
+- Don't add padding to "make things breathe." If something feels cramped, the content is too dense — simplify it.
+
+---
+
+## Anti-patterns
+
+Things we explicitly avoid:
+
+| Don't | Do instead |
+|---|---|
+| Add a border between every table row | Let whitespace separate rows |
+| Wrap toolbars in bordered cards | Let them float in the page flow |
+| Show 12 columns in a table | Show 5-6, tuck the rest in tooltips |
+| Use text badges for status | Use colored dots |
+| Show actions on every row by default | Show on hover |
+| Write "Continue Conversation" | Write nothing — use a chat icon |
+| Add a subtitle under every page title | Remove it unless it adds real context |
+| Use `bg-muted/50` on table headers | Leave them transparent |
+| Create custom badge colors per category | Use the existing shadcn palette |
+| Add loading spinners everywhere | Use skeleton rows that match the layout |
+
+---
+
+## Decision framework
+
+When adding any new UI element, ask:
+
+1. **Does this help 80%+ of users on this page?** No → tuck it away.
+2. **Can this be communicated with an icon instead of text?** Yes → use an icon + tooltip.
+3. **Is this data needed at scan-time or only at investigation-time?** Investigation → put it on the detail page or in a hover tooltip.
+4. **Am I adding a border, shadow, or background to create "structure"?** Stop. Use whitespace and alignment instead.
+5. **Am I overriding a shadcn default?** Why? The defaults exist for consistency.

--- a/dashboard/src/app/admin/page.tsx
+++ b/dashboard/src/app/admin/page.tsx
@@ -540,7 +540,7 @@ export default function AdminPage() {
             <div className="overflow-x-auto">
               <Table>
                 <TableHeader>
-                  <TableRow className="border-b border-border">
+                  <TableRow>
                     <TableHead className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">Permission</TableHead>
                     {(["admin", "maintainer", "operator", "analyst", "chatter"] as const).map((role) => (
                       <TableHead key={role} className="text-center text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">
@@ -551,7 +551,7 @@ export default function AdminPage() {
                 </TableHeader>
                 <TableBody>
                   {ROLE_PERMISSIONS.map((row) => (
-                    <TableRow key={row.permission} className="border-b border-muted/50 last:border-0">
+                    <TableRow key={row.permission}>
                       <TableCell className="text-xs text-muted-foreground">{row.permission}</TableCell>
                       {(["admin", "maintainer", "operator", "analyst", "chatter"] as const).map((role) => (
                         <TableCell key={role} className="text-center">
@@ -612,7 +612,7 @@ export default function AdminPage() {
           <div className="overflow-x-auto">
             <Table className="min-w-[600px]">
               <TableHeader>
-                <TableRow className="border-b border-border bg-muted/60">
+                <TableRow className="bg-muted/40">
                   <TableHead className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider sticky left-0 bg-muted/60 z-10 min-w-[180px]">
                     User
                   </TableHead>
@@ -663,7 +663,7 @@ export default function AdminPage() {
               </TableHeader>
               <TableBody>
                 {users.map((user) => (
-                  <TableRow key={user.email} className="border-b border-border last:border-0 hover:bg-muted/50 transition-colors">
+                  <TableRow key={user.email} className="hover:bg-muted/50 transition-colors">
                     <TableCell className="sticky left-0 bg-card z-10">
                       <Link href={`/admin/${encodeURIComponent(user.email)}`} className="flex items-center gap-2.5 group">
                         <div className="w-8 h-8 rounded-full bg-brand-100 flex items-center justify-center flex-shrink-0">
@@ -1190,7 +1190,7 @@ export default function AdminPage() {
                 <div className="overflow-x-auto">
                   <Table>
                     <TableHeader>
-                      <TableRow className="border-b border-border bg-muted/60">
+                      <TableRow className="bg-muted/40">
                         <TableHead className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider w-[280px]">Key</TableHead>
                         <TableHead className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">Value</TableHead>
                         <TableHead className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider w-[100px] text-center">Status</TableHead>
@@ -1208,7 +1208,7 @@ export default function AdminPage() {
                         const isDuplicate = newVars.some((nv) => nv.key.trim() === v.key);
 
                         return (
-                          <TableRow key={v.key} className={cn("border-b border-border last:border-0 transition-colors", v.is_readonly ? "bg-muted/40" : isEdited ? "bg-amber-50/30" : "hover:bg-muted/50")}>
+                          <TableRow key={v.key} className={cn("transition-colors", v.is_readonly ? "bg-muted/40" : isEdited ? "bg-amber-50/30" : "hover:bg-muted/50")}>
                             <TableCell>
                               <div className="flex items-center gap-2">
                                 <code className="text-[13px] font-mono text-foreground">{v.key}</code>
@@ -1337,7 +1337,7 @@ export default function AdminPage() {
                       {newVars.map((nv, idx) => {
                         const isDuplicate = envVars.some((v) => v.key === nv.key.trim()) || newVars.filter((n, i) => i !== idx && n.key.trim() === nv.key.trim()).length > 0;
                         return (
-                          <TableRow key={`new-${idx}`} className="border-b border-border last:border-0 bg-emerald-50/20">
+                          <TableRow key={`new-${idx}`} className="bg-emerald-50/20">
                             <TableCell>
                               <div className="flex items-center gap-2">
                                 <Input

--- a/dashboard/src/app/admin/teams/[id]/page.tsx
+++ b/dashboard/src/app/admin/teams/[id]/page.tsx
@@ -187,7 +187,7 @@ export default function TeamDetailPage() {
 
         <Table>
           <TableHeader>
-            <TableRow className="border-border">
+            <TableRow className="">
               <TableHead className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">Tool</TableHead>
               <TableHead className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">Default Role</TableHead>
               <TableHead className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">Members Affected</TableHead>
@@ -203,7 +203,7 @@ export default function TeamDetailPage() {
               const defaultRole = td?.role ?? null;
 
               return (
-                <TableRow key={toolKey} className="border-border/50">
+                <TableRow key={toolKey} className="">
                   <TableCell className="pr-4">
                     <Link href={`/mcp/${toolKey}`} className="flex items-center gap-2.5 group">
                       <div
@@ -270,7 +270,7 @@ export default function TeamDetailPage() {
 
         <Table>
           <TableHeader>
-            <TableRow className="border-border">
+            <TableRow className="">
               <TableHead className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">Tool</TableHead>
               <TableHead className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">OAuth Required</TableHead>
               <TableHead className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">Connected</TableHead>
@@ -289,7 +289,7 @@ export default function TeamDetailPage() {
               ).length;
 
               return (
-                <TableRow key={toolKey} className="border-border/50">
+                <TableRow key={toolKey} className="">
                   <TableCell className="pr-4">
                     <Link href={`/mcp/${toolKey}`} className="flex items-center gap-2.5 group">
                       <div

--- a/dashboard/src/app/analytics/page.tsx
+++ b/dashboard/src/app/analytics/page.tsx
@@ -385,7 +385,7 @@ export default function AnalyticsPage() {
           <Card className="overflow-hidden">
             <Table>
               <TableHeader>
-                <TableRow className="border-b border-border bg-muted/50">
+                <TableRow className="bg-muted/40">
                   <TableHead className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Type</TableHead>
                   <TableHead className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">Name</TableHead>
                   <TableHead className="text-right text-xs font-semibold text-muted-foreground uppercase tracking-wider">Input Tokens</TableHead>

--- a/dashboard/src/app/conversations/page.tsx
+++ b/dashboard/src/app/conversations/page.tsx
@@ -4,11 +4,10 @@ import { useEffect, useState, useCallback } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { fetchConversations, fetchStats, fetchPersons, basePath } from "../../lib/api";
+import { fetchConversations, fetchStats, fetchPersons } from "../../lib/api";
 import type { Conversation, StatsResponse } from "../../lib/api";
 import { useUser } from "../../lib/UserContext";
 import ChatContextMenu from "../../components/ChatContextMenu";
-import ConfidenceBadge from "../../components/ConfidenceBadge";
 import ClientTimestamp from "../../components/ClientTimestamp";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -17,7 +16,11 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { RiSearchLine, RiCloseLine, RiRefreshLine, RiChat1Line } from "@remixicon/react";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  RiSearchLine, RiCloseLine, RiRefreshLine, RiChat1Line,
+  RiAtLine, RiChat3Line, RiLinksLine, RiComputerLine, RiGitBranchLine, RiTaskLine
+} from "@remixicon/react";
 import { cn } from "@/lib/utils";
 import { EmptyState } from "@/components/EmptyState";
 
@@ -30,19 +33,25 @@ const sourceLabels: Record<string, string> = {
   task_step: "Task",
 };
 
-const sourceStyles: Record<string, string> = {
-  slack_mention: "bg-blue-50 text-blue-700",
-  slack_dm: "bg-indigo-50 text-indigo-700",
-  pylon_webhook: "bg-amber-50 text-amber-700",
-  dashboard: "bg-brand-50 text-brand-700",
-  flow: "bg-emerald-50 text-emerald-700",
-  task_step: "bg-purple-50 text-purple-700",
+const sourceIconStyles: Record<string, string> = {
+  slack_mention: "text-blue-500",
+  slack_dm: "text-indigo-500",
+  pylon_webhook: "text-amber-500",
+  dashboard: "text-brand-500",
+  flow: "text-emerald-500",
+  task_step: "text-purple-500",
 };
 
-const statusStyles: Record<string, string> = {
-  running: "bg-blue-50 text-blue-700",
-  completed: "bg-gray-100 text-gray-600",
-  error: "bg-red-50 text-red-700",
+const statusDotStyles: Record<string, string> = {
+  running: "bg-blue-500 animate-pulse",
+  completed: "bg-emerald-500",
+  error: "bg-red-500",
+};
+
+const statusLabels: Record<string, string> = {
+  running: "Running",
+  completed: "Completed",
+  error: "Error",
 };
 
 const topicStyles: Record<string, string> = {
@@ -71,38 +80,49 @@ const topicLabels: Record<string, string> = {
   other: "Other",
 };
 
+function SourceIcon({ source, size = 15 }: { source: string; size?: number }) {
+  const icons: Record<string, React.ElementType> = {
+    slack_mention: RiAtLine,
+    slack_dm: RiChat3Line,
+    pylon_webhook: RiLinksLine,
+    dashboard: RiComputerLine,
+    flow: RiGitBranchLine,
+    task_step: RiTaskLine,
+  };
+  const Icon = icons[source] || RiChat1Line;
+  return <Icon size={size} />;
+}
+
 function SkeletonRow() {
   return (
     <TableRow>
-      <TableCell><Skeleton className="h-3 w-20" /></TableCell>
-      <TableCell><Skeleton className="h-5 w-16 rounded-full" /></TableCell>
-      <TableCell><Skeleton className="h-3 w-48" /><Skeleton className="h-2 w-32 mt-1.5" /></TableCell>
+      <TableCell className="w-4 pr-0"><Skeleton className="h-2 w-2 rounded-full" /></TableCell>
+      <TableCell>
+        <Skeleton className="h-4 w-48" />
+        <Skeleton className="h-3 w-24 mt-1" />
+      </TableCell>
+      <TableCell className="w-8"><Skeleton className="h-4 w-4" /></TableCell>
       <TableCell><Skeleton className="h-5 w-14 rounded-full" /></TableCell>
-      <TableCell><Skeleton className="h-3 w-6 mx-auto" /></TableCell>
-      <TableCell><Skeleton className="h-3 w-10" /></TableCell>
       <TableCell><Skeleton className="h-3 w-14" /></TableCell>
-      <TableCell><Skeleton className="h-3 w-12" /></TableCell>
-      <TableCell><Skeleton className="h-5 w-16 rounded-full" /></TableCell>
-      <TableCell><Skeleton className="h-5 w-10 rounded-full" /></TableCell>
-      <TableCell><Skeleton className="h-3 w-14" /></TableCell>
+      <TableCell><Skeleton className="h-3 w-20" /></TableCell>
+      <TableCell className="w-16" />
     </TableRow>
   );
 }
 
 function MobileSkeletonCard() {
   return (
-    <Card className="p-4">
+    <Card className="p-3">
       <CardContent className="p-0">
-        <div className="flex items-center gap-2 mb-2">
-          <Skeleton className="h-5 w-16 rounded-full" />
-          <Skeleton className="h-5 w-14 rounded-full" />
-        </div>
-        <Skeleton className="h-4 w-3/4 mb-1" />
-        <Skeleton className="h-3 w-1/2 mb-2" />
-        <div className="flex items-center gap-2">
-          <Skeleton className="h-3 w-20" />
-          <Skeleton className="h-3 w-16" />
-          <Skeleton className="h-3 w-12" />
+        <div className="flex items-start gap-2">
+          <Skeleton className="h-2 w-2 rounded-full mt-1.5" />
+          <div className="flex-1">
+            <Skeleton className="h-4 w-3/4 mb-1.5" />
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-3 w-20" />
+              <Skeleton className="h-3 w-12" />
+            </div>
+          </div>
         </div>
       </CardContent>
     </Card>
@@ -141,7 +161,6 @@ export default function ConversationsPage() {
       .catch((e) => console.error("Failed to load persons:", e));
   }, []);
 
-  // When viewMode changes to "mine", set personFilter to user email; when "all", clear it
   useEffect(() => {
     if (viewMode === "mine" && session?.user?.email) {
       setPersonFilter(session.user.email);
@@ -152,8 +171,6 @@ export default function ConversationsPage() {
   }, [viewMode, session?.user?.email]);
 
   useEffect(() => {
-    // Don't fetch until personFilter is set when in "mine" mode — prevents
-    // loading all conversations first and then flickering to "my" data.
     if (viewMode === "mine" && !personFilter) return;
     loadData();
   }, [page, sourceFilter, categoryFilter, debouncedSearch, personFilter, topicFilter]);
@@ -196,67 +213,65 @@ export default function ConversationsPage() {
     setPage(1);
   }, [viewMode]);
 
+  function formatDuration(ms: number | null | undefined) {
+    if (!ms) return null;
+    return ms > 60000 ? `${Math.round(ms / 60000)}m` : `${Math.round(ms / 1000)}s`;
+  }
+
   return (
-    <div className="space-y-2 animate-fade-in-up">
-      {/* Page header */}
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <div>
+    <TooltipProvider delayDuration={300}>
+      <div className="space-y-2 animate-fade-in-up">
+        {/* Page header */}
+        <div className="flex flex-wrap items-center justify-between gap-2">
           <h1 className="text-lg md:text-xl font-heading font-semibold text-foreground">Conversations</h1>
-          <p className="text-[13px] text-muted-foreground mt-1">Browse and manage all agent conversations</p>
+          {isAdmin && (
+            <div className="flex items-center bg-muted border border-border rounded-lg p-0.5">
+              <Button
+                variant={viewMode === "mine" ? "default" : "ghost"}
+                size="sm"
+                onClick={() => setViewMode("mine")}
+                className={cn(
+                  viewMode === "mine"
+                    ? "bg-accent-200 text-accent-on"
+                    : "text-muted-foreground hover:text-foreground"
+                )}
+              >
+                My Conversations
+              </Button>
+              <Button
+                variant={viewMode === "all" ? "default" : "ghost"}
+                size="sm"
+                onClick={() => setViewMode("all")}
+                className={cn(
+                  viewMode === "all"
+                    ? "bg-accent-200 text-accent-on"
+                    : "text-muted-foreground hover:text-foreground"
+                )}
+              >
+                All
+              </Button>
+            </div>
+          )}
         </div>
-        {isAdmin && (
-          <div className="flex items-center bg-muted border border-border rounded-lg p-0.5">
-            <Button
-              variant={viewMode === "mine" ? "default" : "ghost"}
-              size="sm"
-              onClick={() => setViewMode("mine")}
-              className={cn(
-                viewMode === "mine"
-                  ? "bg-accent-200 text-accent-on"
-                  : "text-muted-foreground hover:text-foreground"
-              )}
-            >
-              My Conversations
-            </Button>
-            <Button
-              variant={viewMode === "all" ? "default" : "ghost"}
-              size="sm"
-              onClick={() => setViewMode("all")}
-              className={cn(
-                viewMode === "all"
-                  ? "bg-accent-200 text-accent-on"
-                  : "text-muted-foreground hover:text-foreground"
-              )}
-            >
-              All
-            </Button>
+
+        {/* Search + Filters — single row, no card borders */}
+        <div className="flex flex-col md:flex-row gap-2 md:items-center">
+          <div className="relative md:w-60 shrink-0">
+            <RiSearchLine className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" size={16} />
+            <Input
+              type="text"
+              placeholder="Search..."
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="w-full pl-10 pr-4 py-2 text-[13px] border-border focus-visible:ring-accent-200 focus-visible:border-accent-200"
+            />
           </div>
-        )}
-      </div>
-
-      {/* Search bar */}
-      <div className="bg-card rounded-xl border border-border px-4 py-3">
-        <div className="relative">
-          <RiSearchLine className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" size={16} />
-          <Input
-            type="text"
-            placeholder="Search conversations..."
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full pl-10 pr-4 py-2 text-[13px] bg-muted/50 border-border focus-visible:ring-accent-200 focus-visible:border-accent-200"
-          />
-        </div>
-      </div>
-
-      {/* Filters bar */}
-      <div className="bg-card rounded-xl border border-border px-4 py-3">
-        <div className="flex flex-col md:flex-row md:flex-wrap gap-2 md:items-center md:justify-between">
-          <div className="grid grid-cols-2 md:flex md:flex-wrap gap-2 md:gap-3">
+          <div className="flex flex-wrap items-center gap-2 flex-1">
             <Select
               value={sourceFilter || "__all__"}
               onValueChange={(val) => { setSourceFilter(val === "__all__" ? "" : val); setPage(1); }}
             >
-              <SelectTrigger className="bg-card border-border text-[13px] text-foreground">
+              <SelectTrigger className="w-auto min-w-[120px] bg-card border-border text-[13px] text-foreground">
                 <SelectValue placeholder="All Sources" />
               </SelectTrigger>
               <SelectContent>
@@ -271,7 +286,7 @@ export default function ConversationsPage() {
               value={categoryFilter || "__all__"}
               onValueChange={(val) => { setCategoryFilter(val === "__all__" ? "" : val); setPage(1); }}
             >
-              <SelectTrigger className="bg-card border-border text-[13px] text-foreground">
+              <SelectTrigger className="w-auto min-w-[130px] bg-card border-border text-[13px] text-foreground">
                 <SelectValue placeholder="All Categories" />
               </SelectTrigger>
               <SelectContent>
@@ -287,7 +302,7 @@ export default function ConversationsPage() {
                 value={personFilter || "__all__"}
                 onValueChange={(val) => { setPersonFilter(val === "__all__" ? "" : val); setPage(1); }}
               >
-                <SelectTrigger className="bg-card border-border text-[13px] text-foreground">
+                <SelectTrigger className="w-auto min-w-[120px] bg-card border-border text-[13px] text-foreground">
                   <SelectValue placeholder="All Persons" />
                 </SelectTrigger>
                 <SelectContent>
@@ -302,7 +317,7 @@ export default function ConversationsPage() {
               value={topicFilter || "__all__"}
               onValueChange={(val) => { setTopicFilter(val === "__all__" ? "" : val); setPage(1); }}
             >
-              <SelectTrigger className="bg-card border-border text-[13px] text-foreground">
+              <SelectTrigger className="w-auto min-w-[110px] bg-card border-border text-[13px] text-foreground">
                 <SelectValue placeholder="All Topics" />
               </SelectTrigger>
               <SelectContent>
@@ -319,140 +334,254 @@ export default function ConversationsPage() {
                 <SelectItem value="other">Other</SelectItem>
               </SelectContent>
             </Select>
-          </div>
-          <div className="flex items-center gap-2">
-            {hasActiveFilters && (
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={clearFilters}
-                className="text-muted-foreground hover:text-foreground press-scale"
-              >
-                <RiCloseLine size={14} />
-                Clear
-              </Button>
-            )}
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => loadData()}
-              className="text-brand-600 hover:text-brand-800 press-scale"
-            >
-              <RiRefreshLine size={16} />
-              Refresh
-            </Button>
+            <div className="ml-auto flex items-center gap-0.5">
+              {hasActiveFilters && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={clearFilters}
+                      className="text-muted-foreground hover:text-foreground press-scale h-8 w-8 p-0"
+                    >
+                      <RiCloseLine size={16} />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Clear filters</TooltipContent>
+                </Tooltip>
+              )}
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => loadData()}
+                    className="text-muted-foreground hover:text-foreground press-scale h-8 w-8 p-0"
+                  >
+                    <RiRefreshLine size={16} />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Refresh</TooltipContent>
+              </Tooltip>
+            </div>
           </div>
         </div>
-      </div>
 
-      {/* Desktop table */}
-      <div className="desktop-table bg-card rounded-xl border border-border overflow-hidden">
-        <Table>
-          <TableHeader>
-            <TableRow className="border-b border-muted text-left">
-              <TableHead>Time</TableHead>
-              <TableHead>Source</TableHead>
-              <TableHead>Account</TableHead>
-              <TableHead>Title</TableHead>
-              <TableHead>Topic</TableHead>
-              <TableHead>Turns</TableHead>
-              <TableHead>Duration</TableHead>
-              <TableHead>Cost</TableHead>
-              <TableHead>Savings</TableHead>
-              <TableHead>Status</TableHead>
-              <TableHead>Confidence</TableHead>
-              <TableHead className="w-10"></TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody className="divide-y divide-muted/50">
-            {loading ? (
-              <>
-                <SkeletonRow /><SkeletonRow /><SkeletonRow /><SkeletonRow />
-                <SkeletonRow /><SkeletonRow /><SkeletonRow /><SkeletonRow />
-              </>
-            ) : conversations.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={12} className="py-6">
-                  {hasActiveFilters ? (
-                    <EmptyState
-                      icon={RiChat1Line}
-                      title="No conversations match your filters"
-                      action="Clear all filters"
-                      onAction={clearFilters}
-                    />
-                  ) : (
-                    <EmptyState icon={RiChat1Line} title="No conversations found" description="Start a new conversation from the chat page" />
-                  )}
-                </TableCell>
+        {/* Desktop table */}
+        <div className="desktop-table bg-card rounded-xl overflow-hidden">
+          <Table>
+            <TableHeader>
+              <TableRow className="text-left">
+                <TableHead className="w-4 pr-0"></TableHead>
+                <TableHead>Conversation</TableHead>
+                <TableHead className="w-8"></TableHead>
+                <TableHead>Topic</TableHead>
+                <TableHead>Cost</TableHead>
+                <TableHead>Time</TableHead>
+                <TableHead className="w-16"></TableHead>
               </TableRow>
-            ) : (
-              conversations.map((c, idx) => (
-                <TableRow
-                  key={c.conversation_id}
-                  className="hover:bg-muted/50 cursor-pointer transition-colors animate-fade-in-up"
-                  style={{ animationDelay: `${Math.min(idx * 30, 300)}ms` }}
-                  onClick={(e) => {
-                    const url = `/conversations/${c.conversation_id}`;
-                    if (e.metaKey || e.ctrlKey) {
-                      window.open(url, "_blank");
-                    } else {
-                      router.push(url);
-                    }
-                  }}
-                >
-                  <TableCell className="text-muted-foreground whitespace-nowrap text-xs">
-                    <ClientTimestamp iso={c.started_at} variant="short" />
+            </TableHeader>
+            <TableBody>
+              {loading ? (
+                <>
+                  <SkeletonRow /><SkeletonRow /><SkeletonRow /><SkeletonRow />
+                  <SkeletonRow /><SkeletonRow /><SkeletonRow /><SkeletonRow />
+                </>
+              ) : conversations.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={7} className="py-6">
+                    {hasActiveFilters ? (
+                      <EmptyState
+                        icon={RiChat1Line}
+                        title="No conversations match your filters"
+                        action="Clear all filters"
+                        onAction={clearFilters}
+                      />
+                    ) : (
+                      <EmptyState icon={RiChat1Line} title="No conversations found" description="Start a new conversation from the chat page" />
+                    )}
                   </TableCell>
-                  <TableCell>
-                    <Badge variant="secondary" className={cn("text-xs", sourceStyles[c.source] || "bg-gray-100 text-gray-600")}>
-                      {sourceLabels[c.source] || c.source}
-                    </Badge>
-                  </TableCell>
-                  <TableCell className="text-muted-foreground text-xs">
-                    {c.claude_account ? c.claude_account : <span className="text-muted-foreground/50">&mdash;</span>}
-                  </TableCell>
-                  <TableCell className="text-foreground max-w-xs">
-                    <div className="truncate font-medium" title={c.title || c.prompt?.slice(0, 80)}>
-                      {c.title || c.prompt?.slice(0, 60) + (c.prompt?.length > 60 ? "..." : "")}
-                    </div>
-                  </TableCell>
-                  <TableCell>
-                    {c.topic ? (
-                      <Badge variant="secondary" className={cn("text-xs", topicStyles[c.topic] || "bg-gray-100 text-gray-600")}>
-                        {topicLabels[c.topic] || c.topic}
-                      </Badge>
-                    ) : <span className="text-xs text-muted-foreground/50">&mdash;</span>}
-                  </TableCell>
-                  <TableCell className="text-muted-foreground text-center">{c.total_turns}</TableCell>
-                  <TableCell className="text-muted-foreground whitespace-nowrap">
-                    {c.duration_ms ? (c.duration_ms > 60000 ? `${Math.round(c.duration_ms / 60000)}m` : `${Math.round(c.duration_ms / 1000)}s`) : "-"}
-                  </TableCell>
-                  <TableCell className="text-muted-foreground whitespace-nowrap text-xs tabular-nums">
-                    {c.cost?.total_cost_usd != null ? `$${c.cost.total_cost_usd.toFixed(4)}` : "-"}
-                  </TableCell>
-                  <TableCell className="whitespace-nowrap text-xs tabular-nums">
-                    {c.savings?.savings_usd != null ? (
-                      <span className="text-emerald-600 font-medium">+${c.savings.savings_usd.toFixed(2)}</span>
-                    ) : <span className="text-muted-foreground">-</span>}
-                  </TableCell>
-                  <TableCell>
-                    <Badge variant="secondary" className={cn("text-xs", statusStyles[c.status] || "bg-gray-100 text-gray-600")}>{c.status}</Badge>
-                  </TableCell>
-                  <TableCell><ConfidenceBadge confidence={c.confidence} /></TableCell>
-                  <TableCell>
-                    <div className="flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
-                      {c.status !== "running" && (
-                        <Button variant="ghost" size="xs" asChild className="text-brand-600 hover:bg-brand-50 press-scale">
-                          <Link
-                            href={`/chat?continue=${c.conversation_id}`}
-                            onClick={(e) => e.stopPropagation()}
-                            title="Continue this conversation"
-                          >
-                            <RiChat1Line size={14} />
-                            Continue
-                          </Link>
-                        </Button>
+                </TableRow>
+              ) : (
+                conversations.map((c, idx) => (
+                  <TableRow
+                    key={c.conversation_id}
+                    className="group hover:bg-muted/50 cursor-pointer transition-colors animate-fade-in-up"
+                    style={{ animationDelay: `${Math.min(idx * 30, 300)}ms` }}
+                    onClick={(e) => {
+                      const url = `/conversations/${c.conversation_id}`;
+                      if (e.metaKey || e.ctrlKey) {
+                        window.open(url, "_blank");
+                      } else {
+                        router.push(url);
+                      }
+                    }}
+                  >
+                    {/* Status dot */}
+                    <TableCell className="w-4 pr-0">
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <div className={cn("h-2 w-2 rounded-full", statusDotStyles[c.status] || "bg-gray-400")} />
+                        </TooltipTrigger>
+                        <TooltipContent>{statusLabels[c.status] || c.status}</TooltipContent>
+                      </Tooltip>
+                    </TableCell>
+
+                    {/* Title + Account */}
+                    <TableCell>
+                      <div className="truncate font-medium text-foreground max-w-md" title={c.title || c.prompt?.slice(0, 80)}>
+                        {c.title || (c.prompt ? c.prompt.slice(0, 60) + (c.prompt.length > 60 ? "..." : "") : "Untitled")}
+                      </div>
+                      {c.claude_account && (
+                        <div className="text-xs text-muted-foreground/60 truncate mt-0.5">{c.claude_account}</div>
                       )}
+                    </TableCell>
+
+                    {/* Source icon */}
+                    <TableCell className="w-8">
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span className={cn("inline-flex", sourceIconStyles[c.source] || "text-gray-400")}>
+                            <SourceIcon source={c.source} />
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent>{sourceLabels[c.source] || c.source}</TooltipContent>
+                      </Tooltip>
+                    </TableCell>
+
+                    {/* Topic */}
+                    <TableCell>
+                      {c.topic ? (
+                        <Badge variant="secondary" className={cn("text-xs", topicStyles[c.topic] || "bg-gray-100 text-gray-600")}>
+                          {topicLabels[c.topic] || c.topic}
+                        </Badge>
+                      ) : <span className="text-xs text-muted-foreground/40">&mdash;</span>}
+                    </TableCell>
+
+                    {/* Cost — hover shows full details */}
+                    <TableCell className="tabular-nums text-xs">
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span className="text-muted-foreground cursor-default">
+                            {c.cost?.total_cost_usd != null ? `$${c.cost.total_cost_usd.toFixed(2)}` : "-"}
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent side="bottom" className="text-xs">
+                          <div className="space-y-0.5 tabular-nums">
+                            {c.cost?.total_cost_usd != null && <div>Cost: ${c.cost.total_cost_usd.toFixed(4)}</div>}
+                            {c.savings?.savings_usd != null && (
+                              <div className="text-emerald-400">Saved: +${c.savings.savings_usd.toFixed(2)}</div>
+                            )}
+                            <div>{c.total_turns} turns{formatDuration(c.duration_ms) ? ` · ${formatDuration(c.duration_ms)}` : ""}</div>
+                            {c.confidence?.category && (
+                              <div className="capitalize">{c.confidence.category} confidence</div>
+                            )}
+                          </div>
+                        </TooltipContent>
+                      </Tooltip>
+                    </TableCell>
+
+                    {/* Time */}
+                    <TableCell className="text-muted-foreground text-xs whitespace-nowrap">
+                      <ClientTimestamp iso={c.started_at} variant="short" />
+                    </TableCell>
+
+                    {/* Actions — hover reveal */}
+                    <TableCell className="w-16">
+                      <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity" onClick={(e) => e.stopPropagation()}>
+                        {c.status !== "running" && (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Button variant="ghost" size="xs" asChild className="text-brand-600 hover:bg-brand-50 press-scale">
+                                <Link
+                                  href={`/chat?continue=${c.conversation_id}`}
+                                  onClick={(e) => e.stopPropagation()}
+                                >
+                                  <RiChat1Line size={14} />
+                                </Link>
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent>Continue</TooltipContent>
+                          </Tooltip>
+                        )}
+                        <ChatContextMenu
+                          conversationId={c.conversation_id}
+                          conversationTitle={c.title || c.prompt?.slice(0, 50) || "Untitled"}
+                          isPinned={isPinned(c.conversation_id)}
+                          projectId={c.project_id}
+                          projects={projects}
+                          onRename={async (id, newTitle) => { await renameConversation(id, newTitle); loadData(); }}
+                          onDelete={async (id) => { await removeConversation(id); loadData(); }}
+                          onTogglePin={togglePin}
+                          onAssignProject={async (id, pid) => { await assignToProject(id, pid); loadData(); }}
+                          onRemoveProject={async (id) => { await unassignFromProject(id); loadData(); }}
+                          onCreateProject={async (name) => { await addProject(name); }}
+                        />
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </div>
+
+        {/* Mobile card list */}
+        <div className="mobile-cards space-y-2">
+          {loading ? (
+            <>
+              <MobileSkeletonCard /><MobileSkeletonCard /><MobileSkeletonCard />
+              <MobileSkeletonCard /><MobileSkeletonCard />
+            </>
+          ) : conversations.length === 0 ? (
+            hasActiveFilters ? (
+              <EmptyState
+                icon={RiChat1Line}
+                title="No conversations match your filters"
+                action="Clear all filters"
+                onAction={clearFilters}
+              />
+            ) : (
+              <EmptyState icon={RiChat1Line} title="No conversations found" description="Start a new conversation from the chat page" />
+            )
+          ) : (
+            conversations.map((c, idx) => (
+              <Card
+                key={c.conversation_id}
+                className="p-3 active:bg-muted/50 transition-colors animate-fade-in-up cursor-pointer"
+                style={{ animationDelay: `${Math.min(idx * 30, 300)}ms` }}
+                onClick={(e) => {
+                  const url = `/conversations/${c.conversation_id}`;
+                  if (e.metaKey || e.ctrlKey) {
+                    window.open(url, "_blank");
+                  } else {
+                    router.push(url);
+                  }
+                }}
+              >
+                <CardContent className="p-0">
+                  <div className="flex items-start gap-2.5">
+                    <div className={cn("h-2 w-2 rounded-full mt-1.5 shrink-0", statusDotStyles[c.status] || "bg-gray-400")} />
+                    <div className="flex-1 min-w-0">
+                      <div className="text-[13px] font-medium text-foreground truncate">
+                        {c.title || (c.prompt ? c.prompt.slice(0, 60) + (c.prompt.length > 60 ? "..." : "") : "Untitled")}
+                      </div>
+                      <div className="flex items-center gap-2 mt-1.5 text-xs text-muted-foreground flex-wrap">
+                        <span className={cn("inline-flex", sourceIconStyles[c.source] || "text-gray-400")}>
+                          <SourceIcon source={c.source} size={12} />
+                        </span>
+                        <ClientTimestamp iso={c.started_at} variant="short" />
+                        {c.cost?.total_cost_usd != null && (
+                          <span className="tabular-nums">${c.cost.total_cost_usd.toFixed(2)}</span>
+                        )}
+                        {c.topic && (
+                          <Badge variant="secondary" className={cn("text-[10px] py-0 px-1.5", topicStyles[c.topic] || "bg-gray-100 text-gray-600")}>
+                            {topicLabels[c.topic] || c.topic}
+                          </Badge>
+                        )}
+                      </div>
+                    </div>
+                    <div className="shrink-0" onClick={(e) => e.stopPropagation()}>
                       <ChatContextMenu
                         conversationId={c.conversation_id}
                         conversationTitle={c.title || c.prompt?.slice(0, 50) || "Untitled"}
@@ -467,124 +596,40 @@ export default function ConversationsPage() {
                         onCreateProject={async (name) => { await addProject(name); }}
                       />
                     </div>
-                  </TableCell>
-                </TableRow>
-              ))
-            )}
-          </TableBody>
-        </Table>
-      </div>
+                  </div>
+                </CardContent>
+              </Card>
+            ))
+          )}
+        </div>
 
-      {/* Mobile card list */}
-      <div className="mobile-cards space-y-2">
-        {loading ? (
-          <>
-            <MobileSkeletonCard /><MobileSkeletonCard /><MobileSkeletonCard />
-            <MobileSkeletonCard /><MobileSkeletonCard />
-          </>
-        ) : conversations.length === 0 ? (
-          hasActiveFilters ? (
-            <EmptyState
-              icon={RiChat1Line}
-              title="No conversations match your filters"
-              action="Clear all filters"
-              onAction={clearFilters}
-            />
-          ) : (
-            <EmptyState icon={RiChat1Line} title="No conversations found" description="Start a new conversation from the chat page" />
-          )
-        ) : (
-          conversations.map((c, idx) => (
-            <Card
-              key={c.conversation_id}
-              className="p-3 active:bg-muted/50 transition-colors animate-fade-in-up cursor-pointer"
-              style={{ animationDelay: `${Math.min(idx * 30, 300)}ms` }}
-              onClick={(e) => {
-                const url = `/conversations/${c.conversation_id}`;
-                if (e.metaKey || e.ctrlKey) {
-                  window.open(url, "_blank");
-                } else {
-                  router.push(url);
-                }
-              }}
+        {/* Pagination */}
+        {totalPages > 1 && (
+          <div className="flex justify-center items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              disabled={page === 1}
+              className="press-scale"
             >
-              <CardContent className="p-0">
-                <div className="flex items-center gap-2 mb-1.5 flex-wrap">
-                  <Badge variant="secondary" className={cn("text-xs", sourceStyles[c.source] || "bg-gray-100 text-gray-600")}>
-                    {sourceLabels[c.source] || c.source}
-                  </Badge>
-                  {c.topic && (
-                    <Badge variant="secondary" className={cn("text-xs", topicStyles[c.topic] || "bg-gray-100 text-gray-600")}>
-                      {topicLabels[c.topic] || c.topic}
-                    </Badge>
-                  )}
-                  <Badge variant="secondary" className={cn("text-xs", statusStyles[c.status] || "bg-gray-100 text-gray-600")}>{c.status}</Badge>
-                  <div className="ml-auto" onClick={(e) => e.stopPropagation()}>
-                    <ChatContextMenu
-                      conversationId={c.conversation_id}
-                      conversationTitle={c.title || c.prompt?.slice(0, 50) || "Untitled"}
-                      isPinned={isPinned(c.conversation_id)}
-                      projectId={c.project_id}
-                      projects={projects}
-                      onRename={async (id, newTitle) => { await renameConversation(id, newTitle); loadData(); }}
-                      onDelete={async (id) => { await removeConversation(id); loadData(); }}
-                      onTogglePin={togglePin}
-                      onAssignProject={async (id, pid) => { await assignToProject(id, pid); loadData(); }}
-                      onRemoveProject={async (id) => { await unassignFromProject(id); loadData(); }}
-                      onCreateProject={async (name) => { await addProject(name); }}
-                    />
-                  </div>
-                </div>
-                <div className="text-[13px] font-medium text-foreground truncate">
-                  {c.title || c.prompt?.slice(0, 60) + (c.prompt?.length > 60 ? "..." : "")}
-                </div>
-                {c.title && (
-                  <div className="text-xs text-muted-foreground truncate mt-0.5">
-                    {c.prompt?.slice(0, 60)}{c.prompt?.length > 60 ? "..." : ""}
-                  </div>
-                )}
-                <div className="flex items-center gap-2 mt-2 text-xs text-muted-foreground">
-                  <ClientTimestamp iso={c.started_at} variant="short" />
-                  <span>{c.total_turns} turns</span>
-                  {c.cost?.total_cost_usd != null && (
-                    <span className="tabular-nums">${c.cost.total_cost_usd.toFixed(4)}</span>
-                  )}
-                  {c.savings?.savings_usd != null && (
-                    <span className="text-emerald-600 font-medium tabular-nums">+${c.savings.savings_usd.toFixed(2)}</span>
-                  )}
-                </div>
-              </CardContent>
-            </Card>
-          ))
+              Previous
+            </Button>
+            <span className="px-3 py-1.5 text-[13px] text-muted-foreground">
+              Page {page} of {totalPages}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+              disabled={page === totalPages}
+              className="press-scale"
+            >
+              Next
+            </Button>
+          </div>
         )}
       </div>
-
-      {/* Pagination */}
-      {totalPages > 1 && (
-        <div className="flex justify-center items-center gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setPage((p) => Math.max(1, p - 1))}
-            disabled={page === 1}
-            className="press-scale"
-          >
-            Previous
-          </Button>
-          <span className="px-3 py-1.5 text-[13px] text-muted-foreground">
-            Page {page} of {totalPages}
-          </span>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
-            disabled={page === totalPages}
-            className="press-scale"
-          >
-            Next
-          </Button>
-        </div>
-      )}
-    </div>
+    </TooltipProvider>
   );
 }

--- a/dashboard/src/app/mcp/[tool]/page.tsx
+++ b/dashboard/src/app/mcp/[tool]/page.tsx
@@ -226,7 +226,7 @@ export default function ToolDetailPage() {
               {config?.roles && config.roles.length > 0 ? (
                 <Table>
                   <TableHeader>
-                    <TableRow className="border-b border-border">
+                    <TableRow className="">
                       <TableHead className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">Role</TableHead>
                       <TableHead className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">Description</TableHead>
                       <TableHead />
@@ -256,7 +256,7 @@ export default function ToolDetailPage() {
                   <h2 className="text-[13px] font-heading font-semibold text-foreground mb-2">Team Assignments</h2>
                   <Table>
                     <TableHeader>
-                      <TableRow className="border-b border-border">
+                      <TableRow className="">
                         <TableHead className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">Team</TableHead>
                         <TableHead className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">Default Role</TableHead>
                         <TableHead className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">Members</TableHead>
@@ -325,7 +325,7 @@ export default function ToolDetailPage() {
               {toolUsers.length > 0 ? (
                 <Table>
                   <TableHeader>
-                    <TableRow className="border-b border-border">
+                    <TableRow className="">
                       <TableHead className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">User</TableHead>
                       <TableHead className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">Effective Role</TableHead>
                       <TableHead className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">Source</TableHead>
@@ -461,7 +461,7 @@ export default function ToolDetailPage() {
               {toolUsers.length > 0 ? (
                 <Table>
                   <TableHeader>
-                    <TableRow className="border-b border-border">
+                    <TableRow className="">
                       <TableHead className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">User</TableHead>
                       <TableHead className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">Status</TableHead>
                       <TableHead className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">Last Used</TableHead>

--- a/dashboard/src/app/webhook-logs/page.tsx
+++ b/dashboard/src/app/webhook-logs/page.tsx
@@ -265,7 +265,7 @@ function WebhookLogsContent() {
         <Card className="overflow-hidden">
           <Table>
             <TableHeader>
-              <TableRow className="text-left text-muted-foreground border-b border-border bg-muted/50">
+              <TableRow className="text-left text-muted-foreground">
                 <TableHead className="font-medium">Received</TableHead>
                 <TableHead className="font-medium">Flow</TableHead>
                 <TableHead className="font-medium">Auth</TableHead>
@@ -295,7 +295,7 @@ function WebhookLogsContent() {
           <div className="overflow-x-auto">
             <Table>
               <TableHeader>
-                <TableRow className="text-left text-muted-foreground border-b border-border bg-muted/50">
+                <TableRow className="text-left text-muted-foreground">
                   <TableHead className="font-medium">Received</TableHead>
                   <TableHead className="font-medium">Flow</TableHead>
                   <TableHead className="font-medium">Auth</TableHead>

--- a/dashboard/src/components/ui/table.tsx
+++ b/dashboard/src/components/ui/table.tsx
@@ -23,7 +23,7 @@ function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
   return (
     <thead
       data-slot="table-header"
-      className={cn("[&_tr]:border-b", className)}
+      className={cn("", className)}
       {...props}
     />
   )
@@ -33,7 +33,7 @@ function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
   return (
     <tbody
       data-slot="table-body"
-      className={cn("[&_tr:last-child]:border-0", className)}
+      className={cn("", className)}
       {...props}
     />
   )
@@ -44,7 +44,7 @@ function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
     <tfoot
       data-slot="table-footer"
       className={cn(
-        "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+        "bg-muted/50 font-medium",
         className
       )}
       {...props}
@@ -57,7 +57,7 @@ function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
     <tr
       data-slot="table-row"
       className={cn(
-        "border-b transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted",
+        "transition-colors hover:bg-muted/50 has-aria-expanded:bg-muted/50 data-[state=selected]:bg-muted",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary

- **Conversations table**: Collapsed from 12 columns to 7. Status is now a colored dot, source is an icon with tooltip, account is a subtitle under title, and turns/duration/savings/confidence are tucked into a cost hover tooltip. Actions (continue, context menu) only appear on row hover. Search and filters merged into a single borderless row.
- **Global table cleanup**: Removed all row separators, header borders, and footer borders from the base `Table` component. Cleaned explicit border classes from webhook-logs, admin, teams, MCP tools, and analytics tables.
- **DESIGN.md**: Added a design principles doc covering cognitive load minimization, icon-over-text, borderless tables, hover-reveal patterns, shadcn defaults, and a decision framework for future UI work.
- **Title generation bug**: Added stderr logging to `_generate_title_llm()` and `_classify_topic_llm()` — previously the claude CLI subprocess stderr was silently discarded, making failures invisible.

## Test plan

- [ ] Verify conversations table renders with status dots, icon-only source, and hover-reveal actions
- [ ] Hover over cost cell and confirm tooltip shows full cost, savings, turns, duration, confidence
- [ ] Confirm no row separators or table borders on all pages: conversations, webhook-logs, admin, teams, MCP tools, analytics
- [ ] Verify search + filters bar is a single row with no card borders
- [ ] Check mobile card view still works on conversations page
- [ ] Trigger a new conversation and check server logs for title generation stderr output

🤖 Generated with [Claude Code](https://claude.com/claude-code)