### PR TITLE
feat: per-user OAuth for custom MCP connectors

### DIFF
--- a/agent/client.py
+++ b/agent/client.py
@@ -130,6 +130,10 @@ async def merge_db_integrations(config: dict) -> dict:
             # Custom connectors carry their own inline remote MCP config (no
             # catalog entry). Added by admins from the Integrations page.
             if integration.get("is_custom"):
+                # OAuth connectors are handled per-user at stream_agent() time
+                if integration.get("auth_mode") == "oauth":
+                    logger.info("Skipping OAuth custom connector '%s' from shared pool config", provider)
+                    continue
                 try:
                     cfg = {"type": "http", "url": integration["mcp_url"]}
                     if integration.get("api_key_encrypted"):
@@ -165,6 +169,41 @@ async def merge_db_integrations(config: dict) -> dict:
         logger.exception("Failed to load integrations from DB — using config.yaml only")
 
     return config
+
+
+async def build_user_mcp_overrides(user_email: str) -> dict:
+    """Build per-user MCP server config for OAuth-requiring custom connectors.
+
+    Returns a dict of MCP server configs keyed by provider slug.
+    Only includes connectors where the user has a valid token.
+    """
+    try:
+        from observability.db import get_db
+        from api.oauth_helpers import get_valid_custom_mcp_token
+
+        db = get_db()
+        if db is None:
+            return {}
+
+        overrides = {}
+        async for integration in db.integrations.find({
+            "is_custom": True, "status": "active", "auth_mode": "oauth",
+        }):
+            provider = integration["provider"]
+            token = await get_valid_custom_mcp_token(user_email, provider, db=db)
+            if token:
+                header = integration.get("auth_header") or "Authorization"
+                overrides[provider] = {
+                    "type": "http",
+                    "url": integration["mcp_url"],
+                    "headers": {header: f"Bearer {token}"},
+                }
+                logger.info("Built per-user MCP config for %s / %s", user_email, provider)
+
+        return overrides
+    except Exception:
+        logger.exception("Failed to build user MCP overrides for %s", user_email)
+        return {}
 
 
 def _resolve_mcp_template(template: dict, api_key: str, extra_fields: dict | None = None) -> dict:
