### PR TITLE
feat: Tasks board — kanban workflow over chats with attention system (ADA-77)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,11 @@ LOMA_SEED_SKILLS=true
 # Optional OAuth token encryption for personal integrations
 OAUTH_ENCRYPTION_KEY=generate-a-fernet-key
 
+# Optional web push for tasks-board notifications (leave blank to disable).
+# Generate a key pair with: python -c "from py_vapid import Vapid; from py_vapid.utils import b64urlencode; v=Vapid(); v.generate_keys(); print(b64urlencode(v.private_key.private_numbers().private_value.to_bytes(32,'big')))"
+VAPID_PRIVATE_KEY=
+VAPID_SUBJECT=mailto:admin@your-company.com
+
 # Optional integrations
 GITHUB_API_KEY=
 LINEAR_API_KEY=

--- a/api/push_routes.py
+++ b/api/push_routes.py
@@ -1,0 +1,97 @@
+"""Web push subscription routes (tasks-board attention notifications).
+
+One doc per browser in the `push_subscriptions` collection, unique by
+endpoint. See observability/push.py for sending.
+"""
+
+import logging
+from datetime import datetime, timezone
+
+from aiohttp import web
+
+from observability.db import get_db
+from observability.push import vapid_public_key
+from api.auth_helpers import get_user_email
+
+logger = logging.getLogger(__name__)
+
+
+async def handle_vapid_public_key(request: web.Request) -> web.Response:
+    """GET /api/push/vapid-public-key — 404 when push isn't configured."""
+    key = vapid_public_key()
+    if not key:
+        return web.json_response({"error": "Push not configured"}, status=404)
+    return web.json_response({"key": key})
+
+
+async def handle_subscribe(request: web.Request) -> web.Response:
+    """POST /api/push/subscriptions — upsert this browser's subscription."""
+    db = get_db()
+    if db is None:
+        return web.json_response({"error": "Observability not configured"}, status=503)
+
+    user_email = get_user_email(request)
+    if not user_email:
+        return web.json_response({"error": "Authentication required"}, status=401)
+
+    try:
+        body = await request.json()
+    except Exception:
+        return web.json_response({"error": "Invalid JSON"}, status=400)
+
+    subscription = body.get("subscription") or {}
+    endpoint = subscription.get("endpoint")
+    keys = subscription.get("keys") or {}
+    if not endpoint or not keys.get("p256dh") or not keys.get("auth"):
+        return web.json_response({"error": "Invalid subscription"}, status=400)
+
+    # Upsert by endpoint — a browser re-subscribing (or a different user on
+    # the same browser) replaces the existing doc for that endpoint.
+    await db.push_subscriptions.update_one(
+        {"subscription.endpoint": endpoint},
+        {"$set": {
+            "user_email": user_email,
+            "subscription": {
+                "endpoint": endpoint,
+                "keys": {"p256dh": keys["p256dh"], "auth": keys["auth"]},
+            },
+            "user_agent": request.headers.get("User-Agent", "")[:200],
+            "created_at": datetime.now(timezone.utc),
+        }},
+        upsert=True,
+    )
+    return web.json_response({"subscribed": True}, status=201)
+
+
+async def handle_unsubscribe(request: web.Request) -> web.Response:
+    """DELETE /api/push/subscriptions — remove this browser's subscription."""
+    db = get_db()
+    if db is None:
+        return web.json_response({"error": "Observability not configured"}, status=503)
+
+    user_email = get_user_email(request)
+    if not user_email:
+        return web.json_response({"error": "Authentication required"}, status=401)
+
+    try:
+        body = await request.json()
+    except Exception:
+        return web.json_response({"error": "Invalid JSON"}, status=400)
+
+    endpoint = body.get("endpoint")
+    if not endpoint:
+        return web.json_response({"error": "endpoint is required"}, status=400)
+
+    # Own subscriptions only.
+    await db.push_subscriptions.delete_one({
+        "subscription.endpoint": endpoint,
+        "user_email": user_email,
+    })
+    return web.json_response({"subscribed": False})
+
+
+def setup_push_routes(app: web.Application):
+    """Register web-push routes on the aiohttp app."""
+    app.router.add_get("/api/push/vapid-public-key", handle_vapid_public_key)
+    app.router.add_post("/api/push/subscriptions", handle_subscribe)
+    app.router.add_delete("/api/push/subscriptions", handle_unsubscribe)

--- a/api/routes.py
+++ b/api/routes.py
@@ -425,7 +425,9 @@ async def handle_list_conversations(request: web.Request) -> web.Response:
     page = int(request.query.get("page", 1))
     per_page = min(int(request.query.get("per_page", 50)), 100)
 
-    query: dict = {"deleted": {"$ne": True}}
+    # Staged board drafts (task_status="todo") haven't run yet — they belong
+    # on the tasks board, not in Activity. They appear here once started.
+    query: dict = {"deleted": {"$ne": True}, "task_status": {"$ne": "todo"}}
     # Track isolation condition separately to avoid $or key conflicts with search
     isolation_condition: dict | None = None
 
@@ -567,14 +569,18 @@ async def handle_get_stats(request: web.Request) -> web.Response:
     if db is None:
         return web.json_response({"error": "Observability not configured"}, status=503)
 
-    total = await db.conversations.count_documents({})
+    # Exclude staged board drafts — they haven't run yet.
+    total = await db.conversations.count_documents({"task_status": {"$ne": "todo"}})
     by_source = await db.conversations.aggregate([
+        {"$match": {"task_status": {"$ne": "todo"}}},
         {"$group": {"_id": "$source", "count": {"$sum": 1}}}
     ]).to_list(20)
     by_category = await db.conversations.aggregate([
+        {"$match": {"task_status": {"$ne": "todo"}}},
         {"$group": {"_id": "$confidence.category", "count": {"$sum": 1}}}
     ]).to_list(20)
     by_status = await db.conversations.aggregate([
+        {"$match": {"task_status": {"$ne": "todo"}}},
         {"$group": {"_id": "$status", "count": {"$sum": 1}}}
     ]).to_list(20)
 
@@ -750,9 +756,10 @@ async def handle_generate_titles(request: web.Request) -> web.Response:
     if db is None:
         return web.json_response({"error": "Observability not configured"}, status=503)
 
