### PR TITLE
feat: queue prompts while agent is streaming

### DIFF
--- a/agent/client.py
+++ b/agent/client.py
@@ -708,6 +708,7 @@ async def stream_agent(
 
     # Append file contents inline; save images to temp files for the agent to read
     temp_files = []  # track temp files to clean up later
+    image_files: list[dict] = []  # raw image data for OpenCode file parts
     if files:
         for f in files:
             if f["type"] == "text":
@@ -715,8 +716,7 @@ async def stream_agent(
                     f"## Attached File: {f['name']}\n```\n{f['data']}\n```"
                 )
             elif f["type"] == "image":
-                # Save image to a temp file \u2014 the Claude Code CLI can read
-                # images via its built-in Read tool (multimodal support)
+                image_files.append(f)
                 ext = Path(f["name"]).suffix or ".png"
                 tmp = tempfile.NamedTemporaryFile(
                     suffix=ext, prefix="slack_img_", delete=False
@@ -820,6 +820,7 @@ async def stream_agent(
                 observer=observer,
                 include_steps=include_steps,
                 source=source,
+                image_files=image_files or None,
             ):
                 yield event
         except Exception as e:

--- a/agent/opencode_runtime.py
+++ b/agent/opencode_runtime.py
@@ -975,6 +975,7 @@ async def run_opencode_agent(
     observer=None,
     include_steps: bool = False,
     source: str = "dashboard",
+    image_files: list[dict] | None = None,
 ) -> AsyncGenerator[str | dict, None]:
     """Run one dashboard chat turn through OpenCode and yield dashboard events."""
     started_at = time.perf_counter()
@@ -1043,10 +1044,21 @@ async def run_opencode_agent(
 
     system_prompt = _opencode_system_prompt()
 
+    parts: list[dict] = [{"type": "text", "text": full_prompt}]
+    if image_files:
+        for img in image_files:
+            parts.append({
+                "type": "file",
+                "mime": img.get("mimetype", "image/png"),
+                "filename": img.get("name"),
+                "url": f"data:{img.get('mimetype', 'image/png')};base64,{img['data']}",
+            })
+        logger.info("[OPENCODE] Attached %d image(s) as file parts", len(image_files))
+
     body = {
         "model": {"providerID": provider_id, "modelID": model_id},
         "system": system_prompt,
-        "parts": [{"type": "text", "text": full_prompt}],
+        "parts": parts,
     }
     logger.info(
         "OpenCode turn prepared model=%s source=%s system_chars=%d prompt_chars=%d mcp_servers=%d catalog=%.3fs session=%.3fs idle_timeout=%ds request_timeout=%ds",

--- a/dashboard/src/components/ChatPanel.tsx
+++ b/dashboard/src/components/ChatPanel.tsx
@@ -121,6 +121,8 @@ export interface ChatItem {
   /** Client-observed response duration for this assistant message */
   responseTimeSeconds?: number;
   elapsedSeconds?: number;
+  /** True when this user message is queued to be sent after the current stream finishes */
+  queued?: boolean;
 }
 
 /** Pretty-print a tool name for display */
@@ -698,6 +700,8 @@ export default function ChatPanel({
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
+  const queuedMessagesRef = useRef<{ text: string; files?: ChatFile[] }[]>([]);
+  const [queuedCount, setQueuedCount] = useState(0);
 
   const selectedModelInfo = useMemo(
     () => agentModels.find((model) => model.id === selectedModel) || null,
@@ -860,7 +864,7 @@ export default function ChatPanel({
 
   useEffect(() => {
     const handleEscapeKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && isStreaming) {
+      if (e.key === "Escape" && isStreaming && document.activeElement !== inputRef.current) {
         e.preventDefault();
         handleStop();
       }
@@ -931,9 +935,30 @@ export default function ChatPanel({
     }
   });
 
-  const handleSend = async (overrideMessage?: string) => {
+  const handleSend = async (overrideMessage?: string, { fromQueue }: { fromQueue?: boolean } = {}) => {
     const displayText = overrideMessage ?? input.trim();
-    if ((!displayText && pendingFiles.length === 0) || isStreaming) return;
+    if (!displayText && pendingFiles.length === 0) return;
+
+    if (isStreaming) {
+      const isOverride = overrideMessage !== undefined;
+      const filesToQueue = !isOverride && pendingFiles.length > 0 ? [...pendingFiles] : undefined;
+      const fileNames = filesToQueue?.map((f) => f.name);
+      queuedMessagesRef.current.push({ text: displayText, files: filesToQueue });
+      setQueuedCount(queuedMessagesRef.current.length);
+      setItems((prev) => [
+        ...prev,
+        { role: "user", content: displayText, fileNames, files: filesToQueue, queued: true },
+      ]);
+      if (!isOverride) {
+        setInput("");
+        setPendingFiles([]);
+        requestAnimationFrame(() => {
+          if (inputRef.current) inputRef.current.style.height = "auto";
+        });
+      }
+      scrollToBottom();
+      return;
+    }
     const message = systemContext && overrideMessage
       ? `[Context: ${systemContext}]\n\n${displayText}`
       : displayText;
@@ -961,7 +986,9 @@ export default function ChatPanel({
       setPendingFiles([]);
       setAccountInfo(null);
     }
-    setItems((prev) => [...prev, { role: "user", content: displayMessage, fileNames, files: filesToSend }]);
+    if (!fromQueue) {
+      setItems((prev) => [...prev, { role: "user", content: displayMessage, fileNames, files: filesToSend }]);
+    }
     setIsStreaming(true);
     setStreamStartedAt(performance.now());
 
@@ -1175,7 +1202,21 @@ export default function ChatPanel({
       }
       abortControllerRef.current = null;
       scrollToBottom();
-      if (!enteredRecovery) {
+
+      const queued = queuedMessagesRef.current;
+      if (queued.length > 0 && !enteredRecovery) {
+        queuedMessagesRef.current = [];
+        setQueuedCount(0);
+        setItems((prev) => prev.map((item) =>
+          item.queued ? { ...item, queued: false } : item
+        ));
+        const combinedText = queued.map((q) => q.text).join("\n\n");
+        const combinedFiles = queued.flatMap((q) => q.files || []);
+        if (combinedFiles.length) {
+          setPendingFiles(combinedFiles);
+        }
+        requestAnimationFrame(() => handleSend(combinedText, { fromQueue: true }));
+      } else if (!enteredRecovery) {
         requestAnimationFrame(() => {
           inputRef.current?.focus();
         });
@@ -1491,10 +1532,9 @@ export default function ChatPanel({
                   onChange={(e) => setInput(e.target.value)}
                   onKeyDown={handleKeyDown}
                   onPaste={handlePaste}
-                  placeholder="What do you need to get done?"
-                  disabled={isStreaming}
+                  placeholder={isStreaming ? "Type your next message..." : "What do you need to get done?"}
                   rows={2}
-                  className="w-full bg-transparent px-4 md:px-5 pt-4 md:pt-5 pb-3 text-[15px] text-foreground placeholder-muted-foreground focus:outline-none disabled:opacity-50 resize-none overflow-hidden leading-relaxed border-0 focus-visible:ring-0 focus-visible:border-transparent rounded-none min-h-0"
+                  className="w-full bg-transparent px-4 md:px-5 pt-4 md:pt-5 pb-3 text-[15px] text-foreground placeholder-muted-foreground focus:outline-none resize-none overflow-hidden leading-relaxed border-0 focus-visible:ring-0 focus-visible:border-transparent rounded-none min-h-0"
                   style={{ maxHeight: "200px" }}
                 />
                 <div className="flex items-center justify-between gap-2 px-3 pb-3">
@@ -1507,7 +1547,6 @@ export default function ChatPanel({
                       variant="ghost"
                       size="icon-sm"
                       onClick={() => fileInputRef.current?.click()}
-                      disabled={isStreaming}
                       title="Attach files"
                       className="text-muted-foreground hover:text-foreground"
                     >
@@ -1515,15 +1554,11 @@ export default function ChatPanel({
                     </Button>
                     <Button
                       type="submit"
-                      disabled={isStreaming || (!input.trim() && pendingFiles.length === 0)}
+                      disabled={!input.trim() && pendingFiles.length === 0}
                       className="bg-accent-200 hover:bg-accent-300 disabled:opacity-30 disabled:hover:bg-accent-200 text-accent-on rounded-lg press-scale"
                       size="icon-sm"
                     >
-                      {isStreaming ? (
-                        <RiLoader4Line size={16} className="animate-spin" />
-                      ) : (
-                        <RiSendPlaneLine size={16} />
-                      )}
+                      <RiSendPlaneLine size={16} />
                     </Button>
                   </div>
                 </div>
@@ -1609,8 +1644,17 @@ export default function ChatPanel({
                 if (item.role === "user") {
                   return (
                     <div key={i} className="flex justify-end animate-message-in">
-                      <div className="bg-muted rounded-xl px-3 py-2 max-w-[75%] text-[13px] leading-relaxed break-words whitespace-pre-wrap">
+                      <div className={cn(
+                        "rounded-xl px-3 py-2 max-w-[75%] text-[13px] leading-relaxed break-words whitespace-pre-wrap",
+                        item.queued ? "bg-muted/60 border border-dashed border-border" : "bg-muted"
+                      )}>
                         {item.content || <TypingIndicator />}
+                        {item.queued && (
+                          <div className="flex items-center gap-1 mt-1.5 text-[11px] text-muted-foreground">
+                            <RiTimeLine size={12} />
+                            <span>Queued — will send when agent finishes</span>
+                          </div>
+                        )}
                         {item.fileNames && item.fileNames.length > 0 && (
                           <div className="mt-1.5 flex flex-wrap gap-1.5">
                             {item.fileNames.map((name, fi) => {
@@ -1735,10 +1779,9 @@ export default function ChatPanel({
                   onChange={(e) => setInput(e.target.value)}
                   onKeyDown={handleKeyDown}
                   onPaste={handlePaste}
-                  placeholder={isStreaming ? "Agent is working... press Esc or Stop to interrupt" : "Ask the agent something..."}
-                  disabled={isStreaming}
+                  placeholder={isStreaming ? (queuedCount > 0 ? `${queuedCount} message${queuedCount > 1 ? "s" : ""} queued — type another or wait for agent` : "Type a follow-up while agent is working...") : "Ask the agent something..."}
                   rows={1}
-                  className="w-full bg-transparent px-3 pt-3 pb-1.5 text-[13px] text-foreground placeholder-muted-foreground focus:outline-none disabled:opacity-50 resize-none overflow-hidden border-0 focus-visible:ring-0 focus-visible:border-transparent rounded-none min-h-0"
+                  className="w-full bg-transparent px-3 pt-3 pb-1.5 text-[13px] text-foreground placeholder-muted-foreground focus:outline-none resize-none overflow-hidden border-0 focus-visible:ring-0 focus-visible:border-transparent rounded-none min-h-0"
                   style={{ maxHeight: "160px" }}
                 />
                 <div className="flex items-center justify-between gap-2 px-2 pb-2">
@@ -1751,13 +1794,12 @@ export default function ChatPanel({
                       variant="ghost"
                       size="icon-sm"
                       onClick={() => fileInputRef.current?.click()}
-                      disabled={isStreaming}
                       title="Attach files"
                       className="text-muted-foreground hover:text-foreground"
                     >
                       <RiAttachmentLine size={16} />
                     </Button>
-                    {isStreaming ? (
+                    {isStreaming && (
                       <Button
                         type="button"
                         variant="destructive"
@@ -1768,16 +1810,15 @@ export default function ChatPanel({
                       >
                         <RiStopLine size={16} />
                       </Button>
-                    ) : (
-                      <Button
-                        type="submit"
-                        size="icon-sm"
-                        disabled={!input.trim() && pendingFiles.length === 0}
-                        className="bg-accent-200 hover:bg-accent-300 disabled:opacity-40 disabled:hover:bg-accent-200 text-accent-on rounded-lg press-scale"
-                      >
-                        <RiSendPlaneLine size={16} />
-                      </Button>
                     )}
+                    <Button
+                      type="submit"
+                      size="icon-sm"
+                      disabled={!input.trim() && pendingFiles.length === 0}
+                      className="bg-accent-200 hover:bg-accent-300 disabled:opacity-40 disabled:hover:bg-accent-200 text-accent-on rounded-lg press-scale"
+                    >
+                      <RiSendPlaneLine size={16} />
+                    </Button>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- Users can now type and submit messages while the agent is actively streaming a response
- Each submitted message appears immediately in chat with a dashed-border "Queued" indicator (clock icon + label)
- Multiple messages can be queued — all are concatenated with `\n\n` and sent as a single follow-up turn when the current stream finishes
- Textarea, file attachment, and send button remain fully enabled during streaming; stop button shown alongside send
- Escape key no longer stops the agent when the textarea is focused (prevents accidental stops while typing)
- Placeholder dynamically shows queue count: "2 messages queued — type another or wait for agent"

## Test plan
- [ ] Start a chat, submit a prompt, and while agent is streaming type + submit a follow-up
- [ ] Verify the follow-up appears immediately with the queued indicator (dashed border + clock icon)
- [ ] Submit multiple messages while streaming — verify all show as queued
- [ ] Wait for agent to finish — verify all queued messages are sent as one combined prompt
- [ ] Verify the queued indicators disappear once the combined message is sent
- [ ] Test stopping the agent (click Stop) while messages are queued — queued messages should still auto-send
- [ ] Verify Escape doesn't stop the agent when typing in the textarea
- [ ] Verify file attachments work with queued messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)