### PR TITLE
feat: add anthropic/claude-fable-5 model support (ADA-70)

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -137,6 +137,7 @@ logger = logging.getLogger(__name__)
 # The first entry is treated as the headline/default Claude model.
 SUPPORTED_CLAUDE_MODEL_IDS = (
     "claude-opus-4-8",
+    "claude-fable-5",
     "claude-opus-4-7",
     "claude-opus-4-6",
 )
@@ -144,6 +145,7 @@ SUPPORTED_CLAUDE_MODEL_IDS = (
 FAVORITE_MODEL_IDS = (
     "opencode-go/deepseek-v4-flash",
     "anthropic/claude-opus-4-8",
+    "anthropic/claude-fable-5",
     "anthropic/claude-opus-4-7",
     "anthropic/claude-opus-4-6",
     "openai/gpt-5.5",

--- a/dashboard/src/app/flows/[id]/page.tsx
+++ b/dashboard/src/app/flows/[id]/page.tsx
@@ -60,6 +60,7 @@ const LABEL_COLORS = [
 
 const FAVORITE_MODEL_IDS = [
   "anthropic/claude-opus-4-8",
+  "anthropic/claude-fable-5",
   "anthropic/claude-opus-4-7",
   "anthropic/claude-opus-4-6",
   "opencode-go/deepseek-v4-flash",

--- a/dashboard/src/components/ChatPanel.tsx
+++ b/dashboard/src/components/ChatPanel.tsx
@@ -34,6 +34,7 @@ const MODEL_STORAGE_KEY = "dashboard-chat-selected-model";
 const FAVORITE_MODEL_IDS = [
   "opencode-go/deepseek-v4-flash",
   "anthropic/claude-opus-4-8",
+  "anthropic/claude-fable-5",
   "anthropic/claude-opus-4-7",
   "anthropic/claude-opus-4-6",
   "openai/gpt-5.5",


### PR DESCRIPTION
## Summary
- Adds `anthropic/claude-fable-5` as a supported/selectable Claude model in the dashboard alongside the current `claude-opus-4-8`.

## Context
Linear: [ADA-70 — Add Fable to Loma](https://linear.app/plotline/issue/ADA-70)
Requested: add support for `anthropic/claude-fable-5` along with the current `claude-opus-4-8`.

## Changes
- `api/routes.py` — added `claude-fable-5` to `SUPPORTED_CLAUDE_MODEL_IDS` (so `_claude_entry` surfaces `anthropic/claude-fable-5` in the `/api/agent-models` catalog) and `anthropic/claude-fable-5` to `FAVORITE_MODEL_IDS` (recommended ranking, placed right after `claude-opus-4-8`).
- `dashboard/src/components/ChatPanel.tsx` — added `anthropic/claude-fable-5` to the chat model picker favorites.
- `dashboard/src/app/flows/[id]/page.tsx` — added `anthropic/claude-fable-5` to the flows model picker favorites.

## Notes
- `claude-opus-4-8` remains the headline/default Claude model (first entry, unchanged). Fable is added as a co-primary option, ranked directly after Opus.
- Runtime defaults were intentionally left unchanged (`CLAUDE_MODEL` in `.env.example`, `ClientPool.default_model()` in `agent/pool.py`, and `utils/github_pr.py`) since the request was to add selectable support, not switch the default.

## Testing
- `python3 -c "import ast; ast.parse(open('api/routes.py').read())"` — parses OK.
- Verified no tests assert on the exact contents of `SUPPORTED_CLAUDE_MODEL_IDS` / `FAVORITE_MODEL_IDS`.

---
- This PR was generated by the Plotline IE Bot based on the request on ADA-70.
- Please review carefully before merging.