### PR TITLE
Add persistent loma-workspace volume + $LOMA_WORKSPACE_DIR for agent repo cloning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,13 @@ LOMA_SKILL_ASSET_DIR=/var/lib/loma/skill-assets
 
 LOMA_SECRETS_DIR=/home/ubuntu/secrets
 
+# Persistent in-container workspace for cloning & running repos across turns/sessions.
+# Backed by the named volume `loma-workspace`, mounted at this path in
+# docker-compose.yml. Lets long-running agent tasks (e.g. run-plotline-services-local)
+# keep their clone across container recreation instead of losing it to /tmp's
+# ephemeral writable overlay. Mirrors the Dockerfile ENV of the same name.
+LOMA_WORKSPACE_DIR=/opt/loma-workspace
+
 # Feature flags
 LOMA_ENABLE_SCHEDULER=false
 LOMA_ENABLE_WEBHOOKS=true

--- a/.env.example
+++ b/.env.example
@@ -46,11 +46,6 @@ LOMA_SKILL_ASSET_DIR=/var/lib/loma/skill-assets
 
 LOMA_SECRETS_DIR=/home/ubuntu/secrets
 
-# Persistent in-container workspace for cloning & running repos across turns/sessions.
-# Backed by the named volume `loma-workspace`, mounted at this path in
-# docker-compose.yml. Lets long-running agent tasks (e.g. run-plotline-services-local)
-# keep their clone across container recreation instead of losing it to /tmp's
-# ephemeral writable overlay. Mirrors the Dockerfile ENV of the same name.
 LOMA_WORKSPACE_DIR=/opt/loma-workspace
 
 # Feature flags

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,11 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 ENV PYTHONPATH=/app
 ENV WEBHOOK_PORT=3000
+# Persistent in-container workspace for cloning & running repos (named volume
+# loma-workspace -> /opt/loma-workspace in docker-compose.yml). Lets long-running
+# agent tasks keep their clone across container recreation, unlike /tmp's
+# ephemeral writable overlay. Exposed as $LOMA_WORKSPACE_DIR to the agent process.
+ENV LOMA_WORKSPACE_DIR=/opt/loma-workspace
+RUN mkdir -p /opt/loma-workspace
 EXPOSE 3000
 CMD ["python", "app.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,10 +17,6 @@ services:
       # Persist connected Claude Code accounts (CLAUDE_USERS_DIR) across container
       # recreation — otherwise `claude login` creds are lost on every rebuild/redeploy.
       - loma-claude-users:/opt/claude-users
-      # Persistent workspace for cloning & running repos inside the agent (e.g. the
-      # run-plotline-services-local boot loop). Backed by a named volume so a clone
-      # survives container recreation, unlike /tmp's ephemeral overlay. Exposed to
-      # the agent as $LOMA_WORKSPACE_DIR (default /opt/loma-workspace).
       - loma-workspace:/opt/loma-workspace
       - ${LOMA_SECRETS_DIR:-/home/ubuntu/secrets}:/home/ubuntu/secrets:ro
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,11 @@ services:
       # Persist connected Claude Code accounts (CLAUDE_USERS_DIR) across container
       # recreation — otherwise `claude login` creds are lost on every rebuild/redeploy.
       - loma-claude-users:/opt/claude-users
+      # Persistent workspace for cloning & running repos inside the agent (e.g. the
+      # run-plotline-services-local boot loop). Backed by a named volume so a clone
+      # survives container recreation, unlike /tmp's ephemeral overlay. Exposed to
+      # the agent as $LOMA_WORKSPACE_DIR (default /opt/loma-workspace).
+      - loma-workspace:/opt/loma-workspace
       - ${LOMA_SECRETS_DIR:-/home/ubuntu/secrets}:/home/ubuntu/secrets:ro
     restart: unless-stopped
 
@@ -70,3 +75,4 @@ services:
 volumes:
   loma-skill-assets:
   loma-claude-users:
+  loma-workspace:


### PR DESCRIPTION
## Why

The agent (a Claude Code subprocess inside `loma-backend`) clones repos like `plotlinehq/plotline-services` into `/tmp` during closed-loop dev tasks (see the `run-plotline-services-local` skill). `/tmp` is the container's ephemeral writable overlay: it is wiped on every container recreation / redeploy, so clones + `node_modules` (a `npm run init` takes minutes) vanish between sessions and across usage-limit/timeout session boundaries. Long-running boot/login/screenshot loops kept dying for exactly this reason.

## What

Add a dedicated **named volume** `loma-workspace`, mounted on `loma-backend` at `/opt/loma-workspace` and exposed to the agent process as `$LOMA_WORKSPACE_DIR` (default `/opt/loma-workspace`). Named volumes persist across `restart: unless-stopped` and container recreation, so a once-cloned work tree is reusable.

### Changes
- `docker-compose.yml`
  - `loma-backend.volumes`: add `loma-workspace:/opt/loma-workspace` (documented inline).
  - top-level `volumes:`: declare `loma-workspace`.
- `Dockerfile`
  - `ENV LOMA_WORKSPACE_DIR=/opt/loma-workspace` — guarantees the env var is set for the agent even if `.env` omits it (mirrors `LOMA_SKILL_ASSET_DIR`).
  - `RUN mkdir -p /opt/loma-workspace` — ensures the mount point exists / is owned by the container user (root) before the volume attaches.
- `.env.example`
  - Document `LOMA_WORKSPACE_DIR=/opt/loma-workspace` next to `LOMA_SECRETS_DIR`, with a note on why it exists (vs `/tmp`).

### Why a named volume (not a bind mount)
- Matches the existing pattern (`loma-skill-assets`, `loma-claude-users`).
- No host path to provision; works on any box incl. preview/CI stacks (compose just creates an empty volume).
- Keeps the clone out of the image layer and out of `/tmp`.

## Scope / safety
- **Does not** touch the read-only `${LOMA_SECRETS_DIR:-/home/ubuntu/secrets}:ro` bind mount or any existing volume.
- **Does not** change any port, env, or runtime behaviour — purely additive mount + env var.
- Existing deployments need a one-time `docker compose up -d` (on the host) to pick up the new volume; no data migration.

## Operator action after merge
`docker compose up -d` (and a rebuild if the `Dockerfile` change matters) so the container picks up the `loma-workspace` volume and the new `ENV`. Then `echo $LOMA_WORKSPACE_DIR` in-container should print `/opt/loma-workspace`.

## Companion skill update
The `run-plotline-services-local` Loma skill (DB-backed) has been updated in the same change to:
- instruct cloning under `${LOMA_WORKSPACE_DIR:-/opt/loma-workspace}` instead of `/tmp`;
- document the workspace volume as a deployment dependency;
- call out the single-turn lifecycle caveat (agent pool SIGKILLs the subprocess tree at turn end, so background servers don't survive turn boundaries even though the clone does);
- fix the dashboard port to `:3001` throughout (it was inconsistent — playbook waited on `:3000` while the verified port is `:3001`).