-    # Find conversations missing title or topic
+    # Find conversations missing title or topic (skip unsent board drafts)
     missing = await db.conversations.find(
-        {"$or": [{"title": {"$exists": False}}, {"title": None}, {"title": ""},
+        {"task_status": {"$ne": "todo"},
+         "$or": [{"title": {"$exists": False}}, {"title": None}, {"title": ""},
                  {"topic": {"$exists": False}}, {"topic": None}, {"topic": ""}]},
         {"conversation_id": 1, "prompt": 1, "final_response": 1, "title": 1, "topic": 1},
     ).limit(200).to_list(200)
@@ -813,6 +820,7 @@ async def handle_chat(request: web.Request) -> web.Response:
 
     # Set up observability — reuse existing conversation if conversation_id provided
     observer = None
+    existing = None
     db = get_db()
     existing_conversation_id = body.get("conversation_id")
     if db is not None:
@@ -825,19 +833,47 @@ async def handle_chat(request: web.Request) -> web.Response:
         if existing_conversation_id:
             # Check if conversation already exists (resume) or is client-generated (start)
             existing = await db.conversations.find_one(
-                {"conversation_id": existing_conversation_id}, {"_id": 1}
+                {"conversation_id": existing_conversation_id},
+                {"_id": 1, "task_status": 1, "metadata.user_name": 1},
             )
             observer = ConversationObserver(
                 db, metadata=metadata,
                 conversation_id=existing_conversation_id,
             )
             if existing:
+                if existing.get("task_status") == "todo":
+                    # First send on a staged board task: flip it to active.
+                    # resume() never sets started_at, and Activity sorts by it.
+                    now = datetime.now(timezone.utc)
+                    await db.conversations.update_one(
+                        {"conversation_id": existing_conversation_id},
+                        {"$set": {
+                            "task_status": "active",
+                            "task_started_at": now,
+                            "started_at": now,
+                        }},
+                    )
                 await observer.resume()
             else:
                 await observer.start()
         else:
             observer = ConversationObserver(db, metadata=metadata)
             await observer.start()
+
+        # Board tasks carry the owner's personal working context on every turn.
+        if existing and existing.get("task_status"):
+            owner = (existing.get("metadata") or {}).get("user_name") or user_email
+            owner_doc = await db.users.find_one({"email": owner}, {"task_board": 1})
+            board_prompt = ((owner_doc or {}).get("task_board") or {}).get("prompt", "").strip()
+            if board_prompt:
+                context_block = (
+                    "## User's role & working context (apply to this task)\n"
+                    f"{board_prompt}"
+                )
+                conversation_context = (
+                    f"{context_block}\n\n{conversation_context}"
+                    if conversation_context else context_block
+                )
 
     response = web.StreamResponse(
         status=200,
@@ -1703,6 +1739,14 @@ def setup_api_routes(app: web.Application):
     # Project routes (chat organization)
     from api.project_routes import setup_project_routes
     setup_project_routes(app)
+
+    # Tasks board routes (kanban layer over conversations)
+    from api.task_routes import setup_task_routes
+    setup_task_routes(app)
+
+    # Web push subscription routes (tasks-board notifications)
+    from api.push_routes import setup_push_routes
+    setup_push_routes(app)
 
     # File serving routes (binary artifact previews)
     from api.file_routes import setup_file_routes

--- a/api/routes.py
+++ b/api/routes.py
@@ -425,9 +425,12 @@ async def handle_list_conversations(request: web.Request) -> web.Response:
     page = int(request.query.get("page", 1))
     per_page = min(int(request.query.get("per_page", 50)), 100)
 
-    # Staged board drafts (task_status="todo") haven't run yet — they belong
-    # on the tasks board, not in Activity. They appear here once started.
-    query: dict = {"deleted": {"$ne": True}, "task_status": {"$ne": "todo"}}
+    # Unstarted board drafts (staged, never run) belong on the tasks board,
+    # not in Activity. Parked tasks (staged after running) stay visible.
+    query: dict = {
+        "deleted": {"$ne": True},
+        "$nor": [{"task_status": "todo", "status": None}],
+    }
     # Track isolation condition separately to avoid $or key conflicts with search
     isolation_condition: dict | None = None
 
@@ -569,18 +572,19 @@ async def handle_get_stats(request: web.Request) -> web.Response:
     if db is None:
         return web.json_response({"error": "Observability not configured"}, status=503)
 
-    # Exclude staged board drafts — they haven't run yet.
-    total = await db.conversations.count_documents({"task_status": {"$ne": "todo"}})
+    # Exclude unstarted board drafts — they haven't run yet.
+    _no_drafts = {"$nor": [{"task_status": "todo", "status": None}]}
+    total = await db.conversations.count_documents(_no_drafts)
     by_source = await db.conversations.aggregate([
-        {"$match": {"task_status": {"$ne": "todo"}}},
+        {"$match": _no_drafts},
         {"$group": {"_id": "$source", "count": {"$sum": 1}}}
     ]).to_list(20)
     by_category = await db.conversations.aggregate([
-        {"$match": {"task_status": {"$ne": "todo"}}},
+        {"$match": _no_drafts},
         {"$group": {"_id": "$confidence.category", "count": {"$sum": 1}}}
     ]).to_list(20)
     by_status = await db.conversations.aggregate([
-        {"$match": {"task_status": {"$ne": "todo"}}},
+        {"$match": _no_drafts},
         {"$group": {"_id": "$status", "count": {"$sum": 1}}}
     ]).to_list(20)
 
@@ -758,7 +762,7 @@ async def handle_generate_titles(request: web.Request) -> web.Response:
 
     # Find conversations missing title or topic (skip unsent board drafts)
     missing = await db.conversations.find(
-        {"task_status": {"$ne": "todo"},
+        {"$nor": [{"task_status": "todo", "status": None}],
          "$or": [{"title": {"$exists": False}}, {"title": None}, {"title": ""},
                  {"topic": {"$exists": False}}, {"topic": None}, {"topic": ""}]},
         {"conversation_id": 1, "prompt": 1, "final_response": 1, "title": 1, "topic": 1},
@@ -834,7 +838,7 @@ async def handle_chat(request: web.Request) -> web.Response:
             # Check if conversation already exists (resume) or is client-generated (start)
             existing = await db.conversations.find_one(
                 {"conversation_id": existing_conversation_id},
-                {"_id": 1, "task_status": 1, "metadata.user_name": 1},
+                {"_id": 1, "task_status": 1, "started_at": 1, "metadata.user_name": 1},
             )
             observer = ConversationObserver(
                 db, metadata=metadata,
@@ -842,16 +846,18 @@ async def handle_chat(request: web.Request) -> web.Response:
             )
             if existing:
                 if existing.get("task_status") == "todo":
-                    # First send on a staged board task: flip it to active.
-                    # resume() never sets started_at, and Activity sorts by it.
+                    # Sending on a staged board task flips it to active. This
+                    # covers both fresh drafts (set started_at — resume() never
+                    # does, and Activity sorts by it) and parked chats resumed
+                    # from a lane (keep their original timestamps).
                     now = datetime.now(timezone.utc)
+                    flip: dict = {"task_status": "active"}
+                    if not existing.get("started_at"):
+                        flip["started_at"] = now
+                        flip["task_started_at"] = now
                     await db.conversations.update_one(
                         {"conversation_id": existing_conversation_id},
-                        {"$set": {
-                            "task_status": "active",
-                            "task_started_at": now,
-                            "started_at": now,
-                        }},
+                        {"$set": flip},
                     )
                 await observer.resume()
             else:

--- a/api/task_routes.py
+++ b/api/task_routes.py
@@ -99,6 +99,7 @@ def _task_view(task: dict, lane_ids: list[str]) -> dict:
         "conversation_id": task.get("conversation_id"),
         "title": task.get("title") or None,
         "prompt": prompt[:200],
+        "model": task.get("model") or None,
         "status": task.get("status"),
         "task_status": task.get("task_status"),
         "task_lane": task.get("task_lane"),
@@ -115,7 +116,7 @@ def _task_view(task: dict, lane_ids: list[str]) -> dict:
 
 
 _TASK_PROJECTION = {
-    "conversation_id": 1, "title": 1, "prompt": 1, "status": 1,
+    "conversation_id": 1, "title": 1, "prompt": 1, "model": 1, "status": 1,
     "task_status": 1, "task_lane": 1, "task_rank": 1,
     "total_turns": 1, "started_at": 1, "finished_at": 1,
     "task_created_at": 1, "task_staged_at": 1, "task_started_at": 1,
@@ -143,6 +144,7 @@ async def handle_create_task(request: web.Request) -> web.Response:
         return web.json_response({"error": "prompt is required"}, status=400)
 
     title = (body.get("title") or "").strip() or None
+    model = (body.get("model") or "").strip()
     board = await _get_board_config_for(db, user_email)
     lane_ids = [lane["id"] for lane in board["lanes"]]
     lane = body.get("lane") or lane_ids[0]
@@ -163,7 +165,7 @@ async def handle_create_task(request: web.Request) -> web.Response:
         "status": None,
         "metadata": {"user_name": user_email},
         "prompt": prompt,
-        "model": "",
+        "model": model,
         "total_turns": 0,
         "final_response": "",
         "messages": [],
@@ -367,6 +369,11 @@ async def handle_update_task(request: web.Request) -> web.Response:
         if not prompt:
             return web.json_response({"error": "prompt cannot be empty"}, status=400)
         updates["prompt"] = prompt
+
+    if "model" in body:
+        if current != "todo":
+            return web.json_response({"error": "Only drafts can be edited"}, status=400)
+        updates["model"] = (body["model"] or "").strip()
 
     if "title" in body:
         title = (body["title"] or "").strip() or None

--- a/api/task_routes.py
+++ b/api/task_routes.py
@@ -1,7 +1,8 @@
 """Tasks board routes — a kanban layer over conversations.
 
 A task IS a conversation (1:1) plus board state stored on the conversation doc:
-  - task_status: "todo" (staged draft) | "active" (started) | "done" (user-closed)
+  - task_status: "todo" (staged: an unstarted draft OR a started chat parked
+    to recontinue later) | "active" (started) | "done" (user-closed)
   - task_lane: staging lane id (meaningful only while task_status == "todo")
   - task_rank: float sort key within staged lanes
 
@@ -321,18 +322,20 @@ async def handle_update_task(request: web.Request) -> web.Response:
         if target not in ("todo", "active", "done"):
             return web.json_response({"error": "Invalid task_status"}, status=400)
         # Transition matrix (server side of components/tasks/transitions.ts):
-        # - "todo" is only valid before the first run (drafts); once a
-        #   conversation exists it can never go back to a staging lane.
+        # - "todo" holds both unstarted drafts and *parked* started tasks
+        #   (active -> todo shelves a chat in a lane to recontinue later;
+        #   sending a message flips it back to active in handle_chat).
         # - "active" from todo happens in handle_chat on first send, but is
         #   also allowed here for done->active (reopen) and for converting an
         #   existing chat into a task (current is None).
-        if target == "todo" and has_run:
+        if target == "todo" and current not in ("todo", "active"):
             return web.json_response(
-                {"error": "A started task cannot return to a staging lane"}, status=400)
+                {"error": "Only active tasks can move to a staging lane"}, status=400)
         if target == "active" and not has_run and current == "todo":
             return web.json_response(
                 {"error": "Start the task by sending its prompt, not by PATCH"}, status=400)
-        if target == "done" and current not in ("active", "done"):
+        started = current in ("active", "done") or (current == "todo" and has_run)
+        if target == "done" and not started:
             return web.json_response(
                 {"error": "Only started tasks can be marked done"}, status=400)
         updates["task_status"] = target
@@ -343,6 +346,16 @@ async def handle_update_task(request: web.Request) -> web.Response:
         if target == "active" and current is None:
             # Converting an existing chat into a board task.
             updates["task_created_at"] = conversation.get("task_created_at") or now
+        if target == "todo" and current == "active":
+            # Parking: land in the requested lane (validated below) or the
+            # task's previous lane, defaulting to the first lane.
+            updates["task_staged_at"] = now
+            if "task_lane" not in body and not conversation.get("task_lane"):
+                owner = (conversation.get("metadata") or {}).get("user_name") or user_email
+                board = await _get_board_config_for(db, owner)
+                updates["task_lane"] = board["lanes"][0]["id"]
+            if conversation.get("task_rank") is None and "task_rank" not in body:
+                updates["task_rank"] = -now.timestamp()
 
     if "task_lane" in body:
         if (updates.get("task_status") or current) != "todo":
@@ -363,7 +376,7 @@ async def handle_update_task(request: web.Request) -> web.Response:
             return web.json_response({"error": "task_rank must be a number"}, status=400)
 
     if "prompt" in body:
-        if current != "todo":
+        if current != "todo" or has_run:
             return web.json_response({"error": "Only drafts can be edited"}, status=400)
         prompt = (body["prompt"] or "").strip()
         if not prompt:
@@ -371,7 +384,7 @@ async def handle_update_task(request: web.Request) -> web.Response:
         updates["prompt"] = prompt
 
     if "model" in body:
-        if current != "todo":
+        if current != "todo" or has_run:
             return web.json_response({"error": "Only drafts can be edited"}, status=400)
         updates["model"] = (body["model"] or "").strip()
 

--- a/api/task_routes.py
+++ b/api/task_routes.py
@@ -1,0 +1,481 @@
+"""Tasks board routes — a kanban layer over conversations.
+
+A task IS a conversation (1:1) plus board state stored on the conversation doc:
+  - task_status: "todo" (staged draft) | "active" (started) | "done" (user-closed)
+  - task_lane: staging lane id (meaningful only while task_status == "todo")
+  - task_rank: float sort key within staged lanes
+
+Board columns are derived — "working" vs "needs input" comes from the live
+conversation status, never stored:
+  todo               -> the task's staging lane
+  active + running   -> working
+  active + not-running -> needs input
+  done               -> done
+
+Per-user board config (staging lanes + personal prompt) lives on the users doc
+under `task_board`; tasks reference lanes by id so renames are config-only.
+"""
+
+import logging
+import uuid
+from datetime import datetime, timezone
+
+from aiohttp import web
+
+from observability.db import get_db
+from api.auth_helpers import get_system_role, get_user_email
+
+logger = logging.getLogger(__name__)
+
+# Statuses where the agent is no longer running — the user's turn.
+NEEDS_INPUT_STATUSES = ("completed", "error", "interrupted")
+
+DEFAULT_BOARD = {
+    "prompt": "",
+    "lanes": [{"id": "todo", "name": "Todo", "order": 0}],
+}
+
+MAX_LANE_NAME_LEN = 40
+MAX_LANES = 10
+MAX_BOARD_PROMPT_LEN = 10000
+
+
+def _serialize(doc):
+    """Make a MongoDB document JSON-serializable."""
+    if doc is None:
+        return None
+    if isinstance(doc, list):
+        return [_serialize(d) for d in doc]
+    if isinstance(doc, dict):
+        result = {}
+        for k, v in doc.items():
+            if k == "_id":
+                result[k] = str(v)
+            elif isinstance(v, datetime):
+                result[k] = v.isoformat()
+            elif isinstance(v, (dict, list)):
+                result[k] = _serialize(v)
+            else:
+                result[k] = v
+        return result
+    if isinstance(doc, datetime):
+        return doc.isoformat()
+    return doc
+
+
+def get_board_config(user_doc: dict | None) -> dict:
+    """Return the user's board config, materializing the default when absent."""
+    board = (user_doc or {}).get("task_board") or {}
+    lanes = board.get("lanes") or []
+    if not lanes:
+        lanes = [dict(lane) for lane in DEFAULT_BOARD["lanes"]]
+    lanes = sorted(lanes, key=lambda lane: lane.get("order", 0))
+    return {"prompt": board.get("prompt", ""), "lanes": lanes}
+
+
+async def _get_board_config_for(db, user_email: str) -> dict:
+    user_doc = await db.users.find_one({"email": user_email}, {"task_board": 1})
+    return get_board_config(user_doc)
+
+
+def derive_column(task: dict, lane_ids: list[str]) -> str:
+    """Derive the board column for a task. Unknown lanes fold into the first."""
+    task_status = task.get("task_status")
+    if task_status == "todo":
+        lane = task.get("task_lane") or (lane_ids[0] if lane_ids else "todo")
+        return lane if lane in lane_ids else (lane_ids[0] if lane_ids else "todo")
+    if task_status == "done":
+        return "done"
+    # active
+    if task.get("status") == "running":
+        return "working"
+    return "needs_input"
+
+
+def _task_view(task: dict, lane_ids: list[str]) -> dict:
+    """Shape a conversation doc into the board card payload."""
+    prompt = task.get("prompt") or ""
+    return {
+        "conversation_id": task.get("conversation_id"),
+        "title": task.get("title") or None,
+        "prompt": prompt[:200],
+        "status": task.get("status"),
+        "task_status": task.get("task_status"),
+        "task_lane": task.get("task_lane"),
+        "task_rank": task.get("task_rank"),
+        "column": derive_column(task, lane_ids),
+        "total_turns": task.get("total_turns", 0),
+        "started_at": _serialize(task.get("started_at")),
+        "finished_at": _serialize(task.get("finished_at")),
+        "task_created_at": _serialize(task.get("task_created_at")),
+        "task_staged_at": _serialize(task.get("task_staged_at")),
+        "task_started_at": _serialize(task.get("task_started_at")),
+        "task_done_at": _serialize(task.get("task_done_at")),
+    }
+
+
+_TASK_PROJECTION = {
+    "conversation_id": 1, "title": 1, "prompt": 1, "status": 1,
+    "task_status": 1, "task_lane": 1, "task_rank": 1,
+    "total_turns": 1, "started_at": 1, "finished_at": 1,
+    "task_created_at": 1, "task_staged_at": 1, "task_started_at": 1,
+    "task_done_at": 1,
+}
+
+
+async def handle_create_task(request: web.Request) -> web.Response:
+    """POST /api/tasks — create a staged (draft) task."""
+    db = get_db()
+    if db is None:
+        return web.json_response({"error": "Observability not configured"}, status=503)
+
+    user_email = get_user_email(request)
+    if not user_email:
+        return web.json_response({"error": "Authentication required"}, status=401)
+
+    try:
+        body = await request.json()
+    except Exception:
+        return web.json_response({"error": "Invalid JSON"}, status=400)
+
+    prompt = (body.get("prompt") or "").strip()
+    if not prompt:
+        return web.json_response({"error": "prompt is required"}, status=400)
+
+    title = (body.get("title") or "").strip() or None
+    board = await _get_board_config_for(db, user_email)
+    lane_ids = [lane["id"] for lane in board["lanes"]]
+    lane = body.get("lane") or lane_ids[0]
+    if lane not in lane_ids:
+        return web.json_response({"error": "Unknown lane"}, status=400)
+
+    now = datetime.now(timezone.utc)
+    # Draft doc mirrors observer.start()'s shape, but the run hasn't begun:
+    # status/started_at stay None and messages stays [] — observer.resume()
+    # $pushes the prompt as the first user message when the task starts, so
+    # pre-filling messages here would duplicate it.
+    doc = {
+        "conversation_id": str(uuid.uuid4()),
+        "source": "dashboard",
+        "started_at": None,
+        "finished_at": None,
+        "duration_ms": None,
+        "status": None,
+        "metadata": {"user_name": user_email},
+        "prompt": prompt,
+        "model": "",
+        "total_turns": 0,
+        "final_response": "",
+        "messages": [],
+        "confidence": None,
+        "cost": None,
+        "savings": None,
+        "claude_account": None,
+        "error": None,
+        "deleted": False,
+        "title": title,
+        # Guard user-provided titles against finish-time LLM enrichment.
+        "title_edited": bool(title),
+        "task_status": "todo",
+        "task_lane": lane,
+        # Newest first when sorted ascending; reorder uses neighbor midpoints.
+        "task_rank": -now.timestamp(),
+        "task_created_at": now,
+        "task_staged_at": now,
+        "task_started_at": None,
+        "task_done_at": None,
+    }
+    await db.conversations.insert_one(doc)
+    return web.json_response({"task": _task_view(doc, lane_ids)}, status=201)
+
+
+async def handle_list_tasks(request: web.Request) -> web.Response:
+    """GET /api/tasks — the caller's board: lanes, tasks with derived columns, counts."""
+    db = get_db()
+    if db is None:
+        return web.json_response({"error": "Observability not configured"}, status=503)
+
+    user_email = get_user_email(request)
+    if not user_email:
+        return web.json_response({"error": "Authentication required"}, status=401)
+
+    board = await _get_board_config_for(db, user_email)
+    lane_ids = [lane["id"] for lane in board["lanes"]]
+
+    tasks = await db.conversations.find(
+        {
+            "metadata.user_name": user_email,
+            "task_status": {"$in": ["todo", "active", "done"]},
+            "deleted": {"$ne": True},
+        },
+        _TASK_PROJECTION,
+    ).to_list(500)
+
+    views = [_task_view(t, lane_ids) for t in tasks]
+
+    def sort_key(view):
+        column = view["column"]
+        if column in lane_ids:
+            return view.get("task_rank") or 0
+        # Newest first for the derived/done columns.
+        stamp = {
+            "working": view.get("started_at"),
+            "needs_input": view.get("finished_at"),
+            "done": view.get("task_done_at"),
+        }.get(column) or ""
+        return stamp
+
+    staged = sorted([v for v in views if v["column"] in lane_ids], key=sort_key)
+    others = sorted(
+        [v for v in views if v["column"] not in lane_ids],
+        key=sort_key, reverse=True,
+    )
+    ordered = staged + others
+
+    counts: dict[str, int] = {lane_id: 0 for lane_id in lane_ids}
+    counts.update({"working": 0, "needs_input": 0, "done": 0})
+    for view in ordered:
+        counts[view["column"]] = counts.get(view["column"], 0) + 1
+
+    return web.json_response({
+        "lanes": board["lanes"],
+        "tasks": ordered,
+        "counts": counts,
+    })
+
+
+async def handle_needs_input_count(request: web.Request) -> web.Response:
+    """GET /api/tasks/needs-input-count — cheap poll target for the attention system."""
+    db = get_db()
+    if db is None:
+        return web.json_response({"count": 0})
+
+    user_email = get_user_email(request)
+    if not user_email:
+        return web.json_response({"error": "Authentication required"}, status=401)
+
+    count = await db.conversations.count_documents({
+        "metadata.user_name": user_email,
+        "task_status": "active",
+        "status": {"$in": list(NEEDS_INPUT_STATUSES)},
+        "deleted": {"$ne": True},
+    })
+    return web.json_response({"count": count})
+
+
+async def handle_update_task(request: web.Request) -> web.Response:
+    """PATCH /api/tasks/{conversation_id} — board moves, edits, add/remove.
+
+    Accepts any of: task_status, task_lane, task_rank, prompt, title.
+    task_status: null removes the conversation from the board.
+    """
+    db = get_db()
+    if db is None:
+        return web.json_response({"error": "Observability not configured"}, status=503)
+
+    user_email = get_user_email(request)
+    if not user_email:
+        return web.json_response({"error": "Authentication required"}, status=401)
+
+    cid = request.match_info["conversation_id"]
+    system_role = get_system_role(request)
+
+    conversation = await db.conversations.find_one({
+        "conversation_id": cid,
+        "deleted": {"$ne": True},
+    })
+    if not conversation:
+        return web.json_response({"error": "Not found"}, status=404)
+
+    from api.routes import _check_conversation_access
+    if not _check_conversation_access(conversation, user_email, system_role):
+        return web.json_response({"error": "Not found"}, status=404)
+
+    try:
+        body = await request.json()
+    except Exception:
+        return web.json_response({"error": "Invalid JSON"}, status=400)
+
+    now = datetime.now(timezone.utc)
+    current = conversation.get("task_status")
+    has_run = conversation.get("status") is not None
+
+    # Removing from the board clears all task fields.
+    if "task_status" in body and body["task_status"] is None:
+        await db.conversations.update_one(
+            {"conversation_id": cid},
+            {"$unset": {
+                "task_status": "", "task_lane": "", "task_rank": "",
+                "task_created_at": "", "task_staged_at": "",
+                "task_started_at": "", "task_done_at": "",
+            }},
+        )
+        return web.json_response({"task": None})
+
+    updates: dict = {}
+
+    if "task_status" in body:
+        target = body["task_status"]
+        if target not in ("todo", "active", "done"):
+            return web.json_response({"error": "Invalid task_status"}, status=400)
+        # Transition matrix (server side of components/tasks/transitions.ts):
+        # - "todo" is only valid before the first run (drafts); once a
+        #   conversation exists it can never go back to a staging lane.
+        # - "active" from todo happens in handle_chat on first send, but is
+        #   also allowed here for done->active (reopen) and for converting an
+        #   existing chat into a task (current is None).
+        if target == "todo" and has_run:
+            return web.json_response(
+                {"error": "A started task cannot return to a staging lane"}, status=400)
+        if target == "active" and not has_run and current == "todo":
+            return web.json_response(
+                {"error": "Start the task by sending its prompt, not by PATCH"}, status=400)
+        if target == "done" and current not in ("active", "done"):
+            return web.json_response(
+                {"error": "Only started tasks can be marked done"}, status=400)
+        updates["task_status"] = target
+        if target == "done" and current != "done":
+            updates["task_done_at"] = now
+        if target == "active" and current == "done":
+            updates["task_done_at"] = None
+        if target == "active" and current is None:
+            # Converting an existing chat into a board task.
+            updates["task_created_at"] = conversation.get("task_created_at") or now
+
+    if "task_lane" in body:
+        if (updates.get("task_status") or current) != "todo":
+            return web.json_response({"error": "Only staged tasks have lanes"}, status=400)
+        # Lanes belong to the task owner's board, not the caller's.
+        owner = (conversation.get("metadata") or {}).get("user_name") or user_email
+        board = await _get_board_config_for(db, owner)
+        lane_ids = [lane["id"] for lane in board["lanes"]]
+        if body["task_lane"] not in lane_ids:
+            return web.json_response({"error": "Unknown lane"}, status=400)
+        updates["task_lane"] = body["task_lane"]
+        updates["task_staged_at"] = now
+
+    if "task_rank" in body:
+        try:
+            updates["task_rank"] = float(body["task_rank"])
+        except (TypeError, ValueError):
+            return web.json_response({"error": "task_rank must be a number"}, status=400)
+
+    if "prompt" in body:
+        if current != "todo":
+            return web.json_response({"error": "Only drafts can be edited"}, status=400)
+        prompt = (body["prompt"] or "").strip()
+        if not prompt:
+            return web.json_response({"error": "prompt cannot be empty"}, status=400)
+        updates["prompt"] = prompt
+
+    if "title" in body:
+        title = (body["title"] or "").strip() or None
+        updates["title"] = title
+        updates["title_edited"] = bool(title)
+
+    if not updates:
+        return web.json_response({"error": "Nothing to update"}, status=400)
+
+    await db.conversations.update_one({"conversation_id": cid}, {"$set": updates})
+
+    updated = await db.conversations.find_one(
+        {"conversation_id": cid}, _TASK_PROJECTION)
+    owner = (conversation.get("metadata") or {}).get("user_name") or user_email
+    board = await _get_board_config_for(db, owner)
+    lane_ids = [lane["id"] for lane in board["lanes"]]
+    return web.json_response({"task": _task_view(updated, lane_ids)})
+
+
+async def handle_get_board_settings(request: web.Request) -> web.Response:
+    """GET /api/tasks/board-settings — the caller's lanes + personal prompt."""
+    db = get_db()
+    if db is None:
+        return web.json_response({"error": "Observability not configured"}, status=503)
+
+    user_email = get_user_email(request)
+    if not user_email:
+        return web.json_response({"error": "Authentication required"}, status=401)
+
+    board = await _get_board_config_for(db, user_email)
+    return web.json_response(board)
+
+
+async def handle_put_board_settings(request: web.Request) -> web.Response:
+    """PUT /api/tasks/board-settings — save lanes + personal prompt.
+
+    Deleting a lane migrates its staged tasks to the first remaining lane.
+    """
+    db = get_db()
+    if db is None:
+        return web.json_response({"error": "Observability not configured"}, status=503)
+
+    user_email = get_user_email(request)
+    if not user_email:
+        return web.json_response({"error": "Authentication required"}, status=401)
+
+    try:
+        body = await request.json()
+    except Exception:
+        return web.json_response({"error": "Invalid JSON"}, status=400)
+
+    prompt = body.get("prompt", "")
+    if not isinstance(prompt, str) or len(prompt) > MAX_BOARD_PROMPT_LEN:
+        return web.json_response(
+            {"error": f"prompt must be a string of at most {MAX_BOARD_PROMPT_LEN} characters"},
+            status=400)
+
+    lanes_in = body.get("lanes")
+    if not isinstance(lanes_in, list) or not lanes_in:
+        return web.json_response({"error": "At least one lane is required"}, status=400)
+    if len(lanes_in) > MAX_LANES:
+        return web.json_response({"error": f"At most {MAX_LANES} lanes allowed"}, status=400)
+
+    lanes = []
+    seen_ids: set[str] = set()
+    for order, lane in enumerate(lanes_in):
+        if not isinstance(lane, dict):
+            return web.json_response({"error": "Invalid lane"}, status=400)
+        name = (lane.get("name") or "").strip()
+        if not name or len(name) > MAX_LANE_NAME_LEN:
+            return web.json_response(
+                {"error": f"Lane names must be 1-{MAX_LANE_NAME_LEN} characters"}, status=400)
+        # Preserve existing ids (tasks reference lanes by id); mint for new lanes.
+        lane_id = lane.get("id") or str(uuid.uuid4())[:8]
+        if lane_id in seen_ids:
+            return web.json_response({"error": "Duplicate lane id"}, status=400)
+        seen_ids.add(lane_id)
+        lanes.append({"id": lane_id, "name": name, "order": order})
+
+    previous = await _get_board_config_for(db, user_email)
+    removed_ids = [lane["id"] for lane in previous["lanes"] if lane["id"] not in seen_ids]
+    first_lane_id = lanes[0]["id"]
+
+    await db.users.update_one(
+        {"email": user_email},
+        {"$set": {"task_board": {"prompt": prompt, "lanes": lanes}}},
+    )
+
+    migrated = 0
+    if removed_ids:
+        result = await db.conversations.update_many(
+            {
+                "metadata.user_name": user_email,
+                "task_status": "todo",
+                "task_lane": {"$in": removed_ids},
+            },
+            {"$set": {"task_lane": first_lane_id}},
+        )
+        migrated = result.modified_count
+
+    return web.json_response({"prompt": prompt, "lanes": lanes, "migrated": migrated})
+
+
+def setup_task_routes(app: web.Application):
+    """Register tasks-board routes on the aiohttp app."""
+    # Static paths must be registered before the {conversation_id} route.
+    app.router.add_get("/api/tasks/board-settings", handle_get_board_settings)
+    app.router.add_put("/api/tasks/board-settings", handle_put_board_settings)
+    app.router.add_get("/api/tasks/needs-input-count", handle_needs_input_count)
+    app.router.add_post("/api/tasks", handle_create_task)
+    app.router.add_get("/api/tasks", handle_list_tasks)
+    app.router.add_patch("/api/tasks/{conversation_id}", handle_update_task)

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -8,6 +8,9 @@
       "name": "dashboard",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@remixicon/react": "^4.9.0",
         "@tailwindcss/typography": "^0.5.19",
         "@xterm/addon-fit": "^0.11.0",
@@ -540,6 +543,59 @@
       "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
       "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/@dotenvx/dotenvx": {
       "version": "1.75.1",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -9,6 +9,9 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@remixicon/react": "^4.9.0",
     "@tailwindcss/typography": "^0.5.19",
     "@xterm/addon-fit": "^0.11.0",
@@ -31,13 +34,13 @@
     "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {
-    "shadcn": "^4.12.0",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "^16.2.9",
+    "shadcn": "^4.12.0",
     "tailwindcss": "^4",
     "typescript": "^5"
   }

--- a/dashboard/public/sw.js
+++ b/dashboard/public/sw.js
@@ -1,0 +1,45 @@
+// Loma service worker — web push for tasks-board notifications.
+
+self.addEventListener("install", () => {
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener("push", (event) => {
+  if (!event.data) return;
+  let payload;
+  try {
+    payload = event.data.json();
+  } catch {
+    payload = { title: "Loma", body: event.data.text() };
+  }
+  event.waitUntil(
+    self.registration.showNotification(payload.title || "Loma", {
+      body: payload.body || "",
+      tag: payload.tag,
+      data: { url: payload.url },
+      icon: "/favicon.png",
+    }),
+  );
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  const url = event.notification.data && event.notification.data.url;
+  if (!url) return;
+  event.waitUntil(
+    self.clients.matchAll({ type: "window", includeUncontrolled: true }).then((clients) => {
+      for (const client of clients) {
+        // Reuse an open dashboard tab when we can.
+        if (new URL(client.url).origin === self.location.origin && "navigate" in client) {
+          client.focus();
+          return client.navigate(url);
+        }
+      }
+      return self.clients.openWindow(url);
+    }),
+  );
+});

--- a/dashboard/src/app/chat/page.tsx
+++ b/dashboard/src/app/chat/page.tsx
@@ -33,6 +33,8 @@ function ChatPageContent() {
   const taskId = null; // Tasks system removed
   const promptParam = searchParams.get("prompt");
   const autoSendParam = searchParams.get("autoSend") === "true";
+  // Tasks board start flow: ?continue=<id>&start=1 auto-sends a staged draft's prompt
+  const startParam = searchParams.get("start") === "1";
   const skillContextParam = searchParams.get("skillContext");
   const [initialItems, setInitialItems] = useState<ChatItem[] | undefined>();
   const [initialArtifacts, setInitialArtifacts] = useState<Artifact[] | undefined>();
@@ -45,6 +47,9 @@ function ChatPageContent() {
   const [titleValue, setTitleValue] = useState("");
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Draft prompt for staged board tasks — prefills the composer (or auto-sends with ?start=1)
+  const [taskDraftPrompt, setTaskDraftPrompt] = useState<string | null>(null);
+  const [taskStatus, setTaskStatus] = useState<"todo" | "active" | "done" | null>(null);
 
   // Track the active conversation ID — starts from URL param but also updates
   // when a fresh chat creates a new conversation (via onConversationCreated callback)
@@ -96,6 +101,21 @@ function ChatPageContent() {
     async function loadConversation() {
       try {
         const data = await fetchConversation(continueId!);
+        setTaskStatus(data.conversation.task_status || null);
+        if (data.conversation.task_status === "todo") {
+          // Staged board task: nothing has been sent yet. Don't rebuild items
+          // (the fallback would render the draft prompt as an already-sent
+          // message) — put the draft in the composer instead.
+          setInitialItems([]);
+          setTaskDraftPrompt(data.conversation.prompt);
+          setConversationTitle(data.conversation.title || null);
+          setPromptPreview(
+            data.conversation.prompt.length > 80
+              ? data.conversation.prompt.slice(0, 80) + "..."
+              : data.conversation.prompt
+          );
+          return;
+        }
         const { items, artifacts: restoredArtifacts } = rebuildItemsFromConversation(
           data.conversation.messages,
           data.conversation.prompt,
@@ -254,6 +274,7 @@ function ChatPageContent() {
                 conversationTitle={conversationTitle || promptPreview || "Untitled"}
                 isPinned={isPinned(activeConversationId)}
                 projectId={projectId}
+                taskStatus={taskStatus}
                 projects={projects}
                 onRename={async (cid, newTitle) => {
                   await renameConversation(cid, newTitle);
@@ -336,8 +357,8 @@ function ChatPageContent() {
         initialArtifacts={initialArtifacts}
         conversationId={activeConversationId || undefined}
 
-        initialPrompt={promptParam || undefined}
-        autoSend={autoSendParam}
+        initialPrompt={taskDraftPrompt || promptParam || undefined}
+        autoSend={autoSendParam || (startParam && !!taskDraftPrompt)}
         systemContext={skillContextParam || undefined}
         initialStatus={initialStatus}
         onConversationCreated={handleConversationCreated}

--- a/dashboard/src/app/chat/page.tsx
+++ b/dashboard/src/app/chat/page.tsx
@@ -49,6 +49,7 @@ function ChatPageContent() {
   const [error, setError] = useState<string | null>(null);
   // Draft prompt for staged board tasks — prefills the composer (or auto-sends with ?start=1)
   const [taskDraftPrompt, setTaskDraftPrompt] = useState<string | null>(null);
+  const [taskModel, setTaskModel] = useState<string | null>(null);
   const [taskStatus, setTaskStatus] = useState<"todo" | "active" | "done" | null>(null);
 
   // Track the active conversation ID — starts from URL param but also updates
@@ -108,6 +109,7 @@ function ChatPageContent() {
           // message) — put the draft in the composer instead.
           setInitialItems([]);
           setTaskDraftPrompt(data.conversation.prompt);
+          setTaskModel(data.conversation.model || null);
           setConversationTitle(data.conversation.title || null);
           setPromptPreview(
             data.conversation.prompt.length > 80
@@ -358,6 +360,7 @@ function ChatPageContent() {
         conversationId={activeConversationId || undefined}
 
         initialPrompt={taskDraftPrompt || promptParam || undefined}
+        initialModel={taskModel || undefined}
         autoSend={autoSendParam || (startParam && !!taskDraftPrompt)}
         systemContext={skillContextParam || undefined}
         initialStatus={initialStatus}

--- a/dashboard/src/app/chat/page.tsx
+++ b/dashboard/src/app/chat/page.tsx
@@ -103,10 +103,11 @@ function ChatPageContent() {
       try {
         const data = await fetchConversation(continueId!);
         setTaskStatus(data.conversation.task_status || null);
-        if (data.conversation.task_status === "todo") {
-          // Staged board task: nothing has been sent yet. Don't rebuild items
-          // (the fallback would render the draft prompt as an already-sent
-          // message) — put the draft in the composer instead.
+        if (data.conversation.task_status === "todo" && !data.conversation.status) {
+          // Unstarted board draft: nothing has been sent yet. Don't rebuild
+          // items (the fallback would render the draft prompt as an already-
+          // sent message) — put the draft in the composer instead. Parked
+          // chats (staged after running) fall through to the normal rebuild.
           setInitialItems([]);
           setTaskDraftPrompt(data.conversation.prompt);
           setTaskModel(data.conversation.model || null);

--- a/dashboard/src/app/conversations/[id]/page.tsx
+++ b/dashboard/src/app/conversations/[id]/page.tsx
@@ -142,6 +142,7 @@ export default function ConversationDetailPage() {
             conversationTitle={conversation.title || conversation.prompt?.slice(0, 50) || "Untitled"}
             isPinned={isPinned(conversation.conversation_id)}
             projectId={conversation.project_id}
+            taskStatus={conversation.task_status}
             projects={projects}
             onRename={async (cid, newTitle) => {
               await renameConversation(cid, newTitle);

--- a/dashboard/src/app/conversations/page.tsx
+++ b/dashboard/src/app/conversations/page.tsx
@@ -509,6 +509,7 @@ export default function ConversationsPage() {
                           conversationTitle={c.title || c.prompt?.slice(0, 50) || "Untitled"}
                           isPinned={isPinned(c.conversation_id)}
                           projectId={c.project_id}
+                          taskStatus={c.task_status}
                           projects={projects}
                           onRename={async (id, newTitle) => { await renameConversation(id, newTitle); loadData(); }}
                           onDelete={async (id) => { await removeConversation(id); loadData(); }}
@@ -587,6 +588,7 @@ export default function ConversationsPage() {
                         conversationTitle={c.title || c.prompt?.slice(0, 50) || "Untitled"}
                         isPinned={isPinned(c.conversation_id)}
                         projectId={c.project_id}
+                        taskStatus={c.task_status}
                         projects={projects}
                         onRename={async (id, newTitle) => { await renameConversation(id, newTitle); loadData(); }}
                         onDelete={async (id) => { await removeConversation(id); loadData(); }}

--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
+import { RiAddLine, RiNotification3Line, RiNotificationOffLine, RiSettings3Line } from "@remixicon/react";
+import {
+  getPushState,
+  isPushConfigured,
+  isPushSupported,
+  subscribeToPush,
+  unsubscribeFromPush,
+  type PushState,
+} from "@/lib/push";
+import {
+  basePath,
+  createTask,
+  fetchTasksBoard,
+  updateTask,
+  type Task,
+  type TasksBoardResponse,
+} from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { TaskBoard } from "@/components/tasks/TaskBoard";
+import { TaskDialog } from "@/components/tasks/TaskDialog";
+import { BoardSettingsDialog } from "@/components/tasks/BoardSettingsDialog";
+
+const POLL_INTERVAL_MS = 5000;
+
+export default function TasksPage() {
+  const { status: sessionStatus } = useSession();
+  const router = useRouter();
+  const [board, setBoard] = useState<TasksBoardResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [taskDialogOpen, setTaskDialogOpen] = useState(false);
+  const [editingTask, setEditingTask] = useState<Task | null>(null);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  // null = push unavailable (unsupported browser, insecure context, or no VAPID keys)
+  const [pushState, setPushState] = useState<PushState | null>(null);
+  // Pause polling while a mutation is in flight to avoid clobbering optimistic state.
+  const busyRef = useRef(false);
+
+  useEffect(() => {
+    if (!isPushSupported()) return;
+    isPushConfigured().then((configured) => {
+      if (configured) getPushState().then(setPushState).catch(() => {});
+    });
+  }, []);
+
+  const togglePush = async () => {
+    try {
+      setPushState(
+        pushState === "subscribed" ? await unsubscribeFromPush() : await subscribeToPush(),
+      );
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Push setup failed");
+    }
+  };
+
+  const refresh = useCallback(async () => {
+    if (busyRef.current || document.hidden) return;
+    try {
+      const data = await fetchTasksBoard();
+      setBoard(data);
+    } catch {
+      // Transient poll failures are fine — keep showing the last board.
+    }
+  }, []);
+
+  useEffect(() => {
+    if (sessionStatus !== "authenticated") return;
+    refresh();
+    const interval = setInterval(refresh, POLL_INTERVAL_MS);
+    const onVisible = () => {
+      if (!document.hidden) refresh();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisible);
+    };
+  }, [sessionStatus, refresh]);
+
+  const handleTaskSubmit = async (
+    values: { title: string; prompt: string; lane: string },
+    start: boolean,
+  ) => {
+    busyRef.current = true;
+    try {
+      let conversationId: string;
+      if (editingTask) {
+        await updateTask(editingTask.conversation_id, {
+          title: values.title,
+          prompt: values.prompt,
+          task_lane: values.lane,
+        });
+        conversationId = editingTask.conversation_id;
+      } else {
+        const { task } = await createTask({
+          prompt: values.prompt,
+          title: values.title || undefined,
+          lane: values.lane,
+        });
+        conversationId = task.conversation_id;
+      }
+      if (start) {
+        router.push(`${basePath}/chat?continue=${conversationId}&start=1`);
+        return;
+      }
+      const data = await fetchTasksBoard();
+      setBoard(data);
+    } finally {
+      busyRef.current = false;
+    }
+  };
+
+  const laneCounts: Record<string, number> = {};
+  if (board) {
+    for (const lane of board.lanes) laneCounts[lane.id] = board.counts[lane.id] ?? 0;
+  }
+
+  return (
+    <div className="flex h-full flex-col space-y-2 p-4 lg:p-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-lg font-semibold">Tasks</h1>
+        <div className="flex items-center gap-1">
+          <Button size="sm" onClick={() => { setEditingTask(null); setTaskDialogOpen(true); }}>
+            <RiAddLine className="h-4 w-4" />
+            New task
+          </Button>
+          {pushState !== null && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground"
+                  disabled={pushState === "denied"}
+                  onClick={togglePush}
+                >
+                  {pushState === "subscribed"
+                    ? <RiNotification3Line className="h-4 w-4 text-brand-600" />
+                    : <RiNotificationOffLine className="h-4 w-4" />}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                {pushState === "denied"
+                  ? "Notifications blocked in browser settings"
+                  : pushState === "subscribed"
+                    ? "Notifications on"
+                    : "Notify me when a task needs input"}
+              </TooltipContent>
+            </Tooltip>
+          )}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground"
+                onClick={() => setSettingsOpen(true)}
+              >
+                <RiSettings3Line className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Board settings</TooltipContent>
+          </Tooltip>
+        </div>
+      </div>
+
+      {error && <p className="text-xs text-destructive">{error}</p>}
+
+      {board ? (
+        <TaskBoard
+          board={board}
+          onBoardChange={setBoard}
+          onRefresh={refresh}
+          onEditDraft={(task) => { setEditingTask(task); setTaskDialogOpen(true); }}
+          onError={setError}
+        />
+      ) : (
+        <div className="flex gap-4">
+          {[0, 1, 2, 3].map((i) => (
+            <div key={i} className="w-64 space-y-2">
+              <Skeleton className="h-4 w-20" />
+              <Skeleton className="h-14 w-full" />
+              <Skeleton className="h-14 w-full" />
+            </div>
+          ))}
+        </div>
+      )}
+
+      <TaskDialog
+        open={taskDialogOpen}
+        onOpenChange={setTaskDialogOpen}
+        lanes={board?.lanes ?? []}
+        task={editingTask}
+        onSubmit={handleTaskSubmit}
+      />
+      <BoardSettingsDialog
+        open={settingsOpen}
+        onOpenChange={setSettingsOpen}
+        laneCounts={laneCounts}
+        onSaved={refresh}
+      />
+    </div>
+  );
+}

--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { RiAddLine, RiNotification3Line, RiNotificationOffLine, RiSettings3Line } from "@remixicon/react";
+import { RiAddLine, RiChatHistoryLine, RiNotification3Line, RiNotificationOffLine, RiSettings3Line } from "@remixicon/react";
 import {
   getPushState,
   isPushConfigured,
@@ -25,6 +25,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { TaskBoard } from "@/components/tasks/TaskBoard";
 import { TaskDialog } from "@/components/tasks/TaskDialog";
+import { AddChatDialog } from "@/components/tasks/AddChatDialog";
 import { BoardSettingsDialog } from "@/components/tasks/BoardSettingsDialog";
 
 const POLL_INTERVAL_MS = 5000;
@@ -37,6 +38,7 @@ export default function TasksPage() {
   const [taskDialogOpen, setTaskDialogOpen] = useState(false);
   const [editingTask, setEditingTask] = useState<Task | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [addChatOpen, setAddChatOpen] = useState(false);
   // null = push unavailable (unsupported browser, insecure context, or no VAPID keys)
   const [pushState, setPushState] = useState<PushState | null>(null);
   // Pause polling while a mutation is in flight to avoid clobbering optimistic state.
@@ -132,6 +134,17 @@ export default function TasksPage() {
             <RiAddLine className="h-4 w-4" />
             New task
           </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground"
+                onClick={() => setAddChatOpen(true)}
+              >
+                <RiChatHistoryLine className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Add existing chat</TooltipContent>
+          </Tooltip>
           {pushState !== null && (
             <Tooltip>
               <TooltipTrigger asChild>
@@ -196,6 +209,11 @@ export default function TasksPage() {
         lanes={board?.lanes ?? []}
         task={editingTask}
         onSubmit={handleTaskSubmit}
+      />
+      <AddChatDialog
+        open={addChatOpen}
+        onOpenChange={setAddChatOpen}
+        onAdded={refresh}
       />
       <BoardSettingsDialog
         open={settingsOpen}

--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -84,7 +84,7 @@ export default function TasksPage() {
   }, [sessionStatus, refresh]);
 
   const handleTaskSubmit = async (
-    values: { title: string; prompt: string; lane: string },
+    values: { title: string; prompt: string; lane: string; model: string },
     start: boolean,
   ) => {
     busyRef.current = true;
@@ -95,6 +95,7 @@ export default function TasksPage() {
           title: values.title,
           prompt: values.prompt,
           task_lane: values.lane,
+          model: values.model,
         });
         conversationId = editingTask.conversation_id;
       } else {
@@ -102,6 +103,7 @@ export default function TasksPage() {
           prompt: values.prompt,
           title: values.title || undefined,
           lane: values.lane,
+          model: values.model || undefined,
         });
         conversationId = task.conversation_id;
       }

--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -37,6 +37,7 @@ export default function TasksPage() {
   const [error, setError] = useState<string | null>(null);
   const [taskDialogOpen, setTaskDialogOpen] = useState(false);
   const [editingTask, setEditingTask] = useState<Task | null>(null);
+  const [newTaskLane, setNewTaskLane] = useState<string | undefined>(undefined);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [addChatOpen, setAddChatOpen] = useState(false);
   // null = push unavailable (unsupported browser, insecure context, or no VAPID keys)
@@ -134,7 +135,7 @@ export default function TasksPage() {
       <div className="flex items-center justify-between">
         <h1 className="text-lg font-semibold">Tasks</h1>
         <div className="flex items-center gap-1">
-          <Button size="sm" onClick={() => { setEditingTask(null); setTaskDialogOpen(true); }}>
+          <Button size="sm" onClick={() => { setEditingTask(null); setNewTaskLane(undefined); setTaskDialogOpen(true); }}>
             <RiAddLine className="h-4 w-4" />
             New task
           </Button>
@@ -193,6 +194,7 @@ export default function TasksPage() {
           onBoardChange={setBoard}
           onRefresh={refresh}
           onEditDraft={(task) => { setEditingTask(task); setTaskDialogOpen(true); }}
+          onAddTask={(laneId) => { setEditingTask(null); setNewTaskLane(laneId); setTaskDialogOpen(true); }}
           onError={setError}
         />
       ) : (
@@ -212,6 +214,7 @@ export default function TasksPage() {
         onOpenChange={setTaskDialogOpen}
         lanes={board?.lanes ?? []}
         task={editingTask}
+        defaultLane={newTaskLane}
         onSubmit={handleTaskSubmit}
       />
       <AddChatDialog

--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -61,10 +61,14 @@ export default function TasksPage() {
     }
   };
 
+  const hasBoardRef = useRef(false);
   const refresh = useCallback(async () => {
-    if (busyRef.current || document.hidden) return;
+    // Pause polling when the tab is hidden — but always allow the initial
+    // load (a background/occluded tab would otherwise show skeletons forever).
+    if (busyRef.current || (document.hidden && hasBoardRef.current)) return;
     try {
       const data = await fetchTasksBoard();
+      hasBoardRef.current = true;
       setBoard(data);
     } catch {
       // Transient poll failures are fine — keep showing the last board.

--- a/dashboard/src/components/ChatContextMenu.tsx
+++ b/dashboard/src/components/ChatContextMenu.tsx
@@ -29,16 +29,20 @@ import {
   RiFolderLine,
   RiCloseLine,
   RiCheckLine,
+  RiCheckboxLine,
   RiAddLine,
   RiDeleteBinLine,
   RiLoader4Line,
 } from "@remixicon/react";
+import { updateTask } from "@/lib/api";
 
 interface ChatContextMenuProps {
   conversationId: string;
   conversationTitle: string;
   isPinned: boolean;
   projectId?: string | null;
+  /** Board membership — pass conversation.task_status to enable add/remove */
+  taskStatus?: "todo" | "active" | "done" | null;
   projects: Array<{ project_id: string; name: string }>;
   onRename: (conversationId: string, newTitle: string) => Promise<void>;
   onDelete: (conversationId: string) => Promise<void>;
@@ -54,6 +58,7 @@ export default function ChatContextMenu({
   conversationTitle,
   isPinned,
   projectId,
+  taskStatus,
   projects,
   onRename,
   onDelete,
@@ -70,6 +75,23 @@ export default function ChatContextMenu({
   const [renameValue, setRenameValue] = useState(conversationTitle);
   const [newProjectName, setNewProjectName] = useState("");
   const [loading, setLoading] = useState(false);
+  // Optimistic board membership — lists refresh on their own poll cycles.
+  const [onBoard, setOnBoard] = useState(!!taskStatus);
+
+  useEffect(() => {
+    setOnBoard(!!taskStatus);
+  }, [taskStatus]);
+
+  async function handleToggleBoard() {
+    const next = !onBoard;
+    setOnBoard(next);
+    try {
+      await updateTask(conversationId, { task_status: next ? "active" : null });
+    } catch (e) {
+      setOnBoard(!next);
+      console.error("Failed to update board membership:", e);
+    }
+  }
   const renameInputRef = useRef<HTMLInputElement>(null);
   const projectInputRef = useRef<HTMLInputElement>(null);
 
@@ -271,6 +293,27 @@ export default function ChatContextMenu({
               )}
             </DropdownMenuSubContent>
           </DropdownMenuSub>
+
+          {/* Tasks board */}
+          <DropdownMenuItem
+            onClick={(e) => {
+              e.stopPropagation();
+              handleToggleBoard();
+              setDropdownOpen(false);
+            }}
+          >
+            {onBoard ? (
+              <>
+                <RiCheckboxLine size={16} className="text-brand-600" />
+                Remove from board
+              </>
+            ) : (
+              <>
+                <RiCheckboxLine size={16} className="text-muted-foreground" />
+                Add to board
+              </>
+            )}
+          </DropdownMenuItem>
 
           <DropdownMenuSeparator />
 

--- a/dashboard/src/components/ChatPanel.tsx
+++ b/dashboard/src/components/ChatPanel.tsx
@@ -634,6 +634,7 @@ export default function ChatPanel({
   initialArtifacts,
   conversationId: initialConversationId,
   initialPrompt,
+  initialModel,
   autoSend,
   systemContext,
   initialStatus,
@@ -648,6 +649,8 @@ export default function ChatPanel({
   initialArtifacts?: Artifact[];
   conversationId?: string;
   initialPrompt?: string;
+  /** Model to preselect (e.g. a board task's chosen model) — wins over the saved preference */
+  initialModel?: string;
   autoSend?: boolean;
   systemContext?: string;
   initialStatus?: string;
@@ -753,9 +756,12 @@ export default function ChatPanel({
           ? window.localStorage.getItem(MODEL_STORAGE_KEY)
           : null;
         const savedIsValid = saved && models.some((model) => model.id === saved);
-        const nextModel = savedIsValid
-          ? saved
-          : catalog.default_model || models[0]?.id || "";
+        const initialIsValid = initialModel && models.some((model) => model.id === initialModel);
+        const nextModel = initialIsValid
+          ? initialModel
+          : savedIsValid
+            ? saved
+            : catalog.default_model || models[0]?.id || "";
         setSelectedModel(nextModel);
         setModelLoadState("ready");
       } catch (e) {
@@ -771,7 +777,8 @@ export default function ChatPanel({
     return () => {
       cancelled = true;
     };
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialModel]);
 
   const scrollToBottom = useCallback(() => {
     setTimeout(() => {
@@ -928,11 +935,16 @@ export default function ChatPanel({
 
   const autoSendFired = useRef(false);
   useEffect(() => {
-    if (autoSend && initialPrompt && !autoSendFired.current && !isStreaming && session) {
+    // Wait for the model catalog so the send uses the intended model (e.g. a
+    // board task's chosen model) instead of racing the default.
+    if (autoSend && initialPrompt && !autoSendFired.current && !isStreaming && session
+        && modelLoadState !== "loading") {
       autoSendFired.current = true;
       setInput("");
-      const timer = setTimeout(() => handleSend(initialPrompt), 0);
-      return () => clearTimeout(timer);
+      // Call directly — a deferred setTimeout gets cancelled by this effect's
+      // own cleanup when setInput triggers a re-render (no dep array), which
+      // made auto-send silently flaky.
+      handleSend(initialPrompt);
     }
   });
 

--- a/dashboard/src/components/ChatWithArtifacts.tsx
+++ b/dashboard/src/components/ChatWithArtifacts.tsx
@@ -75,6 +75,7 @@ export default function ChatWithArtifacts({
   initialArtifacts,
   conversationId,
   initialPrompt,
+  initialModel,
   autoSend,
   systemContext,
   initialStatus,
@@ -84,6 +85,7 @@ export default function ChatWithArtifacts({
   initialArtifacts?: Artifact[];
   conversationId?: string;
   initialPrompt?: string;
+  initialModel?: string;
   autoSend?: boolean;
   systemContext?: string;
   initialStatus?: string;
@@ -150,6 +152,7 @@ export default function ChatWithArtifacts({
           initialArtifacts={initialArtifacts}
           conversationId={conversationId}
           initialPrompt={initialPrompt}
+          initialModel={initialModel}
           autoSend={autoSend}
           systemContext={systemContext}
           initialStatus={initialStatus}

--- a/dashboard/src/components/Providers.tsx
+++ b/dashboard/src/components/Providers.tsx
@@ -3,17 +3,20 @@
 import { SessionProvider } from "next-auth/react";
 import { UserProvider } from "../lib/UserContext";
 import { ThemeProvider } from "../lib/ThemeContext";
+import { TaskAttentionProvider } from "../lib/TaskAttentionContext";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   return (
     <SessionProvider>
       <UserProvider>
-        <ThemeProvider>
-          <TooltipProvider delayDuration={300}>
-            {children}
-          </TooltipProvider>
-        </ThemeProvider>
+        <TaskAttentionProvider>
+          <ThemeProvider>
+            <TooltipProvider delayDuration={300}>
+              {children}
+            </TooltipProvider>
+          </ThemeProvider>
+        </TaskAttentionProvider>
       </UserProvider>
     </SessionProvider>
   );

--- a/dashboard/src/components/Sidebar.tsx
+++ b/dashboard/src/components/Sidebar.tsx
@@ -7,6 +7,7 @@ import Link from "next/link";
 import { fetchConversations, fetchPinnedConversations, fetchPoolStatus } from "../lib/api";
 import type { Conversation, PoolStatus } from "../lib/api";
 import { useUser } from "../lib/UserContext";
+import { useTaskAttention } from "../lib/TaskAttentionContext";
 import type { SystemRole } from "../lib/governance-api";
 import CrosscutIcon from "./CrosscutIcon";
 import ChatContextMenu from "./ChatContextMenu";
@@ -21,6 +22,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import {
   RiChat1Line,
+  RiCheckboxLine,
   RiGridLine,
   RiTimeLine,
   RiBookOpenLine,
@@ -42,7 +44,8 @@ type NavItem = {
   name: string;
   href: string;
   icon: React.ReactNode;
-  badgeKey?: never;
+  /** Key into badgeCounts for an attention count shown next to the item */
+  badgeKey?: string;
   /** Minimum system role required to see this nav item */
   minRole?: SystemRole;
 };
@@ -52,6 +55,12 @@ const navigation: NavItem[] = [
     name: "Home",
     href: "/",
     icon: <RiChat1Line size={16} />,
+  },
+  {
+    name: "Tasks",
+    href: "/tasks",
+    badgeKey: "tasks",
+    icon: <RiCheckboxLine size={16} />,
   },
   {
     name: "Activity",
@@ -277,7 +286,8 @@ export default function Sidebar({
   const activeContinueId = pathname === "/chat" ? searchParams.get("continue") : null;
   const [myConversations, setMyConversations] = useState<Conversation[]>([]);
   const [pinnedConversations, setPinnedConversations] = useState<Conversation[]>([]);
-  const [badgeCounts] = useState<Record<string, number>>({});
+  const { needsInputCount } = useTaskAttention();
+  const badgeCounts: Record<string, number> = { tasks: needsInputCount };
   const [poolStatus, setPoolStatus] = useState<PoolStatus | null>(null);
 
   // Filter nav items by role
@@ -391,7 +401,12 @@ export default function Sidebar({
                   )}
                   title={collapsed ? item.name : undefined}
                 >
-                  <span className={cn("transition-colors flex-shrink-0", isActive ? "text-brand-600" : "text-muted-foreground")}>{item.icon}</span>
+                  <span className={cn("relative transition-colors flex-shrink-0", isActive ? "text-brand-600" : "text-muted-foreground")}>
+                    {item.icon}
+                    {collapsed && item.badgeKey && badgeCounts[item.badgeKey] > 0 && (
+                      <span className="absolute -top-0.5 -right-0.5 h-1.5 w-1.5 rounded-full bg-amber-500" />
+                    )}
+                  </span>
                   {!collapsed && <span>{item.name}</span>}
                   {!collapsed && item.badgeKey && badgeCounts[item.badgeKey] > 0 ? (
                     <span className="ml-auto min-w-[18px] h-[18px] px-1 flex items-center justify-center rounded-md bg-brand-50 text-brand-600 text-[10px] font-semibold ring-1 ring-brand-200/60">
@@ -469,6 +484,7 @@ export default function Sidebar({
                           conversationTitle={title}
                           isPinned={true}
                           projectId={c.project_id}
+                          taskStatus={c.task_status}
                           projects={projects}
                           onRename={async (id, newTitle) => { await renameConversation(id, newTitle); reloadConversations(); }}
                           onDelete={async (id) => { await removeConversation(id); reloadConversations(); }}
@@ -525,6 +541,7 @@ export default function Sidebar({
                             conversationTitle={title}
                             isPinned={false}
                             projectId={c.project_id}
+                            taskStatus={c.task_status}
                             projects={projects}
                             onRename={async (id, newTitle) => { await renameConversation(id, newTitle); reloadConversations(); }}
                             onDelete={async (id) => { await removeConversation(id); reloadConversations(); }}

--- a/dashboard/src/components/tasks/AddChatDialog.tsx
+++ b/dashboard/src/components/tasks/AddChatDialog.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSession } from "next-auth/react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+import ClientTimestamp from "@/components/ClientTimestamp";
+import { fetchConversations, updateTask, type Conversation } from "@/lib/api";
+
+const statusDotStyles: Record<string, string> = {
+  running: "bg-blue-500 animate-pulse",
+  completed: "bg-emerald-500",
+  error: "bg-red-500",
+  interrupted: "bg-red-500",
+};
+
+interface AddChatDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onAdded: () => void;
+}
+
+/** Pick one of your existing chats and track it on the board. */
+export function AddChatDialog({ open, onOpenChange, onAdded }: AddChatDialogProps) {
+  const { data: session } = useSession();
+  const [search, setSearch] = useState("");
+  const [conversations, setConversations] = useState<Conversation[] | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setSearch("");
+    setError(null);
+    setConversations(null);
+  }, [open]);
+
+  // Debounced search over the caller's own conversations.
+  useEffect(() => {
+    if (!open || !session?.user?.email) return;
+    const timer = setTimeout(() => {
+      fetchConversations({ person: session.user!.email!, search: search.trim() || undefined })
+        .then((data) => setConversations(data.conversations))
+        .catch((e) => setError(e instanceof Error ? e.message : "Failed to load chats"));
+    }, search ? 300 : 0);
+    return () => clearTimeout(timer);
+  }, [open, search, session?.user?.email]);
+
+  const addable = (conversations ?? []).filter((c) => !c.task_status);
+
+  const add = async (conversation: Conversation) => {
+    setBusyId(conversation.conversation_id);
+    setError(null);
+    try {
+      await updateTask(conversation.conversation_id, { task_status: "active" });
+      onOpenChange(false);
+      onAdded();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to add chat");
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Add existing chat</DialogTitle>
+        </DialogHeader>
+        <Input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search your chats..."
+          autoFocus
+        />
+        <div className="max-h-80 space-y-0.5 overflow-y-auto">
+          {conversations === null ? (
+            [0, 1, 2, 3].map((i) => <Skeleton key={i} className="h-9 w-full" />)
+          ) : addable.length === 0 ? (
+            <p className="px-1 py-3 text-center text-xs text-muted-foreground">
+              {conversations.length > 0
+                ? "All matching chats are already on the board"
+                : "No chats found"}
+            </p>
+          ) : (
+            addable.map((c) => (
+              <button
+                key={c.conversation_id}
+                onClick={() => add(c)}
+                disabled={busyId !== null}
+                className={cn(
+                  "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left",
+                  "hover:bg-muted disabled:opacity-50",
+                  busyId === c.conversation_id && "opacity-50",
+                )}
+              >
+                <span className={cn(
+                  "h-2 w-2 shrink-0 rounded-full",
+                  statusDotStyles[c.status] ?? "bg-muted-foreground/40",
+                )} />
+                <span className="min-w-0 flex-1 truncate text-[13px]">
+                  {c.title || c.prompt || "Untitled"}
+                </span>
+                <span className="shrink-0 text-xs text-muted-foreground">
+                  <ClientTimestamp iso={c.started_at} variant="short" placeholder="" />
+                </span>
+              </button>
+            ))
+          )}
+        </div>
+        {error && <p className="text-xs text-destructive">{error}</p>}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/dashboard/src/components/tasks/BoardSettingsDialog.tsx
+++ b/dashboard/src/components/tasks/BoardSettingsDialog.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  RiAddLine,
+  RiArrowDownSLine,
+  RiArrowUpSLine,
+  RiDeleteBinLine,
+} from "@remixicon/react";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { fetchBoardSettings, saveBoardSettings } from "@/lib/api";
+
+interface EditableLane {
+  id?: string;
+  name: string;
+}
+
+interface BoardSettingsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Count of staged tasks per lane id — used for delete warnings. */
+  laneCounts: Record<string, number>;
+  onSaved: () => void;
+}
+
+export function BoardSettingsDialog({ open, onOpenChange, laneCounts, onSaved }: BoardSettingsDialogProps) {
+  const [prompt, setPrompt] = useState("");
+  const [lanes, setLanes] = useState<EditableLane[]>([]);
+  const [removedWithTasks, setRemovedWithTasks] = useState<string[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setError(null);
+    setRemovedWithTasks([]);
+    fetchBoardSettings()
+      .then((settings) => {
+        setPrompt(settings.prompt);
+        setLanes(settings.lanes.map(({ id, name }) => ({ id, name })));
+      })
+      .catch((e) => setError(e instanceof Error ? e.message : "Failed to load settings"));
+  }, [open]);
+
+  const moveLane = (index: number, delta: number) => {
+    const next = [...lanes];
+    const target = index + delta;
+    if (target < 0 || target >= next.length) return;
+    [next[index], next[target]] = [next[target], next[index]];
+    setLanes(next);
+  };
+
+  const removeLane = (index: number) => {
+    const lane = lanes[index];
+    const count = lane.id ? laneCounts[lane.id] ?? 0 : 0;
+    if (count > 0) {
+      const firstRemaining = lanes.find((_, i) => i !== index);
+      setRemovedWithTasks((prev) => [
+        ...prev,
+        `${count} task${count === 1 ? "" : "s"} in “${lane.name}” will move to “${firstRemaining?.name}”`,
+      ]);
+    }
+    setLanes(lanes.filter((_, i) => i !== index));
+  };
+
+  const save = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      await saveBoardSettings({ prompt, lanes });
+      onOpenChange(false);
+      onSaved();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to save settings");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Board settings</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-5">
+          <div className="space-y-1.5">
+            <Label htmlFor="board-prompt">Context</Label>
+            <Textarea
+              id="board-prompt"
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              placeholder="Your role and working context — added to every task on this board"
+              rows={5}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label>Columns</Label>
+            <div className="space-y-1">
+              {lanes.map((lane, index) => (
+                <div key={lane.id ?? `new-${index}`} className="flex items-center gap-1">
+                  <Input
+                    value={lane.name}
+                    onChange={(e) =>
+                      setLanes(lanes.map((l, i) => (i === index ? { ...l, name: e.target.value } : l)))
+                    }
+                    className="h-8"
+                  />
+                  <Button
+                    variant="ghost" size="icon" className="h-8 w-8 shrink-0"
+                    disabled={index === 0}
+                    onClick={() => moveLane(index, -1)}
+                    title="Move up"
+                  >
+                    <RiArrowUpSLine className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    variant="ghost" size="icon" className="h-8 w-8 shrink-0"
+                    disabled={index === lanes.length - 1}
+                    onClick={() => moveLane(index, 1)}
+                    title="Move down"
+                  >
+                    <RiArrowDownSLine className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    variant="ghost" size="icon" className="h-8 w-8 shrink-0"
+                    disabled={lanes.length <= 1}
+                    onClick={() => removeLane(index)}
+                    title="Delete column"
+                  >
+                    <RiDeleteBinLine className="h-4 w-4" />
+                  </Button>
+                </div>
+              ))}
+            </div>
+            <Button
+              variant="ghost" size="sm" className="text-muted-foreground"
+              onClick={() => setLanes([...lanes, { name: "" }])}
+            >
+              <RiAddLine className="h-4 w-4" />
+              Add column
+            </Button>
+            {removedWithTasks.map((warning) => (
+              <p key={warning} className="text-xs text-amber-600">{warning}</p>
+            ))}
+          </div>
+          {error && <p className="text-xs text-destructive">{error}</p>}
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={busy}>
+            Cancel
+          </Button>
+          <Button onClick={save} disabled={busy}>Save</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/dashboard/src/components/tasks/TaskBoard.tsx
+++ b/dashboard/src/components/tasks/TaskBoard.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  DndContext,
+  DragOverlay,
+  KeyboardSensor,
+  PointerSensor,
+  pointerWithin,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+} from "@dnd-kit/core";
+import { sortableKeyboardCoordinates } from "@dnd-kit/sortable";
+import { basePath, deleteConversation, updateTask, type BoardLane, type Task, type TasksBoardResponse } from "@/lib/api";
+import { canMove, rankBetween } from "./transitions";
+import { TaskColumn } from "./TaskColumn";
+import { TaskCard } from "./TaskCard";
+
+const SYSTEM_COLUMNS = [
+  { id: "working", name: "Working" },
+  { id: "needs_input", name: "Needs input" },
+  { id: "done", name: "Done" },
+];
+
+interface TaskBoardProps {
+  board: TasksBoardResponse;
+  /** Optimistically replace board state; server truth reconciles via polling. */
+  onBoardChange: (board: TasksBoardResponse) => void;
+  onRefresh: () => void;
+  onEditDraft: (task: Task) => void;
+  onError: (message: string | null) => void;
+}
+
+export function TaskBoard({ board, onBoardChange, onRefresh, onEditDraft, onError }: TaskBoardProps) {
+  const router = useRouter();
+  const [activeTask, setActiveTask] = useState<Task | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const laneIds = useMemo(() => board.lanes.map((lane) => lane.id), [board.lanes]);
+  const columns: Array<BoardLane | { id: string; name: string }> = useMemo(
+    () => [...board.lanes, ...SYSTEM_COLUMNS],
+    [board.lanes],
+  );
+
+  const tasksByColumn = useMemo(() => {
+    const map: Record<string, Task[]> = {};
+    for (const column of columns) map[column.id] = [];
+    for (const task of board.tasks) {
+      (map[task.column] ??= []).push(task);
+    }
+    return map;
+  }, [board.tasks, columns]);
+
+  const startTask = (task: Task) => {
+    router.push(`${basePath}/chat?continue=${task.conversation_id}&start=1`);
+  };
+
+  const mutate = async (
+    apply: (tasks: Task[]) => Task[],
+    request: () => Promise<unknown>,
+  ) => {
+    const snapshot = board;
+    onError(null);
+    onBoardChange({ ...board, tasks: apply(board.tasks) });
+    try {
+      await request();
+      onRefresh();
+    } catch (e) {
+      onBoardChange(snapshot);
+      onError(e instanceof Error ? e.message : "Update failed");
+    }
+  };
+
+  const markDone = (task: Task) =>
+    mutate(
+      (tasks) => tasks.map((t) =>
+        t.conversation_id === task.conversation_id
+          ? { ...t, task_status: "done" as const, column: "done" }
+          : t),
+      () => updateTask(task.conversation_id, { task_status: "done" }),
+    );
+
+  const reopen = (task: Task) =>
+    mutate(
+      (tasks) => tasks.map((t) =>
+        t.conversation_id === task.conversation_id
+          ? { ...t, task_status: "active" as const, column: t.status === "running" ? "working" : "needs_input" }
+          : t),
+      () => updateTask(task.conversation_id, { task_status: "active" }),
+    );
+
+  const moveToLane = (task: Task, laneId: string, rank?: number) =>
+    mutate(
+      (tasks) => tasks.map((t) =>
+        t.conversation_id === task.conversation_id
+          ? { ...t, task_lane: laneId, column: laneId, task_rank: rank ?? t.task_rank }
+          : t),
+      () => updateTask(task.conversation_id, {
+        task_lane: laneId,
+        ...(rank !== undefined ? { task_rank: rank } : {}),
+      }),
+    );
+
+  const reorderInLane = (task: Task, rank: number) =>
+    mutate(
+      (tasks) => tasks
+        .map((t) => (t.conversation_id === task.conversation_id ? { ...t, task_rank: rank } : t)),
+      () => updateTask(task.conversation_id, { task_rank: rank }),
+    );
+
+  const removeFromBoard = (task: Task) =>
+    mutate(
+      (tasks) => tasks.filter((t) => t.conversation_id !== task.conversation_id),
+      () => updateTask(task.conversation_id, { task_status: null }),
+    );
+
+  const deleteDraft = (task: Task) =>
+    mutate(
+      (tasks) => tasks.filter((t) => t.conversation_id !== task.conversation_id),
+      () => deleteConversation(task.conversation_id),
+    );
+
+  const openTask = (task: Task) => {
+    if (task.task_status === "todo") {
+      onEditDraft(task);
+    } else {
+      router.push(`${basePath}/chat?continue=${task.conversation_id}`);
+    }
+  };
+
+  const resolveColumn = (overId: string): string | null => {
+    if (tasksByColumn[overId] !== undefined) return overId;
+    const overTask = board.tasks.find((t) => t.conversation_id === overId);
+    return overTask ? overTask.column : null;
+  };
+
+  const handleDragStart = (event: DragStartEvent) => {
+    const task = board.tasks.find((t) => t.conversation_id === event.active.id);
+    setActiveTask(task ?? null);
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const task = activeTask;
+    setActiveTask(null);
+    if (!task || !event.over) return;
+
+    const overId = String(event.over.id);
+    const target = resolveColumn(overId);
+    if (!target || !canMove(task, task.column, target, laneIds)) return;
+
+    if (target === "working") {
+      startTask(task);
+      return;
+    }
+    if (target === "done") {
+      markDone(task);
+      return;
+    }
+
+    // Staged lane: position relative to the card we dropped on (or lane end).
+    const laneTasks = (tasksByColumn[target] ?? []).filter(
+      (t) => t.conversation_id !== task.conversation_id,
+    );
+    let index = laneTasks.findIndex((t) => t.conversation_id === overId);
+    if (index === -1) index = laneTasks.length;
+    const before = index > 0 ? laneTasks[index - 1].task_rank : null;
+    const after = index < laneTasks.length ? laneTasks[index].task_rank : null;
+    const rank = rankBetween(before, after);
+
+    if (target === task.column) {
+      reorderInLane(task, rank);
+    } else {
+      moveToLane(task, target, rank);
+    }
+  };
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={pointerWithin}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+      onDragCancel={() => setActiveTask(null)}
+    >
+      <div className="flex flex-1 gap-4 overflow-x-auto pb-4">
+        {columns.map((column) => (
+          <TaskColumn
+            key={column.id}
+            id={column.id}
+            name={column.name}
+            tasks={tasksByColumn[column.id] ?? []}
+            droppable={
+              activeTask
+                ? canMove(activeTask, activeTask.column, column.id, laneIds)
+                : undefined
+            }
+          >
+            {(tasksByColumn[column.id] ?? []).map((task) => (
+              <TaskCard
+                key={task.conversation_id}
+                task={task}
+                lanes={board.lanes}
+                onOpen={openTask}
+                onStart={startTask}
+                onMarkDone={markDone}
+                onReopen={reopen}
+                onMoveToLane={moveToLane}
+                onRemoveFromBoard={removeFromBoard}
+                onDeleteDraft={deleteDraft}
+              />
+            ))}
+          </TaskColumn>
+        ))}
+      </div>
+      <DragOverlay>
+        {activeTask && (
+          <div className="rounded-md border bg-card px-3 py-2 text-[13px] shadow-md">
+            {activeTask.title || activeTask.prompt}
+          </div>
+        )}
+      </DragOverlay>
+    </DndContext>
+  );
+}

--- a/dashboard/src/components/tasks/TaskBoard.tsx
+++ b/dashboard/src/components/tasks/TaskBoard.tsx
@@ -96,13 +96,22 @@ export function TaskBoard({ board, onBoardChange, onRefresh, onEditDraft, onErro
       () => updateTask(task.conversation_id, { task_status: "active" }),
     );
 
+  // Moving into a staging lane also *parks* active tasks (todo + lane) so a
+  // needs-input chat can be shelved and recontinued later.
   const moveToLane = (task: Task, laneId: string, rank?: number) =>
     mutate(
       (tasks) => tasks.map((t) =>
         t.conversation_id === task.conversation_id
-          ? { ...t, task_lane: laneId, column: laneId, task_rank: rank ?? t.task_rank }
+          ? {
+              ...t,
+              task_status: "todo" as const,
+              task_lane: laneId,
+              column: laneId,
+              task_rank: rank ?? t.task_rank,
+            }
           : t),
       () => updateTask(task.conversation_id, {
+        ...(task.task_status === "active" ? { task_status: "todo" as const } : {}),
         task_lane: laneId,
         ...(rank !== undefined ? { task_rank: rank } : {}),
       }),
@@ -128,7 +137,9 @@ export function TaskBoard({ board, onBoardChange, onRefresh, onEditDraft, onErro
     );
 
   const openTask = (task: Task) => {
-    if (task.task_status === "todo") {
+    // Only unstarted drafts open the details editor; anything with history
+    // (including chats parked in a lane) opens the conversation.
+    if (task.task_status === "todo" && !task.status) {
       onEditDraft(task);
     } else {
       router.push(`${basePath}/chat?continue=${task.conversation_id}`);

--- a/dashboard/src/components/tasks/TaskBoard.tsx
+++ b/dashboard/src/components/tasks/TaskBoard.tsx
@@ -31,10 +31,12 @@ interface TaskBoardProps {
   onBoardChange: (board: TasksBoardResponse) => void;
   onRefresh: () => void;
   onEditDraft: (task: Task) => void;
+  /** Open the new-task dialog with a lane preselected. */
+  onAddTask: (laneId: string) => void;
   onError: (message: string | null) => void;
 }
 
-export function TaskBoard({ board, onBoardChange, onRefresh, onEditDraft, onError }: TaskBoardProps) {
+export function TaskBoard({ board, onBoardChange, onRefresh, onEditDraft, onAddTask, onError }: TaskBoardProps) {
   const router = useRouter();
   const [activeTask, setActiveTask] = useState<Task | null>(null);
 
@@ -212,6 +214,7 @@ export function TaskBoard({ board, onBoardChange, onRefresh, onEditDraft, onErro
                 ? canMove(activeTask, activeTask.column, column.id, laneIds)
                 : undefined
             }
+            onAddTask={laneIds.includes(column.id) ? () => onAddTask(column.id) : undefined}
           >
             {(tasksByColumn[column.id] ?? []).map((task) => (
               <TaskCard

--- a/dashboard/src/components/tasks/TaskCard.tsx
+++ b/dashboard/src/components/tasks/TaskCard.tsx
@@ -48,11 +48,17 @@ export function TaskCard({
   onMoveToLane, onRemoveFromBoard, onDeleteDraft,
 }: TaskCardProps) {
   const isStaged = task.task_status === "todo";
+  const isDraft = isStaged && !task.status;
+  const isParked = isStaged && !!task.status;
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
     useSortable({ id: task.conversation_id, data: { task } });
 
   const isError = task.column === "needs_input" && (task.status === "error" || task.status === "interrupted");
-  const dot = isError ? "bg-red-500" : columnDotStyles[task.column];
+  const dot = isError
+    ? "bg-red-500"
+    : isParked
+      ? "bg-muted-foreground/40" // parked chat: paused, not demanding attention
+      : columnDotStyles[task.column];
   const timestamp =
     task.column === "working" ? task.started_at
     : task.column === "needs_input" ? task.finished_at
@@ -88,7 +94,7 @@ export function TaskCard({
           onClick={(e) => e.stopPropagation()}
           onPointerDown={(e) => e.stopPropagation()}
         >
-          {isStaged && (
+          {isDraft && (
             <Button
               variant="ghost" size="icon" className="h-6 w-6"
               title="Start"
@@ -97,7 +103,7 @@ export function TaskCard({
               <RiPlayLine className="h-3.5 w-3.5" />
             </Button>
           )}
-          {(task.column === "working" || task.column === "needs_input") && (
+          {(task.column === "working" || task.column === "needs_input" || isParked) && (
             <Button
               variant="ghost" size="icon" className="h-6 w-6"
               title="Mark done"
@@ -113,31 +119,38 @@ export function TaskCard({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
-              {isStaged && lanes.length > 1 && (
-                <DropdownMenuSub>
-                  <DropdownMenuSubTrigger>Move to</DropdownMenuSubTrigger>
-                  <DropdownMenuSubContent>
-                    {lanes.filter((lane) => lane.id !== task.task_lane).map((lane) => (
-                      <DropdownMenuItem key={lane.id} onClick={() => onMoveToLane(task, lane.id)}>
-                        {lane.name}
-                      </DropdownMenuItem>
-                    ))}
-                  </DropdownMenuSubContent>
-                </DropdownMenuSub>
-              )}
+              {(() => {
+                // Staged cards move between other lanes; needs-input cards
+                // park into any lane to be recontinued later.
+                const targetLanes = isStaged
+                  ? lanes.filter((lane) => lane.id !== task.task_lane)
+                  : task.column === "needs_input" ? lanes : [];
+                return targetLanes.length > 0 && (
+                  <DropdownMenuSub>
+                    <DropdownMenuSubTrigger>Move to</DropdownMenuSubTrigger>
+                    <DropdownMenuSubContent>
+                      {targetLanes.map((lane) => (
+                        <DropdownMenuItem key={lane.id} onClick={() => onMoveToLane(task, lane.id)}>
+                          {lane.name}
+                        </DropdownMenuItem>
+                      ))}
+                    </DropdownMenuSubContent>
+                  </DropdownMenuSub>
+                );
+              })()}
               {task.column === "done" && (
                 <DropdownMenuItem onClick={() => onReopen(task)}>
                   <RiArrowGoBackLine className="h-3.5 w-3.5" />
                   Reopen
                 </DropdownMenuItem>
               )}
-              {!isStaged && (
+              {!isDraft && (
                 <DropdownMenuItem onClick={() => onRemoveFromBoard(task)}>
                   <RiLogoutBoxRLine className="h-3.5 w-3.5" />
                   Remove from board
                 </DropdownMenuItem>
               )}
-              {isStaged && (
+              {isDraft && (
                 <>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem variant="destructive" onClick={() => onDeleteDraft(task)}>

--- a/dashboard/src/components/tasks/TaskCard.tsx
+++ b/dashboard/src/components/tasks/TaskCard.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import {
+  RiPlayLine,
+  RiCheckLine,
+  RiMoreLine,
+  RiArrowGoBackLine,
+  RiDeleteBinLine,
+  RiLogoutBoxRLine,
+} from "@remixicon/react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import ClientTimestamp from "@/components/ClientTimestamp";
+import type { BoardLane, Task } from "@/lib/api";
+
+const columnDotStyles: Record<string, string> = {
+  working: "bg-blue-500 animate-pulse",
+  needs_input: "bg-amber-500",
+  done: "bg-emerald-500",
+};
+
+interface TaskCardProps {
+  task: Task;
+  lanes: BoardLane[];
+  onOpen: (task: Task) => void;
+  onStart: (task: Task) => void;
+  onMarkDone: (task: Task) => void;
+  onReopen: (task: Task) => void;
+  onMoveToLane: (task: Task, laneId: string) => void;
+  onRemoveFromBoard: (task: Task) => void;
+  onDeleteDraft: (task: Task) => void;
+}
+
+export function TaskCard({
+  task, lanes, onOpen, onStart, onMarkDone, onReopen,
+  onMoveToLane, onRemoveFromBoard, onDeleteDraft,
+}: TaskCardProps) {
+  const isStaged = task.task_status === "todo";
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: task.conversation_id, data: { task } });
+
+  const isError = task.column === "needs_input" && (task.status === "error" || task.status === "interrupted");
+  const dot = isError ? "bg-red-500" : columnDotStyles[task.column];
+  const timestamp =
+    task.column === "working" ? task.started_at
+    : task.column === "needs_input" ? task.finished_at
+    : task.column === "done" ? task.task_done_at
+    : task.task_staged_at;
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      {...attributes}
+      {...listeners}
+      onClick={() => onOpen(task)}
+      className={cn(
+        "group rounded-md border bg-card px-3 py-2 cursor-pointer",
+        "hover:bg-muted/50 touch-none select-none",
+        isDragging && "opacity-40",
+      )}
+    >
+      <div className="flex items-start gap-2">
+        {dot && <span className={cn("mt-1.5 h-2 w-2 shrink-0 rounded-full", dot)} />}
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-[13px]">
+            {task.title || task.prompt}
+          </div>
+          <div className="mt-0.5 flex items-center gap-2 text-xs text-muted-foreground">
+            <ClientTimestamp iso={timestamp} variant="short" placeholder="—" />
+            {task.total_turns > 0 && <span>{task.total_turns} turns</span>}
+          </div>
+        </div>
+        <div
+          className="flex shrink-0 items-center gap-0.5 opacity-0 group-hover:opacity-100"
+          onClick={(e) => e.stopPropagation()}
+          onPointerDown={(e) => e.stopPropagation()}
+        >
+          {isStaged && (
+            <Button
+              variant="ghost" size="icon" className="h-6 w-6"
+              title="Start"
+              onClick={() => onStart(task)}
+            >
+              <RiPlayLine className="h-3.5 w-3.5" />
+            </Button>
+          )}
+          {(task.column === "working" || task.column === "needs_input") && (
+            <Button
+              variant="ghost" size="icon" className="h-6 w-6"
+              title="Mark done"
+              onClick={() => onMarkDone(task)}
+            >
+              <RiCheckLine className="h-3.5 w-3.5" />
+            </Button>
+          )}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="icon" className="h-6 w-6">
+                <RiMoreLine className="h-3.5 w-3.5" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              {isStaged && lanes.length > 1 && (
+                <DropdownMenuSub>
+                  <DropdownMenuSubTrigger>Move to</DropdownMenuSubTrigger>
+                  <DropdownMenuSubContent>
+                    {lanes.filter((lane) => lane.id !== task.task_lane).map((lane) => (
+                      <DropdownMenuItem key={lane.id} onClick={() => onMoveToLane(task, lane.id)}>
+                        {lane.name}
+                      </DropdownMenuItem>
+                    ))}
+                  </DropdownMenuSubContent>
+                </DropdownMenuSub>
+              )}
+              {task.column === "done" && (
+                <DropdownMenuItem onClick={() => onReopen(task)}>
+                  <RiArrowGoBackLine className="h-3.5 w-3.5" />
+                  Reopen
+                </DropdownMenuItem>
+              )}
+              {!isStaged && (
+                <DropdownMenuItem onClick={() => onRemoveFromBoard(task)}>
+                  <RiLogoutBoxRLine className="h-3.5 w-3.5" />
+                  Remove from board
+                </DropdownMenuItem>
+              )}
+              {isStaged && (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem variant="destructive" onClick={() => onDeleteDraft(task)}>
+                    <RiDeleteBinLine className="h-3.5 w-3.5" />
+                    Delete
+                  </DropdownMenuItem>
+                </>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/tasks/TaskColumn.tsx
+++ b/dashboard/src/components/tasks/TaskColumn.tsx
@@ -2,6 +2,7 @@
 
 import { useDroppable } from "@dnd-kit/core";
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import { RiAddLine } from "@remixicon/react";
 import { cn } from "@/lib/utils";
 import type { Task } from "@/lib/api";
 
@@ -11,10 +12,12 @@ interface TaskColumnProps {
   tasks: Task[];
   /** Whether the current drag can drop here (undefined = no drag active). */
   droppable?: boolean;
+  /** Staging lanes only: create a task directly in this lane. */
+  onAddTask?: () => void;
   children: React.ReactNode;
 }
 
-export function TaskColumn({ id, name, tasks, droppable, children }: TaskColumnProps) {
+export function TaskColumn({ id, name, tasks, droppable, onAddTask, children }: TaskColumnProps) {
   const { setNodeRef, isOver } = useDroppable({
     id,
     disabled: droppable === false,
@@ -41,6 +44,18 @@ export function TaskColumn({ id, name, tasks, droppable, children }: TaskColumnP
           )}
         >
           {children}
+          {onAddTask && (
+            <button
+              onClick={onAddTask}
+              className={cn(
+                "flex items-center gap-1 rounded-md px-2 py-1.5 text-xs",
+                "text-muted-foreground/70 hover:bg-muted hover:text-foreground",
+              )}
+            >
+              <RiAddLine className="h-3.5 w-3.5" />
+              Task
+            </button>
+          )}
         </div>
       </SortableContext>
     </div>

--- a/dashboard/src/components/tasks/TaskColumn.tsx
+++ b/dashboard/src/components/tasks/TaskColumn.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useDroppable } from "@dnd-kit/core";
+import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import { cn } from "@/lib/utils";
+import type { Task } from "@/lib/api";
+
+interface TaskColumnProps {
+  id: string;
+  name: string;
+  tasks: Task[];
+  /** Whether the current drag can drop here (undefined = no drag active). */
+  droppable?: boolean;
+  children: React.ReactNode;
+}
+
+export function TaskColumn({ id, name, tasks, droppable, children }: TaskColumnProps) {
+  const { setNodeRef, isOver } = useDroppable({
+    id,
+    disabled: droppable === false,
+  });
+
+  return (
+    <div className="flex w-64 shrink-0 flex-col">
+      <div className="mb-2 flex items-baseline gap-2 px-1">
+        <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+          {name}
+        </span>
+        <span className="text-xs text-muted-foreground/70">{tasks.length}</span>
+      </div>
+      <SortableContext
+        items={tasks.map((t) => t.conversation_id)}
+        strategy={verticalListSortingStrategy}
+      >
+        <div
+          ref={setNodeRef}
+          className={cn(
+            "flex min-h-24 flex-1 flex-col gap-1.5 rounded-lg p-1 transition-colors",
+            isOver && droppable !== false && "bg-muted/60",
+            droppable === false && "opacity-40",
+          )}
+        >
+          {children}
+        </div>
+      </SortableContext>
+    </div>
+  );
+}

--- a/dashboard/src/components/tasks/TaskDialog.tsx
+++ b/dashboard/src/components/tasks/TaskDialog.tsx
@@ -19,7 +19,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import type { BoardLane, Task } from "@/lib/api";
+import { fetchAgentModels, type AgentModel, type BoardLane, type Task } from "@/lib/api";
 
 interface TaskDialogProps {
   open: boolean;
@@ -28,13 +28,18 @@ interface TaskDialogProps {
   /** When set, the dialog edits an existing draft instead of creating one. */
   task?: Task | null;
   defaultLane?: string;
-  onSubmit: (values: { title: string; prompt: string; lane: string }, start: boolean) => Promise<void>;
+  onSubmit: (
+    values: { title: string; prompt: string; lane: string; model: string },
+    start: boolean,
+  ) => Promise<void>;
 }
 
 export function TaskDialog({ open, onOpenChange, lanes, task, defaultLane, onSubmit }: TaskDialogProps) {
   const [title, setTitle] = useState("");
   const [prompt, setPrompt] = useState("");
   const [lane, setLane] = useState(lanes[0]?.id ?? "todo");
+  const [model, setModel] = useState("");
+  const [models, setModels] = useState<AgentModel[]>([]);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -43,20 +48,42 @@ export function TaskDialog({ open, onOpenChange, lanes, task, defaultLane, onSub
       setTitle(task?.title ?? "");
       setPrompt(task?.prompt ?? "");
       setLane(task?.task_lane ?? defaultLane ?? lanes[0]?.id ?? "todo");
+      setModel(task?.model ?? "");
       setError(null);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, task]);
 
+  // Load the model catalog once per dialog open; default new tasks to the
+  // backend's default model so the selection is always explicit.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    fetchAgentModels()
+      .then((catalog) => {
+        if (cancelled) return;
+        setModels(catalog.models || []);
+        setModel((current) =>
+          current && (catalog.models || []).some((m) => m.id === current)
+            ? current
+            : catalog.default_model || catalog.models?.[0]?.id || "",
+        );
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
   const submit = async (start: boolean) => {
     if (!prompt.trim()) {
-      setError("A prompt is required");
+      setError("Details are required");
       return;
     }
     setBusy(true);
     setError(null);
     try {
-      await onSubmit({ title: title.trim(), prompt: prompt.trim(), lane }, start);
+      await onSubmit({ title: title.trim(), prompt: prompt.trim(), lane, model }, start);
       onOpenChange(false);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Something went wrong");
@@ -69,7 +96,7 @@ export function TaskDialog({ open, onOpenChange, lanes, task, defaultLane, onSub
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
-          <DialogTitle>{task ? "Edit task" : "New task"}</DialogTitle>
+          <DialogTitle>{task ? "Task details" : "New task"}</DialogTitle>
         </DialogHeader>
         <div className="space-y-3">
           <div className="space-y-1.5">
@@ -82,30 +109,47 @@ export function TaskDialog({ open, onOpenChange, lanes, task, defaultLane, onSub
             />
           </div>
           <div className="space-y-1.5">
-            <Label htmlFor="task-prompt">Prompt</Label>
+            <Label htmlFor="task-details">Details</Label>
             <Textarea
-              id="task-prompt"
+              id="task-details"
               value={prompt}
               onChange={(e) => setPrompt(e.target.value)}
               placeholder="What should the agent do?"
               rows={6}
             />
           </div>
-          {lanes.length > 1 && (
-            <div className="space-y-1.5">
-              <Label>Lane</Label>
-              <Select value={lane} onValueChange={setLane}>
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {lanes.map((l) => (
-                    <SelectItem key={l.id} value={l.id}>{l.name}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          )}
+          <div className="flex gap-3">
+            {lanes.length > 1 && (
+              <div className="flex-1 space-y-1.5">
+                <Label>Lane</Label>
+                <Select value={lane} onValueChange={setLane}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {lanes.map((l) => (
+                      <SelectItem key={l.id} value={l.id}>{l.name}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+            {models.length > 0 && (
+              <div className="flex-1 space-y-1.5">
+                <Label>Model</Label>
+                <Select value={model} onValueChange={setModel}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="Default" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {models.map((m) => (
+                      <SelectItem key={m.id} value={m.id}>{m.label}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+          </div>
           {error && <p className="text-xs text-destructive">{error}</p>}
         </div>
         <DialogFooter>

--- a/dashboard/src/components/tasks/TaskDialog.tsx
+++ b/dashboard/src/components/tasks/TaskDialog.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { BoardLane, Task } from "@/lib/api";
+
+interface TaskDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  lanes: BoardLane[];
+  /** When set, the dialog edits an existing draft instead of creating one. */
+  task?: Task | null;
+  defaultLane?: string;
+  onSubmit: (values: { title: string; prompt: string; lane: string }, start: boolean) => Promise<void>;
+}
+
+export function TaskDialog({ open, onOpenChange, lanes, task, defaultLane, onSubmit }: TaskDialogProps) {
+  const [title, setTitle] = useState("");
+  const [prompt, setPrompt] = useState("");
+  const [lane, setLane] = useState(lanes[0]?.id ?? "todo");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      setTitle(task?.title ?? "");
+      setPrompt(task?.prompt ?? "");
+      setLane(task?.task_lane ?? defaultLane ?? lanes[0]?.id ?? "todo");
+      setError(null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, task]);
+
+  const submit = async (start: boolean) => {
+    if (!prompt.trim()) {
+      setError("A prompt is required");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    try {
+      await onSubmit({ title: title.trim(), prompt: prompt.trim(), lane }, start);
+      onOpenChange(false);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Something went wrong");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{task ? "Edit task" : "New task"}</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="task-title">Title</Label>
+            <Input
+              id="task-title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Optional"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="task-prompt">Prompt</Label>
+            <Textarea
+              id="task-prompt"
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              placeholder="What should the agent do?"
+              rows={6}
+            />
+          </div>
+          {lanes.length > 1 && (
+            <div className="space-y-1.5">
+              <Label>Lane</Label>
+              <Select value={lane} onValueChange={setLane}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {lanes.map((l) => (
+                    <SelectItem key={l.id} value={l.id}>{l.name}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+          {error && <p className="text-xs text-destructive">{error}</p>}
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={busy}>
+            Cancel
+          </Button>
+          <Button variant="outline" onClick={() => submit(false)} disabled={busy}>
+            {task ? "Save" : "Add"}
+          </Button>
+          <Button onClick={() => submit(true)} disabled={busy}>
+            {task ? "Save & start" : "Add & start"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/dashboard/src/components/tasks/transitions.ts
+++ b/dashboard/src/components/tasks/transitions.ts
@@ -5,21 +5,30 @@ import type { Task } from "@/lib/api";
  * the same rules authoritatively — keep the two in sync.
  *
  * Columns: any staging lane id, "working", "needs_input", "done".
+ * Staging lanes hold two kinds of cards: *drafts* (never run) and *parked*
+ * chats (started, shelved to recontinue later).
  *
- * | From \ To    | staged lane | working      | needs_input | done |
- * |--------------|-------------|--------------|-------------|------|
- * | staged lane  | yes         | yes (=start) | no          | no   |
- * | working      | no          | —            | (derived)   | yes  |
- * | needs_input  | no          | (by replying)| —           | yes  |
- * | done         | no          | no           | no          | —    |
+ * | From \ To    | staged lane      | working            | needs_input | done          |
+ * |--------------|------------------|--------------------|-------------|---------------|
+ * | staged lane  | yes              | draft only (=start)| no          | parked only   |
+ * | working      | no               | —                  | (derived)   | yes           |
+ * | needs_input  | yes (=park)      | (by replying)      | —           | yes           |
+ * | done         | no               | no                 | no          | — (reopen via menu) |
  */
 export function canMove(task: Task, from: string, to: string, laneIds: string[]): boolean {
   if (from === to) return laneIds.includes(from); // same-lane reorder only
   const fromStaged = laneIds.includes(from);
   const toStaged = laneIds.includes(to);
+  const isDraft = !task.status;
 
-  if (fromStaged) return toStaged || to === "working";
-  if (from === "working" || from === "needs_input") return to === "done";
+  if (fromStaged) {
+    if (toStaged) return true;
+    if (to === "working") return isDraft; // parked chats restart by replying in the chat
+    if (to === "done") return !isDraft;
+    return false;
+  }
+  if (from === "needs_input") return to === "done" || toStaged; // park to recontinue later
+  if (from === "working") return to === "done";
   return false; // done: reopen via context menu only
 }
 

--- a/dashboard/src/components/tasks/transitions.ts
+++ b/dashboard/src/components/tasks/transitions.ts
@@ -1,0 +1,32 @@
+import type { Task } from "@/lib/api";
+
+/**
+ * The board's allowed-transition matrix. The backend PATCH handler enforces
+ * the same rules authoritatively — keep the two in sync.
+ *
+ * Columns: any staging lane id, "working", "needs_input", "done".
+ *
+ * | From \ To    | staged lane | working      | needs_input | done |
+ * |--------------|-------------|--------------|-------------|------|
+ * | staged lane  | yes         | yes (=start) | no          | no   |
+ * | working      | no          | —            | (derived)   | yes  |
+ * | needs_input  | no          | (by replying)| —           | yes  |
+ * | done         | no          | no           | no          | —    |
+ */
+export function canMove(task: Task, from: string, to: string, laneIds: string[]): boolean {
+  if (from === to) return laneIds.includes(from); // same-lane reorder only
+  const fromStaged = laneIds.includes(from);
+  const toStaged = laneIds.includes(to);
+
+  if (fromStaged) return toStaged || to === "working";
+  if (from === "working" || from === "needs_input") return to === "done";
+  return false; // done: reopen via context menu only
+}
+
+/** Midpoint rank for dropping between two neighbors in a staged lane. */
+export function rankBetween(before: number | null, after: number | null): number {
+  if (before === null && after === null) return -Date.now();
+  if (before === null) return (after as number) - 1;
+  if (after === null) return before + 1;
+  return (before + after) / 2;
+}

--- a/dashboard/src/lib/TaskAttentionContext.tsx
+++ b/dashboard/src/lib/TaskAttentionContext.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { usePathname } from "next/navigation";
+import { useSession } from "next-auth/react";
+import { fetchNeedsInputCount } from "./api";
+
+const POLL_INTERVAL_MS = 5000;
+
+interface TaskAttentionValue {
+  /** Number of the user's board tasks currently waiting on their input. */
+  needsInputCount: number;
+  refresh: () => void;
+}
+
+const TaskAttentionContext = createContext<TaskAttentionValue>({
+  needsInputCount: 0,
+  refresh: () => {},
+});
+
+export function useTaskAttention() {
+  return useContext(TaskAttentionContext);
+}
+
+/** Strip any previous "(n) " prefix so counts never stack. */
+function baseTitle(title: string): string {
+  return title.replace(/^\(\d+\)\s*/, "");
+}
+
+/**
+ * Short two-note ping via WebAudio — no asset to ship. The AudioContext is
+ * created lazily on the first user gesture (autoplay policy); if it's still
+ * locked we skip silently.
+ */
+function createPinger() {
+  let ctx: AudioContext | null = null;
+
+  const ensureContext = () => {
+    if (typeof window === "undefined" || !("AudioContext" in window)) return;
+    ctx ??= new AudioContext();
+    if (ctx.state === "suspended") ctx.resume().catch(() => {});
+  };
+
+  const play = () => {
+    if (!ctx || ctx.state !== "running") return;
+    const now = ctx.currentTime;
+    for (const [freq, at] of [[880, 0], [1174.66, 0.09]] as const) {
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.type = "sine";
+      osc.frequency.value = freq;
+      gain.gain.setValueAtTime(0.0001, now + at);
+      gain.gain.exponentialRampToValueAtTime(0.06, now + at + 0.015);
+      gain.gain.exponentialRampToValueAtTime(0.0001, now + at + 0.18);
+      osc.connect(gain).connect(ctx.destination);
+      osc.start(now + at);
+      osc.stop(now + at + 0.2);
+    }
+  };
+
+  return { ensureContext, play };
+}
+
+export function TaskAttentionProvider({ children }: { children: React.ReactNode }) {
+  const { status } = useSession();
+  const pathname = usePathname();
+  const [needsInputCount, setNeedsInputCount] = useState(0);
+  const prevCountRef = useRef<number | null>(null);
+  const pingerRef = useRef<ReturnType<typeof createPinger> | null>(null);
+
+  // Unlock audio on the first user gesture.
+  useEffect(() => {
+    pingerRef.current ??= createPinger();
+    const unlock = () => pingerRef.current?.ensureContext();
+    window.addEventListener("pointerdown", unlock, { once: true });
+    return () => window.removeEventListener("pointerdown", unlock);
+  }, []);
+
+  const refresh = useCallback(async () => {
+    try {
+      const count = await fetchNeedsInputCount();
+      const prev = prevCountRef.current;
+      prevCountRef.current = count;
+      setNeedsInputCount(count);
+      // Ding only on transitions into needing input, never on first load,
+      // and only in the visible tab — push notifications cover the rest.
+      if (prev !== null && count > prev && document.visibilityState === "visible") {
+        pingerRef.current?.play();
+      }
+    } catch {
+      // Transient poll failures keep the last known count.
+    }
+  }, []);
+
+  useEffect(() => {
+    if (status !== "authenticated") return;
+    refresh();
+    const interval = setInterval(refresh, POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [status, refresh]);
+
+  // Tab title "(n) " prefix — re-applied on navigation since Next resets
+  // titles (the delayed pass runs after Next's own metadata update).
+  useEffect(() => {
+    const apply = () => {
+      const title = baseTitle(document.title);
+      document.title = needsInputCount > 0 ? `(${needsInputCount}) ${title}` : title;
+    };
+    apply();
+    const timer = setTimeout(apply, 500);
+    return () => clearTimeout(timer);
+  }, [needsInputCount, pathname]);
+
+  return (
+    <TaskAttentionContext.Provider value={{ needsInputCount, refresh }}>
+      {children}
+    </TaskAttentionContext.Provider>
+  );
+}

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -45,6 +45,7 @@ export interface Conversation {
   project_id?: string | null;
   title_edited?: boolean;
   deleted?: boolean;
+  task_status?: "todo" | "active" | "done" | null;
   messages?: Array<{
     role: "user" | "assistant";
     content: string;
@@ -940,4 +941,116 @@ export async function* streamChat(
       // Ignore cancel errors
     }
   }
+}
+
+// ── Tasks board ──────────────────────────────────────────────────────────────
+
+export interface BoardLane {
+  id: string;
+  name: string;
+  order: number;
+}
+
+export interface Task {
+  conversation_id: string;
+  title: string | null;
+  prompt: string;
+  status: string | null;
+  task_status: "todo" | "active" | "done";
+  task_lane: string | null;
+  task_rank: number | null;
+  /** Derived column: a lane id, "working", "needs_input", or "done". */
+  column: string;
+  total_turns: number;
+  started_at: string | null;
+  finished_at: string | null;
+  task_created_at: string | null;
+  task_staged_at: string | null;
+  task_started_at: string | null;
+  task_done_at: string | null;
+}
+
+export interface TasksBoardResponse {
+  lanes: BoardLane[];
+  tasks: Task[];
+  counts: Record<string, number>;
+}
+
+export interface BoardSettings {
+  prompt: string;
+  lanes: BoardLane[];
+}
+
+export async function fetchTasksBoard(): Promise<TasksBoardResponse> {
+  const res = await fetch(`${API_BASE}/api/tasks`);
+  if (!res.ok) throw new Error(`Failed to fetch tasks: ${res.status}`);
+  return res.json();
+}
+
+export async function fetchNeedsInputCount(): Promise<number> {
+  const res = await fetch(`${API_BASE}/api/tasks/needs-input-count`);
+  if (!res.ok) throw new Error(`Failed to fetch needs-input count: ${res.status}`);
+  const data = await res.json();
+  return data.count ?? 0;
+}
+
+export async function createTask(params: {
+  prompt: string;
+  title?: string;
+  lane?: string;
+}): Promise<{ task: Task }> {
+  const res = await fetch(`${API_BASE}/api/tasks`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(params),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.error || `Failed to create task: ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function updateTask(
+  conversationId: string,
+  updates: {
+    task_status?: "todo" | "active" | "done" | null;
+    task_lane?: string;
+    task_rank?: number;
+    prompt?: string;
+    title?: string;
+  },
+): Promise<{ task: Task | null }> {
+  const res = await fetch(`${API_BASE}/api/tasks/${conversationId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(updates),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.error || `Failed to update task: ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function fetchBoardSettings(): Promise<BoardSettings> {
+  const res = await fetch(`${API_BASE}/api/tasks/board-settings`);
+  if (!res.ok) throw new Error(`Failed to fetch board settings: ${res.status}`);
+  return res.json();
+}
+
+export async function saveBoardSettings(settings: {
+  prompt: string;
+  lanes: Array<{ id?: string; name: string }>;
+}): Promise<BoardSettings & { migrated: number }> {
+  const res = await fetch(`${API_BASE}/api/tasks/board-settings`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(settings),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.error || `Failed to save board settings: ${res.status}`);
+  }
+  return res.json();
 }

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -955,6 +955,7 @@ export interface Task {
   conversation_id: string;
   title: string | null;
   prompt: string;
+  model: string | null;
   status: string | null;
   task_status: "todo" | "active" | "done";
   task_lane: string | null;
@@ -998,6 +999,7 @@ export async function createTask(params: {
   prompt: string;
   title?: string;
   lane?: string;
+  model?: string;
 }): Promise<{ task: Task }> {
   const res = await fetch(`${API_BASE}/api/tasks`, {
     method: "POST",
@@ -1019,6 +1021,7 @@ export async function updateTask(
     task_rank?: number;
     prompt?: string;
     title?: string;
+    model?: string;
   },
 ): Promise<{ task: Task | null }> {
   const res = await fetch(`${API_BASE}/api/tasks/${conversationId}`, {

--- a/dashboard/src/lib/push.ts
+++ b/dashboard/src/lib/push.ts
@@ -1,0 +1,85 @@
+// Web push subscription helpers (tasks-board notifications).
+
+import { basePath } from "./api";
+
+const API_BASE = basePath;
+
+export type PushState = "unsupported" | "denied" | "subscribed" | "unsubscribed";
+
+export function isPushSupported(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    "serviceWorker" in navigator &&
+    "PushManager" in window &&
+    window.isSecureContext
+  );
+}
+
+/** Whether the backend has VAPID keys configured (404 = push disabled). */
+export async function isPushConfigured(): Promise<boolean> {
+  try {
+    const res = await fetch(`${API_BASE}/api/push/vapid-public-key`);
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+export async function getPushState(): Promise<PushState> {
+  if (!isPushSupported()) return "unsupported";
+  if (Notification.permission === "denied") return "denied";
+  const registration = await navigator.serviceWorker.getRegistration(`${basePath}/sw.js`);
+  const subscription = await registration?.pushManager.getSubscription();
+  return subscription ? "subscribed" : "unsubscribed";
+}
+
+function urlBase64ToUint8Array(base64: string): Uint8Array {
+  const padding = "=".repeat((4 - (base64.length % 4)) % 4);
+  const raw = atob((base64 + padding).replace(/-/g, "+").replace(/_/g, "/"));
+  return Uint8Array.from(raw, (c) => c.charCodeAt(0));
+}
+
+/** Must be called from a user gesture (permission prompt). */
+export async function subscribeToPush(): Promise<PushState> {
+  if (!isPushSupported()) return "unsupported";
+
+  const registration = await navigator.serviceWorker.register(`${basePath}/sw.js`);
+  const permission = await Notification.requestPermission();
+  if (permission !== "granted") return permission === "denied" ? "denied" : "unsubscribed";
+
+  const keyRes = await fetch(`${API_BASE}/api/push/vapid-public-key`);
+  if (!keyRes.ok) throw new Error("Push is not configured on the server");
+  const { key } = await keyRes.json();
+
+  const subscription =
+    (await registration.pushManager.getSubscription()) ??
+    (await registration.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: urlBase64ToUint8Array(key) as BufferSource,
+    }));
+
+  const res = await fetch(`${API_BASE}/api/push/subscriptions`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ subscription: subscription.toJSON() }),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.error || `Failed to save subscription: ${res.status}`);
+  }
+  return "subscribed";
+}
+
+export async function unsubscribeFromPush(): Promise<PushState> {
+  const registration = await navigator.serviceWorker.getRegistration(`${basePath}/sw.js`);
+  const subscription = await registration?.pushManager.getSubscription();
+  if (!subscription) return "unsubscribed";
+
+  await fetch(`${API_BASE}/api/push/subscriptions`, {
+    method: "DELETE",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ endpoint: subscription.endpoint }),
+  }).catch(() => {});
+  await subscription.unsubscribe();
+  return "unsubscribed";
+}

--- a/multiply.py
+++ b/multiply.py
@@ -1,9 +1,0 @@
-def multiply_three(a, b, c):
-    return a * b * c
-
-
-if __name__ == "__main__":
-    x = 2
-    y = 3
-    z = 5
-    print(f"The product of {x}, {y}, and {z} is {multiply_three(x, y, z)}")

--- a/multiply.py
+++ b/multiply.py
@@ -1,0 +1,9 @@
+def multiply_three(a, b, c):
+    return a * b * c
+
+
+if __name__ == "__main__":
+    x = 2
+    y = 3
+    z = 5
+    print(f"The product of {x}, {y}, and {z} is {multiply_three(x, y, z)}")

--- a/observability/db.py
+++ b/observability/db.py
@@ -95,6 +95,15 @@ async def init_observability():
     await _db.conversations.create_index("deleted")
     await _db.conversations.create_index("project_id")
 
+    # Tasks board: per-user board queries + needs-input counts
+    await _db.conversations.create_index(
+        [("metadata.user_name", 1), ("task_status", 1), ("status", 1)],
+    )
+
+    # Web push subscriptions (tasks board attention) — one doc per browser
+    await _db.push_subscriptions.create_index("subscription.endpoint", unique=True)
+    await _db.push_subscriptions.create_index("user_email")
+
     # Projects collection (chat organization)
     await _db.projects.create_index("project_id", unique=True)
     await _db.projects.create_index("created_by")

--- a/observability/observer.py
+++ b/observability/observer.py
@@ -357,6 +357,10 @@ class ConversationObserver:
             duration_ms=duration_ms,
         ))
 
+        # Board tasks: notify the owner that the agent awaits their input
+        from observability.push import fire_task_push
+        fire_task_push(self.db, self.conversation_id)
+
     async def record_error(self, error: str):
         """Mark conversation as errored."""
         self._stop_heartbeat()
@@ -375,6 +379,9 @@ class ConversationObserver:
             )
         except Exception as e:
             logger.warning("Observability: failed to record error: %s", e)
+
+        from observability.push import fire_task_push
+        fire_task_push(self.db, self.conversation_id)
 
     async def record_account(self, account_email: str):
         """Record which Claude account is processing this conversation."""
@@ -405,6 +412,9 @@ class ConversationObserver:
         except Exception as e:
             logger.warning("Observability: failed to mark conversation as interrupted: %s", e)
 
+        from observability.push import fire_task_push
+        fire_task_push(self.db, self.conversation_id)
+
     async def _run_title_topic_enrichment(self, final_response: str):
         """Generate title and topic for the conversation via LLM."""
         try:
@@ -417,9 +427,16 @@ class ConversationObserver:
                 _classify_topic_llm(prompt, response_snippet),
             )
 
+            # Never clobber a user-provided title (rename PATCH / task drafts
+            # set title_edited) — only enrich the topic in that case.
+            existing = await self.db.conversations.find_one(
+                {"conversation_id": self.conversation_id}, {"title_edited": 1})
+            update_fields = {"topic": topic}
+            if not (existing or {}).get("title_edited"):
+                update_fields["title"] = title
             await self.db.conversations.update_one(
                 {"conversation_id": self.conversation_id},
-                {"$set": {"title": title, "topic": topic}},
+                {"$set": update_fields},
             )
             logger.info("Observability: enrichment complete for %s: title=%r topic=%s",
                          self.conversation_id, title, topic)

--- a/observability/push.py
+++ b/observability/push.py
@@ -1,0 +1,129 @@
+"""Web push notifications for tasks-board attention.
+
+Subscriptions live in the `push_subscriptions` collection — one doc per
+browser, unique by endpoint (see api/push_routes.py).
+
+Pushes fire when a board task's conversation leaves "running" (the user's
+turn). Callers hook this in fire-and-forget style; every failure is swallowed
+into logs so push can never break a chat turn.
+"""
+
+import asyncio
+import json
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+# Statuses that mean the agent stopped mid-flight rather than finishing.
+_STATUS_TITLES = {
+    "completed": "Task needs your input",
+    "error": "Task hit an error",
+    "interrupted": "Task was interrupted",
+}
+
+
+def _vapid_config() -> tuple[str, str] | None:
+    private_key = os.environ.get("VAPID_PRIVATE_KEY", "").strip()
+    subject = os.environ.get("VAPID_SUBJECT", "").strip()
+    if not private_key:
+        return None
+    return private_key, subject or "mailto:admin@localhost"
+
+
+def vapid_public_key() -> str | None:
+    """Derive the base64url public key for PushManager.subscribe()."""
+    config = _vapid_config()
+    if not config:
+        return None
+    try:
+        from py_vapid import Vapid
+        from py_vapid.utils import b64urlencode
+        from cryptography.hazmat.primitives import serialization
+
+        vapid = Vapid.from_string(private_key=config[0])
+        raw = vapid.public_key.public_bytes(
+            serialization.Encoding.X962,
+            serialization.PublicFormat.UncompressedPoint,
+        )
+        return b64urlencode(raw)
+    except Exception as e:
+        logger.warning("Push: failed to derive VAPID public key: %s", e)
+        return None
+
+
+def _send_one(subscription: dict, payload: str, private_key: str, subject: str):
+    """Blocking single-subscription send — run via asyncio.to_thread."""
+    from pywebpush import webpush
+
+    webpush(
+        subscription_info=subscription,
+        data=payload,
+        vapid_private_key=private_key,
+        vapid_claims={"sub": subject},
+    )
+
+
+async def send_task_needs_input_push(db, conversation_id: str):
+    """Notify a board task's owner that the agent stopped and awaits them."""
+    try:
+        config = _vapid_config()
+        if not config or db is None:
+            return
+        private_key, subject = config
+
+        conversation = await db.conversations.find_one(
+            {"conversation_id": conversation_id},
+            {"task_status": 1, "status": 1, "title": 1, "prompt": 1, "metadata.user_name": 1},
+        )
+        if not conversation or conversation.get("task_status") != "active":
+            return
+        owner = (conversation.get("metadata") or {}).get("user_name")
+        if not owner:
+            return
+
+        subscriptions = await db.push_subscriptions.find(
+            {"user_email": owner}).to_list(50)
+        if not subscriptions:
+            return
+
+        status = conversation.get("status") or "completed"
+        base_url = os.environ.get("PUBLIC_BASE_URL", "").rstrip("/")
+        payload = json.dumps({
+            "title": _STATUS_TITLES.get(status, _STATUS_TITLES["completed"]),
+            "body": (conversation.get("title") or conversation.get("prompt") or "")[:120],
+            "tag": conversation_id,
+            "url": f"{base_url}/chat?continue={conversation_id}",
+        })
+
+        from pywebpush import WebPushException
+
+        expired: list[str] = []
+        for entry in subscriptions:
+            subscription = entry.get("subscription") or {}
+            try:
+                await asyncio.to_thread(_send_one, subscription, payload, private_key, subject)
+            except WebPushException as e:
+                status_code = getattr(e.response, "status_code", None)
+                if status_code in (404, 410):
+                    expired.append(subscription.get("endpoint", ""))
+                else:
+                    logger.warning("Push: send failed for %s: %s", owner, e)
+            except Exception as e:
+                logger.warning("Push: send failed for %s: %s", owner, e)
+
+        if expired:
+            await db.push_subscriptions.delete_many(
+                {"subscription.endpoint": {"$in": expired}},
+            )
+    except Exception as e:
+        logger.warning("Push: notification for %s failed: %s", conversation_id, e)
+
+
+def fire_task_push(db, conversation_id: str):
+    """Fire-and-forget wrapper safe to call from status-transition paths."""
+    try:
+        asyncio.create_task(send_task_needs_input_push(db, conversation_id))
+    except RuntimeError:
+        # No running loop (e.g. sync shutdown path) — skip.
+        pass

--- a/recovery.py
+++ b/recovery.py
@@ -84,8 +84,16 @@ async def _run_recovery_check():
 
     # Mark stale conversations older than recovery window as 'interrupted'
     try:
+        stale_filter = {**stale_query, "started_at": {"$lt": recovery_cutoff}}
+        # Board tasks flipping out of "running" here bypass the observer, so
+        # capture them first to fire their needs-input pushes after the update.
+        stale_task_ids = [
+            doc["conversation_id"]
+            async for doc in db.conversations.find(
+                {**stale_filter, "task_status": "active"}, {"conversation_id": 1})
+        ]
         result = await db.conversations.update_many(
-            {**stale_query, "started_at": {"$lt": recovery_cutoff}},
+            stale_filter,
             {"$set": {
                 "status": "interrupted",
                 "finished_at": now,
@@ -97,6 +105,9 @@ async def _run_recovery_check():
                 "[RECOVERY] Marked %d stale conversation(s) as 'interrupted'",
                 result.modified_count,
             )
+        from observability.push import fire_task_push
+        for conversation_id in stale_task_ids:
+            fire_task_push(db, conversation_id)
     except Exception as e:
         logger.exception("[RECOVERY] Failed to mark stale conversations: %s", e)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,8 @@ pytesseract>=0.3.10
 apscheduler>=3.10.0
 openai>=1.50.0
 cryptography>=41.0.0
+# Web push notifications (tasks board attention)
+pywebpush>=2.0
 google-auth>=2.22.0
 google-api-python-client>=2.100.0
 boto3>=1.28.0

--- a/sum.py
+++ b/sum.py
@@ -1,0 +1,8 @@
+def sum_two_numbers(a, b):
+    return a + b
+
+
+if __name__ == "__main__":
+    x = 5
+    y = 7
+    print(f"The sum of {x} and {y} is {sum_two_numbers(x, y)}")

--- a/sum.py
+++ b/sum.py
@@ -1,8 +1,0 @@
-def sum_two_numbers(a, b):
-    return a + b
-
-
-if __name__ == "__main__":
-    x = 5
-    y = 7
-    print(f"The sum of {x} and {y} is {sum_two_numbers(x, y)}")


### PR DESCRIPTION
## What

A task-management layer over dashboard chats, so parallel agent work is visible in one place instead of scattered across tabs: which chats need input, which are running, and what's queued up.

**Core model: a task IS a chat (1:1).** Conversations gain `task_status` (`todo`/`active`/`done`) + `task_lane`/`task_rank`. **Working vs Needs-input is derived live** from `conversation.status` — never stored — so replying to a waiting task flips it back to Working with zero task writes and no state-sync bugs.

## Features

- **Board** (`/tasks`): user-customizable staging lanes (add/rename/reorder — e.g. Backlog → Today) + fixed Working / Needs input / Done columns
- **Drag & drop** (@dnd-kit): across lanes, lane → Working fires the agent (auto-sends the draft prompt via the existing `autoSend` path — zero ChatPanel changes); illegal drops don't activate; optimistic UI with rollback; click actions as mobile/a11y fallback
- **Per-user board prompt**: set your role/context once in board settings; injected into every turn of your board tasks
- **Attention system**: sidebar badge with needs-input count on every page, browser tab `(n)` prefix, sound ping on new needs-input (visible tab only)
- **Web push**: service worker + VAPID; OS notifications even with the tab closed, firing from every status-leaves-running path (finish / error / interrupt / recovery bulk-sweep); expired subscriptions auto-pruned
- **Add to board** / Remove from board in the chat context menu (sidebar, Activity, chat header)

## Also fixes

- Title enrichment clobbering user-set titles at conversation finish (`title_edited` guard)
- Staged drafts excluded from Activity list, stats, and the title backfill

## Deploy notes

- `pip install -r requirements.txt` (adds `pywebpush`)
- New env: `VAPID_PRIVATE_KEY` + `VAPID_SUBJECT` (generation command in `.env.example`); push toggle hides itself when unset
- New Mongo collection `push_subscriptions` + one conversations index (auto-created at startup)

## Tested

Full lifecycle verified against a live backend: create → lane moves → illegal transitions rejected → start (todo→active, no duplicated first message) → needs-input → reply → done → reopen. Board-prompt injection verified end-to-end through a real agent run. UI verified in-browser. `tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)