### PR TITLE
chore: raise default skill index limit from 40 to 150

### DIFF
--- a/api/skill_service.py
+++ b/api/skill_service.py
@@ -25,7 +25,7 @@ TEXT_EXTENSIONS = {".md", ".py", ".json", ".xml", ".txt", ".yaml", ".yml", ".csv
 MAX_INLINE_TEXT_BYTES = int(os.environ.get("LOMA_SKILL_MAX_INLINE_TEXT_BYTES", str(512 * 1024)))
 MAX_ASSET_BYTES = int(os.environ.get("LOMA_SKILL_MAX_ASSET_BYTES", str(100 * 1024 * 1024)))
 MAX_PACKAGE_BYTES = int(os.environ.get("LOMA_SKILL_MAX_PACKAGE_BYTES", str(500 * 1024 * 1024)))
-SKILL_INDEX_LIMIT = int(os.environ.get("LOMA_SKILL_INDEX_LIMIT", "40"))
+SKILL_INDEX_LIMIT = int(os.environ.get("LOMA_SKILL_INDEX_LIMIT", "150"))
 
 
 class SkillError(ValueError):


### PR DESCRIPTION
## Summary
- Raise the default value of `SKILL_INDEX_LIMIT` from `40` to `150` in `api/skill_service.py`.

## Context
The Loma skill index shown in the agent prompt is capped by `SKILL_INDEX_LIMIT` (env `LOMA_SKILL_INDEX_LIMIT`, default 40) and sorted alphabetically by slug. With ~57 skills currently registered, any slug sorting past position 40 (e.g. `run-plotline-services-local`) gets collapsed into the "... N more skills" overflow bucket and never renders inline, even though the records are fully intact and resolvable via `search`/`get`. Bumping the default to 150 lets every skill render inline and removes the overflow line.

## Changes
- `api/skill_service.py` — change `LOMA_SKILL_INDEX_LIMIT` default from `"40"` to `"150"`.

## Notes
- This changes the **default** only. If `LOMA_SKILL_INDEX_LIMIT` is set as an explicit env var in the deployment, that value still takes precedence and must be updated separately.
- The index is cached at startup (`set_loma_skill_index_cache`), so the new limit takes effect on the next process restart/redeploy, not mid-session.

## Testing
- Verified the edit produces a clean one-line diff (`git diff`).
- Confirmed no other code paths reference the old `"40"` default (`grep -rn "LOMA_SKILL_INDEX_LIMIT"`).

This is a draft PR — please review before merging.