@@ -808,6 +847,11 @@ async def stream_agent(
     selected_model = selected_model or _default_agent_model()
     selected_claude_model = _normalize_claude_model(selected_model)
 
+    # Build per-user MCP overrides for OAuth-requiring custom connectors
+    user_mcp_overrides: dict = {}
+    if user_email:
+        user_mcp_overrides = await build_user_mcp_overrides(user_email)
+
     # OpenCode is the default runtime for OSS installs. Claude family selections
     # stay on the Claude Agent SDK runtime when explicitly selected/configured.
     if selected_model and not selected_claude_model:
@@ -820,6 +864,8 @@ async def stream_agent(
                 observer=observer,
                 include_steps=include_steps,
                 source=source,
+                user_email=user_email,
+                user_mcp_overrides=user_mcp_overrides,
             ):
                 yield event
         except Exception as e:
@@ -846,26 +892,63 @@ async def stream_agent(
     client = None
     account_email: str | None = None
 
-    try:
-        client = await pool.acquire(model=selected_claude_model)
-        account = getattr(client, '_pool_account', {})
-        account_email = account.get('email')
-        active_claude_model = getattr(client, "_pool_model", None) or selected_claude_model
-        logger.info("Client acquired (account=%s, model=%s), sending query...", account_email, active_claude_model)
-    except Exception as e:
-        logger.error("pool.acquire() failed: %s", e)
-        if observer:
-            await observer.record_error(f"Client initialization failed: {e}")
-        status = pool.status()
-        if not status["accounts"]:
-            yield "No Claude accounts are connected. Ask a team member to log in via Integrations."
-        else:
-            yield (
-                "I'm temporarily unable to start a new session \u2014 all agent slots are in use "
-                f"({status['in_use']}/{status['pool_size']} busy, {status['queue_depth']} queued). "
-                "Please try again in a minute or two."
+    if user_mcp_overrides and selected_claude_model:
+        # Per-user MCP overrides: create an ephemeral client with merged config
+        account = pool._next_account()
+        if account is None:
+            yield "No Claude accounts are currently available."
+            return
+        try:
+            options = pool._build_options(model_override=selected_claude_model)
+            merged_mcp = dict(options.mcp_servers or {})
+            merged_mcp.update(user_mcp_overrides)
+            options.mcp_servers = merged_mcp
+            allowed_tools = list(options.allowed_tools or [])
+            for server_name in user_mcp_overrides:
+                tool_name = f"mcp__{server_name}"
+                if tool_name not in allowed_tools:
+                    allowed_tools.append(tool_name)
+            options.allowed_tools = allowed_tools
+            options.env = {"CLAUDE_CONFIG_DIR": account["config_dir"]}
+            client = ClaudeSDKClient(options=options)
+            await asyncio.wait_for(client.connect(), timeout=90)
+            client._pool_account = account
+            client._pool_model = options.model
+            client._pool_ephemeral = True
+            pool._in_use += 1
+            account_email = account.get("email")
+            logger.info(
+                "Created per-user MCP client (account=%s, user=%s, extra_servers=%s)",
+                account_email, user_email, list(user_mcp_overrides.keys()),
             )
-        return
+        except Exception as e:
+            logger.error("Failed to create per-user MCP client: %s", e)
+            if client is not None:
+                await pool.safe_disconnect(client)
+            client = None
+            user_mcp_overrides = {}
+
+    if client is None:
+        try:
+            client = await pool.acquire(model=selected_claude_model)
+            account = getattr(client, '_pool_account', {})
+            account_email = account.get('email')
+            active_claude_model = getattr(client, "_pool_model", None) or selected_claude_model
+            logger.info("Client acquired (account=%s, model=%s), sending query...", account_email, active_claude_model)
+        except Exception as e:
+            logger.error("pool.acquire() failed: %s", e)
+            if observer:
+                await observer.record_error(f"Client initialization failed: {e}")
+            status = pool.status()
+            if not status["accounts"]:
+                yield "No Claude accounts are connected. Ask a team member to log in via Integrations."
+            else:
+                yield (
+                    "I'm temporarily unable to start a new session \u2014 all agent slots are in use "
+                    f"({status['in_use']}/{status['pool_size']} busy, {status['queue_depth']} queued). "
+                    "Please try again in a minute or two."
+                )
+            return
 
     # Record which account is processing this conversation
     if observer and account_email:

--- a/agent/opencode_runtime.py
+++ b/agent/opencode_runtime.py
@@ -213,7 +213,9 @@ async def _health_check(base_url: str) -> bool:
         return False
 
 
-async def ensure_opencode_server() -> str:
+async def ensure_opencode_server(
+    user_mcp_overrides: dict | None = None,
+) -> str:
     """Return a reachable OpenCode server URL, starting one if needed.
 
     By default the app starts OpenCode with an isolated config home so global
@@ -228,7 +230,9 @@ async def ensure_opencode_server() -> str:
             return base_url
         raise OpenCodeError(f"Configured OPENCODE_SERVER_URL is not reachable: {base_url}")
 
-    config_home, config_hash = await _write_managed_opencode_config()
+    config_home, config_hash = await _write_managed_opencode_config(
+        user_mcp_overrides=user_mcp_overrides,
+    )
 
     global _opencode_process, _opencode_config_hash
     should_start = _opencode_process is None or _opencode_process.returncode is not None
@@ -286,19 +290,36 @@ async def ensure_opencode_server() -> str:
     raise OpenCodeError(f"OpenCode server did not become ready at {base_url}")
 
 
-async def _write_managed_opencode_config() -> tuple[Path, str]:
+_opencode_config_last_user: str | None = None
+
+
+async def _write_managed_opencode_config(
+    user_mcp_overrides: dict | None = None,
+) -> tuple[Path, str]:
     """Write isolated OpenCode config from this app's MCP source of truth."""
     global _opencode_config_home, _opencode_mcp_names, _opencode_config_checked_at
+    global _opencode_config_last_user
+
+    # Cache key includes user overrides so config changes per-user
+    overrides_key = json.dumps(sorted((user_mcp_overrides or {}).keys()))
 
     now = time.monotonic()
     if (
         _opencode_config_home is not None
         and _opencode_config_hash is not None
         and now - _opencode_config_checked_at < OPENCODE_CONFIG_TTL_SECONDS
+        and _opencode_config_last_user == overrides_key
     ):
         return _opencode_config_home, _opencode_config_hash
 
+    _opencode_config_last_user = overrides_key
+
     app_config = await _load_current_agent_config()
+    # Merge per-user MCP overrides into the app config
+    if user_mcp_overrides:
+        mcp_servers = dict(app_config.get("mcp_servers", {}))
+        mcp_servers.update(user_mcp_overrides)
+        app_config["mcp_servers"] = mcp_servers
     mcp_config = claude_mcp_to_opencode(app_config.get("mcp_servers", {}))
     _opencode_mcp_names = set(mcp_config.keys())
     opencode_config = {
@@ -975,6 +996,8 @@ async def run_opencode_agent(
     observer=None,
     include_steps: bool = False,
     source: str = "dashboard",
+    user_email: str | None = None,
+    user_mcp_overrides: dict | None = None,
 ) -> AsyncGenerator[str | dict, None]:
     """Run one dashboard chat turn through OpenCode and yield dashboard events."""
     started_at = time.perf_counter()
@@ -1071,7 +1094,7 @@ async def run_opencode_agent(
         yield {"type": "turn", "turn_number": turn_count}
         yield {"type": "status", "message": "Sent prompt to OpenCode; waiting for model/tool events"}
 
-    base_url = await ensure_opencode_server()
+    base_url = await ensure_opencode_server(user_mcp_overrides=user_mcp_overrides)
     assistant_message_ids: set[str] = set()
     emitted_text_part_ids: set[str] = set()
     emitted_text_by_part_id: dict[str, str] = {}

--- a/api/integration_routes.py
+++ b/api/integration_routes.py
@@ -10,11 +10,13 @@ import os
 import re
 import uuid
 from datetime import datetime, timezone
+from urllib.parse import urlparse
 
+import aiohttp as _aiohttp
 from aiohttp import web
 
 from api.auth_helpers import require_admin, get_user_email
-from api.oauth_helpers import encrypt_token, decrypt_token
+from api.oauth_helpers import encrypt_token, decrypt_token, register_oauth_client
 from integrations.registry import PROVIDER_CATALOG, list_providers, get_provider
 from observability.db import get_db
 
@@ -74,8 +76,9 @@ async def _list_integrations(request: web.Request) -> web.Response:
 
     # Append admin-added custom MCP connectors (not in the static catalog).
     if db is not None:
+        user_email = get_user_email(request)
         async for doc in db.integrations.find({"is_custom": True, "status": "active"}):
-            result.append({
+            item = {
                 "provider": doc["provider"],
                 "display_name": doc.get("display_name", doc["provider"]),
                 "description": "Custom MCP server",
@@ -89,9 +92,18 @@ async def _list_integrations(request: web.Request) -> web.Response:
                 "is_custom": True,
                 "url": doc.get("mcp_url", ""),
                 "has_token": bool(doc.get("api_key_encrypted")),
+                "auth_mode": doc.get("auth_mode", "none"),
                 "connected_by": doc.get("connected_by"),
                 "connected_at": doc.get("connected_at").isoformat() if doc.get("connected_at") else None,
-            })
+            }
+            if doc.get("auth_mode") == "oauth" and user_email:
+                user_token = await db.oauth_tokens.find_one({
+                    "user_email": user_email,
+                    "provider": doc["provider"],
+                    "provider_type": "custom_mcp",
+                })
+                item["user_oauth_status"] = "connected" if user_token else "not_connected"
+            result.append(item)
 
     return web.json_response(result)
 
@@ -169,10 +181,51 @@ async def _disconnect_integration(request: web.Request) -> web.Response:
     return web.json_response({"status": "disconnected", "provider": provider})
 
 
+async def _probe_custom_connector(request: web.Request) -> web.Response:
+    """POST /api/integrations/custom/probe — check if a URL requires OAuth."""
+    require_admin(request)
+
+    body = await request.json()
+    url = (body.get("url") or "").strip()
+    if not url or not re.match(r"^https?://", url):
+        return web.json_response({"error": "Valid URL required"}, status=400)
+
+    result: dict = {"requires_oauth": False, "reachable": False, "oauth_metadata": None}
+
+    async with _aiohttp.ClientSession() as session:
+        try:
+            async with session.get(url, timeout=_aiohttp.ClientTimeout(total=10), allow_redirects=True) as resp:
+                result["reachable"] = True
+                if resp.status == 401:
+                    result["requires_oauth"] = True
+        except Exception:
+            pass
+
+    parsed = urlparse(url)
+    well_known_url = f"{parsed.scheme}://{parsed.netloc}/.well-known/oauth-authorization-server"
+
+    async with _aiohttp.ClientSession() as session:
+        try:
+            async with session.get(well_known_url, timeout=_aiohttp.ClientTimeout(total=5)) as resp:
+                if resp.status == 200:
+                    metadata = await resp.json()
+                    result["requires_oauth"] = True
+                    result["oauth_metadata"] = {
+                        "authorization_endpoint": metadata.get("authorization_endpoint"),
+                        "token_endpoint": metadata.get("token_endpoint"),
+                        "registration_endpoint": metadata.get("registration_endpoint"),
+                        "scopes_supported": metadata.get("scopes_supported", []),
+                    }
+        except Exception:
+            pass
+
+    return web.json_response(result)
+
+
 async def _add_custom_connector(request: web.Request) -> web.Response:
     """POST /api/integrations/custom — register a custom remote MCP server.
 
-    Admin-only. The connector's tools become available to every user's agent.
+    Admin-only. Supports static token, per-user OAuth, or no auth.
     """
     require_admin(request)
     db = get_db()
@@ -184,11 +237,16 @@ async def _add_custom_connector(request: web.Request) -> web.Response:
     url = (body.get("url") or "").strip()
     token = (body.get("token") or "").strip()
     auth_header = (body.get("auth_header") or "Authorization").strip() or "Authorization"
+    auth_mode = (body.get("auth_mode") or "").strip()
 
     if not name or not url:
         return web.json_response({"error": "name and url are required"}, status=400)
     if not re.match(r"^https?://", url):
         return web.json_response({"error": "url must start with http:// or https://"}, status=400)
+
+    # Infer auth_mode if not explicitly provided
+    if not auth_mode:
+        auth_mode = "static" if token else "none"
 
     slug = _slugify(name)
     if not slug:
@@ -208,7 +266,7 @@ async def _add_custom_connector(request: web.Request) -> web.Response:
 
     user_email = get_user_email(request) or "unknown"
     now = datetime.now(timezone.utc)
-    doc = {
+    doc: dict = {
         "integration_id": str(uuid.uuid4()),
         "provider": slug,
         "is_custom": True,
@@ -216,17 +274,66 @@ async def _add_custom_connector(request: web.Request) -> web.Response:
         "display_name": name,
         "mcp_url": url,
         "auth_header": auth_header,
-        "api_key_encrypted": encrypt_token(token) if token else None,
+        "auth_mode": auth_mode,
+        "api_key_encrypted": encrypt_token(token) if token and auth_mode == "static" else None,
         "connected_by": user_email,
         "connected_at": now,
         "updated_at": now,
     }
+
+    if auth_mode == "oauth":
+        oauth_config = body.get("oauth_config") or {}
+        if not oauth_config.get("authorization_endpoint") or not oauth_config.get("token_endpoint"):
+            return web.json_response(
+                {"error": "OAuth requires authorization_endpoint and token_endpoint"},
+                status=400,
+            )
+
+        # Dynamic client registration if registration_endpoint provided and no client_id
+        client_id = oauth_config.get("client_id", "")
+        client_secret = oauth_config.get("client_secret", "")
+        token_endpoint_auth_method = oauth_config.get("token_endpoint_auth_method", "client_secret_post")
+
+        if not client_id and oauth_config.get("registration_endpoint"):
+            from api.oauth_routes import _oauth_redirect_uri
+            redirect_uri = f"{os.environ.get('APP_BASE_URL', '').rstrip('/')}/api/oauth/custom-mcp/{slug}/callback"
+            reg_result = await register_oauth_client(
+                registration_endpoint=oauth_config["registration_endpoint"],
+                redirect_uri=redirect_uri,
+            )
+            if reg_result is None:
+                return web.json_response(
+                    {"error": "OAuth dynamic client registration failed. Provide client_id manually."},
+                    status=400,
+                )
+            client_id = reg_result["client_id"]
+            client_secret = reg_result.get("client_secret", "")
+            token_endpoint_auth_method = reg_result.get("token_endpoint_auth_method", "client_secret_post")
+            logger.info("[INTEGRATIONS] Dynamic client registration succeeded for '%s'", slug)
+
+        if not client_id:
+            return web.json_response(
+                {"error": "OAuth requires client_id (or a registration_endpoint for dynamic registration)"},
+                status=400,
+            )
+
+        doc["oauth_config"] = {
+            "authorization_endpoint": oauth_config["authorization_endpoint"],
+            "token_endpoint": oauth_config["token_endpoint"],
+            "registration_endpoint": oauth_config.get("registration_endpoint"),
+            "client_id_encrypted": encrypt_token(client_id),
+            "client_secret_encrypted": encrypt_token(client_secret) if client_secret else None,
+            "scopes": oauth_config.get("scopes", []),
+            "token_endpoint_auth_method": token_endpoint_auth_method,
+        }
+        doc["api_key_encrypted"] = None
+
     await db.integrations.insert_one(doc)
-    logger.info("[INTEGRATIONS] Added custom MCP connector '%s' (by %s)", slug, user_email)
+    logger.info("[INTEGRATIONS] Added custom MCP connector '%s' (auth_mode=%s, by %s)", slug, auth_mode, user_email)
 
     await _reload_pool()
 
-    return web.json_response({"status": "connected", "provider": slug}, status=201)
+    return web.json_response({"status": "connected", "provider": slug, "auth_mode": auth_mode}, status=201)
 
 
 async def _remove_custom_connector(request: web.Request) -> web.Response:
@@ -240,6 +347,16 @@ async def _remove_custom_connector(request: web.Request) -> web.Response:
     result = await db.integrations.delete_one({"provider": provider, "is_custom": True})
     if result.deleted_count == 0:
         return web.json_response({"error": "Custom connector not found"}, status=404)
+
+    # Clean up all per-user OAuth tokens for this connector
+    deleted_tokens = await db.oauth_tokens.delete_many({
+        "provider": provider, "provider_type": "custom_mcp",
+    })
+    if deleted_tokens.deleted_count > 0:
+        logger.info(
+            "[INTEGRATIONS] Cleaned up %d user OAuth tokens for removed connector '%s'",
+            deleted_tokens.deleted_count, provider,
+        )
 
     logger.info("[INTEGRATIONS] Removed custom MCP connector '%s'", provider)
 
@@ -294,6 +411,7 @@ def setup_integration_routes(app: web.Application):
     """Register integration API routes."""
     app.router.add_get("/api/integrations", _list_integrations)
     app.router.add_post("/api/integrations/connect", _connect_integration)
+    app.router.add_post("/api/integrations/custom/probe", _probe_custom_connector)
     app.router.add_post("/api/integrations/custom", _add_custom_connector)
     app.router.add_delete("/api/integrations/custom/{provider}", _remove_custom_connector)
     app.router.add_delete("/api/integrations/{provider}", _disconnect_integration)

--- a/api/oauth_helpers.py
+++ b/api/oauth_helpers.py
@@ -390,6 +390,284 @@ async def store_slack_tokens(
     logger.info("Stored Slack OAuth token for %s", user_email)
 
 
+async def _exchange_oauth_code(
+    token_endpoint: str,
+    code: str,
+    client_id: str,
+    client_secret: str,
+    redirect_uri: str,
+    auth_method: str = "client_secret_post",
+) -> dict | None:
+    """Exchange an authorization code for tokens at any OAuth provider."""
+    data = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": redirect_uri,
+    }
+    headers: dict[str, str] = {}
+
+    if auth_method == "client_secret_basic":
+        import base64
+        credentials = base64.b64encode(f"{client_id}:{client_secret}".encode()).decode()
+        headers["Authorization"] = f"Basic {credentials}"
+    else:
+        data["client_id"] = client_id
+        data["client_secret"] = client_secret
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                token_endpoint, data=data, headers=headers,
+                timeout=aiohttp.ClientTimeout(total=15),
+            ) as resp:
+                if resp.status != 200:
+                    text = await resp.text()
+                    logger.error("OAuth code exchange failed (%d): %s", resp.status, text[:300])
+                    return None
+                return await resp.json()
+    except Exception as e:
+        logger.error("OAuth code exchange request failed: %s", e)
+        return None
+
+
+async def _refresh_oauth_token(
+    token_endpoint: str,
+    refresh_token: str,
+    client_id: str,
+    client_secret: str,
+    auth_method: str = "client_secret_post",
+) -> dict | None:
+    """Exchange a refresh token for a new access token at any OAuth provider."""
+    data = {
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+    }
+    headers: dict[str, str] = {}
+
+    if auth_method == "client_secret_basic":
+        import base64
+        credentials = base64.b64encode(f"{client_id}:{client_secret}".encode()).decode()
+        headers["Authorization"] = f"Basic {credentials}"
+    else:
+        data["client_id"] = client_id
+        data["client_secret"] = client_secret
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                token_endpoint, data=data, headers=headers,
+                timeout=aiohttp.ClientTimeout(total=15),
+            ) as resp:
+                if resp.status != 200:
+                    text = await resp.text()
+                    logger.error("OAuth token refresh failed (%d): %s", resp.status, text[:300])
+                    return None
+                return await resp.json()
+    except Exception as e:
+        logger.error("OAuth token refresh request failed: %s", e)
+        return None
+
+
+async def register_oauth_client(
+    registration_endpoint: str,
+    redirect_uri: str,
+    client_name: str = "Loma",
+) -> dict | None:
+    """Dynamically register as an OAuth client (RFC 7591).
+
+    Returns {"client_id": ..., "client_secret": ...} or None on failure.
+    """
+    body = {
+        "client_name": client_name,
+        "redirect_uris": [redirect_uri],
+        "grant_types": ["authorization_code", "refresh_token"],
+        "response_types": ["code"],
+        "token_endpoint_auth_method": "client_secret_post",
+    }
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                registration_endpoint,
+                json=body,
+                timeout=aiohttp.ClientTimeout(total=15),
+            ) as resp:
+                if resp.status not in (200, 201):
+                    text = await resp.text()
+                    logger.error("OAuth client registration failed (%d): %s", resp.status, text[:300])
+                    return None
+                data = await resp.json()
+                if not data.get("client_id"):
+                    logger.error("OAuth registration returned no client_id")
+                    return None
+                return {
+                    "client_id": data["client_id"],
+                    "client_secret": data.get("client_secret", ""),
+                    "token_endpoint_auth_method": data.get(
+                        "token_endpoint_auth_method", "client_secret_post"
+                    ),
+                }
+    except Exception as e:
+        logger.error("OAuth client registration request failed: %s", e)
+        return None
+
+
+# ── Custom MCP OAuth token storage ──────────────────────────────────────
+
+
+async def store_custom_mcp_tokens(
+    db,
+    user_email: str,
+    provider: str,
+    access_token: str,
+    refresh_token: str | None,
+    expires_in: int | None,
+    scopes: list[str],
+) -> None:
+    """Encrypt and store custom MCP OAuth tokens per user."""
+    now = datetime.now(timezone.utc)
+    token_expiry = (
+        datetime.fromtimestamp(time.time() + expires_in, tz=timezone.utc)
+        if expires_in else None
+    )
+
+    update_doc: dict = {
+        "provider": provider,
+        "provider_type": "custom_mcp",
+        "access_token": encrypt_token(access_token),
+        "token_expiry": token_expiry,
+        "scopes": scopes,
+        "updated_at": now,
+    }
+    if refresh_token:
+        update_doc["refresh_token"] = encrypt_token(refresh_token)
+
+    await db.oauth_tokens.update_one(
+        {"user_email": user_email, "provider": provider},
+        {"$set": update_doc, "$setOnInsert": {"connected_at": now}},
+        upsert=True,
+    )
+
+    await _ensure_tool_assignments_mapping(db, user_email)
+    await db.users.update_one(
+        {"email": user_email},
+        {"$set": {
+            f"tool_assignments.custom-mcp-{provider}.oauth_status": "connected",
+            f"tool_assignments.custom-mcp-{provider}.last_used": now.isoformat() + "Z",
+            "updated_at": now,
+        }},
+    )
+    logger.info("Stored custom MCP OAuth tokens for %s / %s", user_email, provider)
+
+
+async def get_valid_custom_mcp_token(user_email: str, provider: str, db=None) -> str | None:
+    """Get a valid custom MCP access token for a user, auto-refreshing if expired."""
+    if db is None:
+        db = get_db()
+    if db is None:
+        return None
+
+    doc = await db.oauth_tokens.find_one({
+        "user_email": user_email, "provider": provider, "provider_type": "custom_mcp",
+    })
+    if doc is None:
+        return None
+
+    expiry = doc.get("token_expiry")
+    if expiry is None or expiry.replace(tzinfo=timezone.utc) > datetime.now(timezone.utc):
+        try:
+            return decrypt_token(doc["access_token"])
+        except ValueError:
+            logger.error("Failed to decrypt custom MCP access token for %s / %s", user_email, provider)
+            return None
+
+    refresh_encrypted = doc.get("refresh_token")
+    if not refresh_encrypted:
+        await _mark_custom_mcp_expired(db, user_email, provider)
+        return None
+
+    try:
+        refresh_token_val = decrypt_token(refresh_encrypted)
+    except ValueError:
+        await _mark_custom_mcp_expired(db, user_email, provider)
+        return None
+
+    integration = await db.integrations.find_one({
+        "provider": provider, "is_custom": True, "auth_mode": "oauth",
+    })
+    if not integration:
+        return None
+
+    oauth_cfg = integration.get("oauth_config", {})
+    client_id = decrypt_token(oauth_cfg["client_id_encrypted"]) if oauth_cfg.get("client_id_encrypted") else ""
+    client_secret = decrypt_token(oauth_cfg["client_secret_encrypted"]) if oauth_cfg.get("client_secret_encrypted") else ""
+
+    new_token = await _refresh_oauth_token(
+        token_endpoint=oauth_cfg["token_endpoint"],
+        refresh_token=refresh_token_val,
+        client_id=client_id,
+        client_secret=client_secret,
+        auth_method=oauth_cfg.get("token_endpoint_auth_method", "client_secret_post"),
+    )
+
+    if new_token is None:
+        await _mark_custom_mcp_expired(db, user_email, provider)
+        return None
+
+    now = datetime.now(timezone.utc)
+    token_expiry = datetime.fromtimestamp(
+        time.time() + new_token.get("expires_in", 3600), tz=timezone.utc
+    )
+    update: dict = {
+        "access_token": encrypt_token(new_token["access_token"]),
+        "token_expiry": token_expiry,
+        "updated_at": now,
+    }
+    if "refresh_token" in new_token:
+        update["refresh_token"] = encrypt_token(new_token["refresh_token"])
+
+    await db.oauth_tokens.update_one(
+        {"user_email": user_email, "provider": provider},
+        {"$set": update},
+    )
+
+    logger.info("Refreshed custom MCP token for %s / %s", user_email, provider)
+    return new_token["access_token"]
+
+
+async def _mark_custom_mcp_expired(db, user_email: str, provider: str) -> None:
+    now = datetime.now(timezone.utc)
+    await _ensure_tool_assignments_mapping(db, user_email)
+    await db.users.update_one(
+        {"email": user_email},
+        {"$set": {
+            f"tool_assignments.custom-mcp-{provider}.oauth_status": "expired",
+            "updated_at": now,
+        }},
+    )
+    logger.warning("Marked custom MCP OAuth as expired for %s / %s", user_email, provider)
+
+
+async def revoke_custom_mcp_tokens(db, user_email: str, provider: str) -> bool:
+    """Delete custom MCP tokens from DB, update user status."""
+    result = await db.oauth_tokens.delete_one({
+        "user_email": user_email, "provider": provider, "provider_type": "custom_mcp",
+    })
+    if result.deleted_count == 0:
+        return False
+
+    now = datetime.now(timezone.utc)
+    await _ensure_tool_assignments_mapping(db, user_email)
+    await db.users.update_one(
+        {"email": user_email},
+        {"$set": {
+            f"tool_assignments.custom-mcp-{provider}.oauth_status": "not_connected",
+            "updated_at": now,
+        }},
+    )
+    logger.info("Disconnected custom MCP for %s / %s", user_email, provider)
+    return True
+
+
 async def revoke_slack_tokens(db, user_email: str) -> bool:
     """Revoke Slack user token, delete from DB, update user status."""
     doc = await db.oauth_tokens.find_one({"user_email": user_email, "provider": "slack"})

--- a/api/oauth_routes.py
+++ b/api/oauth_routes.py
@@ -23,6 +23,10 @@ from api.oauth_helpers import (
     revoke_google_tokens,
     store_slack_tokens,
     revoke_slack_tokens,
+    decrypt_token,
+    _exchange_oauth_code,
+    store_custom_mcp_tokens,
+    revoke_custom_mcp_tokens,
 )
 
 logger = logging.getLogger(__name__)
@@ -440,6 +444,20 @@ async def handle_list_connections(request: web.Request) -> web.Response:
             "updated_at": _serialize(doc.get("updated_at")),
         })
 
+    # Include custom MCP OAuth connections
+    async for doc in db.oauth_tokens.find(
+        {"user_email": email, "provider_type": "custom_mcp"},
+        {"access_token": 0, "refresh_token": 0},
+    ):
+        connections.append({
+            "provider": doc.get("provider", "unknown"),
+            "provider_type": "custom_mcp",
+            "status": "connected",
+            "scopes": doc.get("scopes", []),
+            "connected_at": _serialize(doc.get("connected_at")),
+            "updated_at": _serialize(doc.get("updated_at")),
+        })
+
     # Check for expired statuses for providers without active connections
     user = await db.users.find_one({"email": email})
     if user is not None:
@@ -493,6 +511,136 @@ async def handle_disconnect_slack(request: web.Request) -> web.Response:
     return web.json_response({"disconnected": True})
 
 
+# ── Custom MCP OAuth flow ────────────────────────────────────────────────
+
+
+async def handle_custom_mcp_authorize(request: web.Request) -> web.Response:
+    """GET /api/oauth/custom-mcp/{provider}/authorize — return the OAuth consent URL."""
+    db = get_db()
+    if db is None:
+        return web.json_response({"error": "DB not configured"}, status=503)
+
+    provider = request.match_info["provider"]
+    email = get_user_email(request)
+    if not email:
+        return web.json_response({"error": "User not authenticated"}, status=401)
+
+    integration = await db.integrations.find_one({
+        "provider": provider, "is_custom": True, "auth_mode": "oauth",
+    })
+    if not integration:
+        return web.json_response({"error": "No OAuth-configured connector found"}, status=404)
+
+    oauth_cfg = integration.get("oauth_config", {})
+    auth_endpoint = oauth_cfg.get("authorization_endpoint")
+    if not auth_endpoint:
+        return web.json_response({"error": "Connector missing authorization_endpoint"}, status=500)
+
+    client_id = decrypt_token(oauth_cfg["client_id_encrypted"]) if oauth_cfg.get("client_id_encrypted") else ""
+    if not client_id:
+        return web.json_response({"error": "Connector missing OAuth client credentials"}, status=500)
+
+    redirect_uri = _oauth_redirect_uri(request, f"custom-mcp/{provider}")
+    state = create_oauth_state(email)
+
+    params = {
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "response_type": "code",
+        "state": state,
+    }
+    scopes = oauth_cfg.get("scopes")
+    if scopes:
+        params["scope"] = " ".join(scopes)
+
+    authorize_url = f"{auth_endpoint}?{urlencode(params)}"
+    return web.json_response({"authorize_url": authorize_url})
+
+
+async def handle_custom_mcp_callback(request: web.Request) -> web.Response:
+    """GET /api/oauth/custom-mcp/{provider}/callback — handle OAuth redirect."""
+    db = get_db()
+    provider = request.match_info["provider"]
+
+    if db is None:
+        return _callback_error("Database not available", provider=provider)
+
+    error = request.query.get("error")
+    if error:
+        logger.warning("Custom MCP OAuth error for %s: %s", provider, error)
+        return _callback_error(f"Authorization failed: {error}", provider=provider)
+
+    code = request.query.get("code")
+    state = request.query.get("state")
+    if not code or not state:
+        return _callback_error("Missing authorization code or state", provider=provider)
+
+    email = verify_oauth_state(state)
+    if email is None:
+        return _callback_error("Invalid or expired authorization state", provider=provider)
+
+    integration = await db.integrations.find_one({
+        "provider": provider, "is_custom": True, "auth_mode": "oauth",
+    })
+    if not integration:
+        return _callback_error("Connector not found", provider=provider)
+
+    oauth_cfg = integration.get("oauth_config", {})
+    client_id = decrypt_token(oauth_cfg["client_id_encrypted"]) if oauth_cfg.get("client_id_encrypted") else ""
+    client_secret = decrypt_token(oauth_cfg["client_secret_encrypted"]) if oauth_cfg.get("client_secret_encrypted") else ""
+    redirect_uri = _oauth_redirect_uri(request, f"custom-mcp/{provider}")
+
+    token_data = await _exchange_oauth_code(
+        token_endpoint=oauth_cfg["token_endpoint"],
+        code=code,
+        client_id=client_id,
+        client_secret=client_secret,
+        redirect_uri=redirect_uri,
+        auth_method=oauth_cfg.get("token_endpoint_auth_method", "client_secret_post"),
+    )
+    if token_data is None:
+        return _callback_error("Failed to exchange authorization code", provider=provider)
+
+    access_token = token_data.get("access_token")
+    if not access_token:
+        return _callback_error("OAuth provider did not return an access token", provider=provider)
+
+    raw_scope = token_data.get("scope", "")
+    scopes = raw_scope.split() if isinstance(raw_scope, str) else []
+
+    await store_custom_mcp_tokens(
+        db=db,
+        user_email=email,
+        provider=provider,
+        access_token=access_token,
+        refresh_token=token_data.get("refresh_token"),
+        expires_in=token_data.get("expires_in"),
+        scopes=scopes,
+    )
+
+    display_name = integration.get("display_name", provider)
+    logger.info("Custom MCP OAuth completed for %s / %s", email, provider)
+    return _callback_success_generic(provider=provider, display_name=display_name)
+
+
+async def handle_disconnect_custom_mcp(request: web.Request) -> web.Response:
+    """DELETE /api/oauth/connections/custom-mcp/{provider} — disconnect per-user."""
+    db = get_db()
+    if db is None:
+        return web.json_response({"error": "DB not configured"}, status=503)
+
+    email = get_user_email(request)
+    if not email:
+        return web.json_response({"error": "User not authenticated"}, status=401)
+
+    provider = request.match_info["provider"]
+    revoked = await revoke_custom_mcp_tokens(db, email, provider)
+    if not revoked:
+        return web.json_response({"error": "No connection found"}, status=404)
+
+    return web.json_response({"disconnected": True})
+
+
 # ── Route registration ────────────────────────────────────────────────────
 
 
@@ -506,5 +654,9 @@ def setup_oauth_routes(app: web.Application):
     app.router.add_get("/api/oauth/slack/authorize", handle_slack_authorize)
     app.router.add_get("/api/oauth/slack/callback", handle_slack_callback)
     app.router.add_delete("/api/oauth/connections/slack", handle_disconnect_slack)
+    # Custom MCP
+    app.router.add_get("/api/oauth/custom-mcp/{provider}/authorize", handle_custom_mcp_authorize)
+    app.router.add_get("/api/oauth/custom-mcp/{provider}/callback", handle_custom_mcp_callback)
+    app.router.add_delete("/api/oauth/connections/custom-mcp/{provider}", handle_disconnect_custom_mcp)
     # Shared
     app.router.add_get("/api/oauth/connections", handle_list_connections)

--- a/dashboard/src/app/integrations/manage/page.tsx
+++ b/dashboard/src/app/integrations/manage/page.tsx
@@ -7,6 +7,8 @@ import {
   disconnectGoogle,
   getSlackAuthorizeUrl,
   disconnectSlack,
+  getCustomMcpAuthorizeUrl,
+  disconnectCustomMcp,
   type OAuthConnection,
 } from "../../../lib/oauth-api";
 import {
@@ -22,7 +24,9 @@ import {
   addCustomConnector,
   removeCustomConnector,
   getWebhookUrl,
+  probeCustomConnector,
   type Integration,
+  type ProbeResult,
 } from "../../../lib/integration-api";
 import dynamic from "next/dynamic";
 import { useUser } from "../../../lib/UserContext";
@@ -303,10 +307,18 @@ export default function IntegrationsPage() {
   const canManageOrgIntegrations = hasRole("maintainer");
 
   const [showCustomModal, setShowCustomModal] = useState(false);
-  const [customForm, setCustomForm] = useState({ name: "", url: "", token: "", authHeader: "" });
+  const [customForm, setCustomForm] = useState({
+    name: "", url: "", token: "", authHeader: "",
+    authMode: "" as "" | "none" | "static" | "oauth",
+    oauthAuthUrl: "", oauthTokenUrl: "", oauthRegUrl: "",
+    oauthClientId: "", oauthClientSecret: "", oauthScopes: "",
+  });
   const [customAdvanced, setCustomAdvanced] = useState(false);
   const [addingCustom, setAddingCustom] = useState(false);
   const [removingCustom, setRemovingCustom] = useState<string | null>(null);
+  const [probing, setProbing] = useState(false);
+  const [probeResult, setProbeResult] = useState<ProbeResult | null>(null);
+  const [connectingCustomOAuth, setConnectingCustomOAuth] = useState<string | null>(null);
 
   const [claudeAuth, setClaudeAuth] = useState<ClaudeAuthStatus | null>(null);
   const [showClaudeTerminal, setShowClaudeTerminal] = useState(false);
@@ -367,12 +379,16 @@ export default function IntegrationsPage() {
   useEffect(() => {
     function handleMessage(event: MessageEvent) {
       if (event.data?.type === "oauth-complete") {
-        if (event.data.provider === "slack") setConnectingSlack(false);
-        else setConnecting(false);
+        const prov = event.data.provider;
+        if (prov === "slack") setConnectingSlack(false);
+        else if (prov === "google") setConnecting(false);
+        else setConnectingCustomOAuth(null);
         loadConnections();
       } else if (event.data?.type === "oauth-error") {
-        if (event.data.provider === "slack") setConnectingSlack(false);
-        else setConnecting(false);
+        const prov = event.data.provider;
+        if (prov === "slack") setConnectingSlack(false);
+        else if (prov === "google") setConnecting(false);
+        else setConnectingCustomOAuth(null);
         setError(event.data.error || "OAuth failed");
       }
     }
@@ -505,25 +521,106 @@ export default function IntegrationsPage() {
     await loadConnections();
   };
 
+  const handleProbeUrl = async () => {
+    const url = customForm.url.trim();
+    if (!url) return;
+    setProbing(true);
+    setProbeResult(null);
+    setError(null);
+    try {
+      const result = await probeCustomConnector(url);
+      setProbeResult(result);
+      if (result.requires_oauth && result.oauth_metadata) {
+        setCustomForm((f) => ({
+          ...f,
+          authMode: "oauth",
+          oauthAuthUrl: result.oauth_metadata?.authorization_endpoint || "",
+          oauthTokenUrl: result.oauth_metadata?.token_endpoint || "",
+          oauthRegUrl: result.oauth_metadata?.registration_endpoint || "",
+          oauthScopes: (result.oauth_metadata?.scopes_supported || []).join(" "),
+        }));
+        setCustomAdvanced(true);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to probe URL");
+    } finally {
+      setProbing(false);
+    }
+  };
+
   const handleAddCustomConnector = async () => {
     if (!customForm.name.trim() || !customForm.url.trim()) return;
     setAddingCustom(true);
     setError(null);
     try {
-      await addCustomConnector({
+      const authMode = customForm.authMode || (customForm.token.trim() ? "static" : "none");
+      const result = await addCustomConnector({
         name: customForm.name.trim(),
         url: customForm.url.trim(),
         token: customForm.token.trim() || undefined,
         authHeader: customForm.authHeader.trim() || undefined,
+        authMode,
+        oauthConfig: authMode === "oauth" ? {
+          authorization_endpoint: customForm.oauthAuthUrl.trim(),
+          token_endpoint: customForm.oauthTokenUrl.trim(),
+          registration_endpoint: customForm.oauthRegUrl.trim() || undefined,
+          client_id: customForm.oauthClientId.trim() || undefined,
+          client_secret: customForm.oauthClientSecret.trim() || undefined,
+          scopes: customForm.oauthScopes.trim() ? customForm.oauthScopes.trim().split(/\s+/) : undefined,
+        } : undefined,
       });
       setShowCustomModal(false);
-      setCustomForm({ name: "", url: "", token: "", authHeader: "" });
+      setCustomForm({
+        name: "", url: "", token: "", authHeader: "",
+        authMode: "", oauthAuthUrl: "", oauthTokenUrl: "", oauthRegUrl: "",
+        oauthClientId: "", oauthClientSecret: "", oauthScopes: "",
+      });
       setCustomAdvanced(false);
+      setProbeResult(null);
       await loadConnections();
+
+      // If OAuth, open the auth popup immediately for the admin
+      if (result.auth_mode === "oauth" && result.provider) {
+        handleConnectCustomOAuth(result.provider);
+      }
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to add connector");
     } finally {
       setAddingCustom(false);
+    }
+  };
+
+  const handleConnectCustomOAuth = async (provider: string) => {
+    setError(null);
+    setConnectingCustomOAuth(provider);
+    try {
+      const url = await getCustomMcpAuthorizeUrl(provider);
+      const w = 500, h = 600;
+      const left = window.screenX + (window.outerWidth - w) / 2;
+      const top = window.screenY + (window.outerHeight - h) / 2;
+      const popup = window.open(
+        url,
+        `custom-mcp-oauth-${provider}`,
+        `width=${w},height=${h},left=${left},top=${top},popup=yes`,
+      );
+      if (!popup) {
+        setError("Popup blocked. Please allow popups and try again.");
+        setConnectingCustomOAuth(null);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to start OAuth flow");
+      setConnectingCustomOAuth(null);
+    }
+  };
+
+  const handleDisconnectCustomOAuth = async (provider: string, displayName: string) => {
+    if (!confirm(`Disconnect your ${displayName} account?`)) return;
+    setError(null);
+    try {
+      await disconnectCustomMcp(provider);
+      await loadConnections();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to disconnect");
     }
   };
 
@@ -622,12 +719,44 @@ export default function IntegrationsPage() {
             </div>
             <div>
               <Label className="mb-1">Remote MCP server URL</Label>
-              <Input
-                type="url"
-                value={customForm.url}
-                onChange={(e) => setCustomForm((f) => ({ ...f, url: e.target.value }))}
-                placeholder="https://mcp.example.com/mcp"
-              />
+              <div className="flex gap-2">
+                <Input
+                  type="url"
+                  value={customForm.url}
+                  onChange={(e) => {
+                    setCustomForm((f) => ({ ...f, url: e.target.value }));
+                    setProbeResult(null);
+                  }}
+                  placeholder="https://mcp.example.com/mcp"
+                  className="flex-1"
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={handleProbeUrl}
+                  disabled={probing || !customForm.url.trim()}
+                >
+                  {probing ? "Checking..." : "Check"}
+                </Button>
+              </div>
+              {probeResult && (
+                <div className="mt-2">
+                  {probeResult.requires_oauth ? (
+                    <Badge className="bg-amber-50 text-amber-600 border-amber-100">
+                      OAuth required — each user authenticates individually
+                    </Badge>
+                  ) : probeResult.reachable ? (
+                    <Badge className="bg-emerald-50 text-emerald-600 border-emerald-100">
+                      Reachable — no OAuth required
+                    </Badge>
+                  ) : (
+                    <Badge variant="secondary">
+                      Could not reach server
+                    </Badge>
+                  )}
+                </div>
+              )}
             </div>
 
             <Button
@@ -641,34 +770,96 @@ export default function IntegrationsPage() {
             </Button>
             {customAdvanced && (
               <div className="space-y-4 pl-1">
-                <div>
-                  <Label className="mb-1">Access token (optional)</Label>
-                  <Input
-                    type="password"
-                    value={customForm.token}
-                    onChange={(e) => setCustomForm((f) => ({ ...f, token: e.target.value }))}
-                    placeholder="Sent as the auth header value"
-                  />
-                </div>
-                <div>
-                  <Label className="mb-1">Auth header name (optional)</Label>
-                  <Input
-                    type="text"
-                    value={customForm.authHeader}
-                    onChange={(e) => setCustomForm((f) => ({ ...f, authHeader: e.target.value }))}
-                    placeholder="Authorization"
-                  />
-                  <p className="text-[11px] text-muted-foreground mt-1">
-                    Defaults to <code>Authorization</code>. The token is sent as this header&apos;s value.
-                  </p>
-                </div>
+                {customForm.authMode !== "oauth" && (
+                  <>
+                    <div>
+                      <Label className="mb-1">Access token (optional)</Label>
+                      <Input
+                        type="password"
+                        value={customForm.token}
+                        onChange={(e) => setCustomForm((f) => ({ ...f, token: e.target.value }))}
+                        placeholder="Sent as the auth header value"
+                      />
+                    </div>
+                    <div>
+                      <Label className="mb-1">Auth header name (optional)</Label>
+                      <Input
+                        type="text"
+                        value={customForm.authHeader}
+                        onChange={(e) => setCustomForm((f) => ({ ...f, authHeader: e.target.value }))}
+                        placeholder="Authorization"
+                      />
+                      <p className="text-[11px] text-muted-foreground mt-1">
+                        Defaults to <code>Authorization</code>. The token is sent as this header&apos;s value.
+                      </p>
+                    </div>
+                  </>
+                )}
+                {customForm.authMode === "oauth" && (
+                  <>
+                    <Separator />
+                    <p className="text-xs font-medium text-foreground">OAuth Configuration</p>
+                    {probeResult?.oauth_metadata?.registration_endpoint ? (
+                      <p className="text-[11px] text-emerald-600">
+                        Dynamic client registration supported — client credentials will be obtained automatically.
+                      </p>
+                    ) : (
+                      <>
+                        <div>
+                          <Label className="mb-1">Client ID</Label>
+                          <Input
+                            type="text"
+                            value={customForm.oauthClientId}
+                            onChange={(e) => setCustomForm((f) => ({ ...f, oauthClientId: e.target.value }))}
+                            placeholder="Required if no dynamic registration"
+                          />
+                        </div>
+                        <div>
+                          <Label className="mb-1">Client Secret</Label>
+                          <Input
+                            type="password"
+                            value={customForm.oauthClientSecret}
+                            onChange={(e) => setCustomForm((f) => ({ ...f, oauthClientSecret: e.target.value }))}
+                            placeholder="Optional"
+                          />
+                        </div>
+                      </>
+                    )}
+                    <div>
+                      <Label className="mb-1">Authorization URL</Label>
+                      <Input
+                        type="url"
+                        value={customForm.oauthAuthUrl}
+                        onChange={(e) => setCustomForm((f) => ({ ...f, oauthAuthUrl: e.target.value }))}
+                        placeholder="https://auth.example.com/authorize"
+                      />
+                    </div>
+                    <div>
+                      <Label className="mb-1">Token URL</Label>
+                      <Input
+                        type="url"
+                        value={customForm.oauthTokenUrl}
+                        onChange={(e) => setCustomForm((f) => ({ ...f, oauthTokenUrl: e.target.value }))}
+                        placeholder="https://auth.example.com/token"
+                      />
+                    </div>
+                    <div>
+                      <Label className="mb-1">Scopes (space-separated, optional)</Label>
+                      <Input
+                        type="text"
+                        value={customForm.oauthScopes}
+                        onChange={(e) => setCustomForm((f) => ({ ...f, oauthScopes: e.target.value }))}
+                        placeholder="read write"
+                      />
+                    </div>
+                  </>
+                )}
               </div>
             )}
 
             <Alert>
               <AlertDescription className="text-xs text-amber-600">
-                Only add MCP servers you trust — their tools run for every user&apos;s agent. Interactive-OAuth
-                servers are not supported; use token/header auth.
+                Only add MCP servers you trust — their tools run for every user&apos;s agent.
               </AlertDescription>
             </Alert>
           </div>
@@ -928,26 +1119,61 @@ export default function IntegrationsPage() {
                             </p>
                           </div>
                         </div>
-                        {isAdmin && (
-                          <Button
-                            variant="destructive"
-                            size="sm"
-                            className="shrink-0 whitespace-nowrap"
-                            onClick={() => handleRemoveCustomConnector(integ.provider, integ.display_name)}
-                            disabled={removingCustom === integ.provider}
-                          >
-                            {removingCustom === integ.provider ? "Removing..." : "Remove"}
-                          </Button>
-                        )}
+                        <div className="flex items-center gap-2">
+                          {integ.auth_mode === "oauth" && (
+                            integ.user_oauth_status === "connected" ? (
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                className="shrink-0 whitespace-nowrap"
+                                onClick={() => handleDisconnectCustomOAuth(integ.provider, integ.display_name)}
+                              >
+                                Disconnect
+                              </Button>
+                            ) : (
+                              <Button
+                                size="sm"
+                                className="shrink-0 whitespace-nowrap"
+                                onClick={() => handleConnectCustomOAuth(integ.provider)}
+                                disabled={connectingCustomOAuth === integ.provider}
+                              >
+                                {connectingCustomOAuth === integ.provider ? "Connecting..." : "Connect"}
+                              </Button>
+                            )
+                          )}
+                          {isAdmin && (
+                            <Button
+                              variant="destructive"
+                              size="sm"
+                              className="shrink-0 whitespace-nowrap"
+                              onClick={() => handleRemoveCustomConnector(integ.provider, integ.display_name)}
+                              disabled={removingCustom === integ.provider}
+                            >
+                              {removingCustom === integ.provider ? "Removing..." : "Remove"}
+                            </Button>
+                          )}
+                        </div>
                       </div>
                       <Separator className="my-5" />
                       <div className="flex flex-wrap items-center gap-2">
                         <Badge className="bg-emerald-50 text-emerald-600 border-emerald-100">
                           MCP tools active (mcp__{integ.provider})
                         </Badge>
-                        <Badge variant="secondary">
-                          {integ.has_token ? "Token auth" : "No auth"}
-                        </Badge>
+                        {integ.auth_mode === "oauth" ? (
+                          integ.user_oauth_status === "connected" ? (
+                            <Badge className="bg-emerald-50 text-emerald-600 border-emerald-100">
+                              Your auth: Connected
+                            </Badge>
+                          ) : (
+                            <Badge className="bg-amber-50 text-amber-600 border-amber-100">
+                              Login required
+                            </Badge>
+                          )
+                        ) : (
+                          <Badge variant="secondary">
+                            {integ.has_token ? "Token auth" : "No auth"}
+                          </Badge>
+                        )}
                         {integ.connected_by && (
                           <span className="text-xs text-muted-foreground">
                             Added {formatDate(integ.connected_at)} by {integ.connected_by}

--- a/dashboard/src/lib/integration-api.ts
+++ b/dashboard/src/lib/integration-api.ts
@@ -31,6 +31,19 @@ export interface Integration {
   is_custom?: boolean;
   url?: string;
   has_token?: boolean;
+  auth_mode?: "none" | "static" | "oauth";
+  user_oauth_status?: "connected" | "not_connected" | "expired";
+}
+
+export interface ProbeResult {
+  requires_oauth: boolean;
+  reachable: boolean;
+  oauth_metadata?: {
+    authorization_endpoint: string;
+    token_endpoint: string;
+    registration_endpoint?: string;
+    scopes_supported: string[];
+  } | null;
 }
 
 // ── API calls ─────────────────────────────────────────────────────────────
@@ -73,12 +86,35 @@ export async function disconnectIntegration(provider: string): Promise<void> {
   }
 }
 
+export async function probeCustomConnector(url: string): Promise<ProbeResult> {
+  const res = await fetch(`${API_BASE}/api/integrations/custom/probe`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ url }),
+  });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error(data.error || `Probe failed: ${res.status}`);
+  }
+  return res.json();
+}
+
 export async function addCustomConnector(input: {
   name: string;
   url: string;
   token?: string;
   authHeader?: string;
-}): Promise<void> {
+  authMode?: "none" | "static" | "oauth";
+  oauthConfig?: {
+    authorization_endpoint: string;
+    token_endpoint: string;
+    registration_endpoint?: string;
+    client_id?: string;
+    client_secret?: string;
+    scopes?: string[];
+    token_endpoint_auth_method?: string;
+  };
+}): Promise<{ status: string; provider: string; auth_mode?: string }> {
   const res = await fetch(`${API_BASE}/api/integrations/custom`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -87,12 +123,15 @@ export async function addCustomConnector(input: {
       url: input.url,
       token: input.token || "",
       auth_header: input.authHeader || "",
+      auth_mode: input.authMode || (input.token ? "static" : "none"),
+      oauth_config: input.oauthConfig,
     }),
   });
   if (!res.ok) {
     const data = await res.json().catch(() => ({}));
     throw new Error(data.error || `Failed to add connector: ${res.status}`);
   }
+  return res.json();
 }
 
 export async function removeCustomConnector(provider: string): Promise<void> {

--- a/dashboard/src/lib/oauth-api.ts
+++ b/dashboard/src/lib/oauth-api.ts
@@ -64,3 +64,19 @@ export async function disconnectSlack(): Promise<void> {
   });
   if (!res.ok) throw await apiError(res, "Failed to disconnect Slack");
 }
+
+// ── Custom MCP OAuth ─────────────────────────────────────────────────────
+
+export async function getCustomMcpAuthorizeUrl(provider: string): Promise<string> {
+  const res = await fetch(`${API_BASE}/api/oauth/custom-mcp/${provider}/authorize`);
+  if (!res.ok) throw await apiError(res, "Failed to get authorize URL");
+  const data = await res.json();
+  return data.authorize_url;
+}
+
+export async function disconnectCustomMcp(provider: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/oauth/connections/custom-mcp/${provider}`, {
+    method: "DELETE",
+  });
+  if (!res.ok) throw await apiError(res, "Failed to disconnect");
+}


### PR DESCRIPTION
## Summary

- Custom MCP connectors now support per-user OAuth — each user authenticates individually with the MCP server instead of sharing org-level tokens
- Probe endpoint auto-detects OAuth requirements via RFC 8414 metadata discovery (`.well-known/oauth-authorization-server`)
- Dynamic client registration (RFC 7591) when supported by the MCP server — no admin-provided client credentials needed
- Per-user tokens stored encrypted in `db.oauth_tokens`, auto-refreshed at conversation start
- OAuth connectors excluded from shared pool config; ephemeral Claude SDK clients created per-user at runtime
- OpenCode runtime rebuilt with user's tokens before each run
- Frontend: "Check" button probes URLs, OAuth config auto-fills from discovery, per-user Connect/Disconnect on cards, "Login required" badges

## Files changed

| Area | Files |
|------|-------|
| OAuth helpers | `api/oauth_helpers.py` — generic code exchange, refresh, dynamic registration, per-user token CRUD |
| OAuth routes | `api/oauth_routes.py` — authorize/callback/disconnect endpoints for custom MCP |
| Integration routes | `api/integration_routes.py` — probe endpoint, extended add/remove/list |
| Claude SDK runtime | `agent/client.py` — `build_user_mcp_overrides()`, ephemeral per-user clients |
| OpenCode runtime | `agent/opencode_runtime.py` — user-aware config rebuilding |
| Frontend | `dashboard/src/app/integrations/manage/page.tsx` — probe UI, OAuth config, per-user auth cards |
| API clients | `dashboard/src/lib/integration-api.ts`, `dashboard/src/lib/oauth-api.ts` |

## Test plan

- [ ] Add a custom MCP connector URL that returns 401 → verify probe detects OAuth
- [ ] Verify `.well-known/oauth-authorization-server` discovery auto-fills OAuth config
- [ ] Add connector with dynamic client registration → verify client_id obtained automatically
- [ ] Admin authenticates via OAuth popup → verify token stored, card shows "Connected"
- [ ] Different user sees "Login required" badge → clicks Connect → authenticates → card updates
- [ ] Start conversation → verify agent can use per-user MCP tools
- [ ] Token refresh: let token expire → new conversation auto-refreshes
- [ ] Remove connector → verify all user tokens cleaned up
- [ ] Existing static-token and no-auth connectors unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)