### PR TITLE
feat: enable SSH from loma-backend container to ubuntu@98.83.133.237

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.12-slim
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends nodejs npm git curl ca-certificates \
-    poppler-utils tesseract-ocr \
+    poppler-utils tesseract-ocr openssh-client \
     && OPENCODE_INSTALL_DIR=/usr/local/bin sh -c 'curl -fsSL https://opencode.ai/install | bash' \
     && ln -sf /root/.opencode/bin/opencode /usr/local/bin/opencode \
     && opencode --version \
@@ -31,5 +31,11 @@ ENV WEBHOOK_PORT=3000
 # ephemeral writable overlay. Exposed as $LOMA_WORKSPACE_DIR to the agent process.
 ENV LOMA_WORKSPACE_DIR=/opt/loma-workspace
 RUN mkdir -p /opt/loma-workspace
+# SSH config for reaching the ops host. The host's ~/.ssh is bind-mounted
+# read-only at /root/.ssh-host (see docker-compose.yml); /root/.ssh itself
+# stays writable so known_hosts can persist.
+RUN mkdir -p /root/.ssh \
+    && printf 'Host 98.83.133.237\n  User ubuntu\n  IdentityFile /root/.ssh-host/id_rsa\n  StrictHostKeyChecking accept-new\n' > /root/.ssh/config \
+    && chmod 700 /root/.ssh && chmod 600 /root/.ssh/config
 EXPOSE 3000
 CMD ["python", "app.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,10 @@ services:
       - loma-claude-users:/opt/claude-users
       - loma-workspace:/opt/loma-workspace
       - ${LOMA_SECRETS_DIR:-/home/ubuntu/secrets}:/home/ubuntu/secrets:ro
+      # Host SSH key dir (key authorized on 98.83.133.237), mounted read-only at a
+      # side path so the container keeps a writable /root/.ssh for known_hosts.
+      # Override LOMA_SSH_DIR if the key lives elsewhere on the host.
+      - ${LOMA_SSH_DIR:-/home/ubuntu/.ssh}:/root/.ssh-host:ro
     restart: unless-stopped
 
   loma-dashboard:


### PR DESCRIPTION
## Summary
- Install `openssh-client` in the `loma-backend` image so the app can run `ssh`/`scp`
- Bind-mount the host's `~/.ssh` (configurable via `LOMA_SSH_DIR`, default `/home/ubuntu/.ssh`) read-only into the container at `/root/.ssh-host`
- Bake an SSH config in the image so the app can simply run `ssh 98.83.133.237` (user `ubuntu`, identity `/root/.ssh-host/id_rsa`, `StrictHostKeyChecking accept-new`)

## Context
The loma-backend container needs to SSH to the ops host `ubuntu@98.83.133.237`. The deployment host's `~/.ssh` key pair is already authorized on that server (`id_rsa.pub` is in its `authorized_keys`), but the container had no SSH client and no access to the key. Requested by Adarsh via the Loma dashboard chat.

## Changes
- `Dockerfile` — add `openssh-client` to the apt install; create `/root/.ssh/config` with a `Host 98.83.133.237` entry pointing at the mounted key
- `docker-compose.yml` — mount `${LOMA_SSH_DIR:-/home/ubuntu/.ssh}` read-only at `/root/.ssh-host` on `loma-backend`

## Design notes
- The key dir is mounted at `/root/.ssh-host` (not `/root/.ssh`) so the container keeps a **writable** `/root/.ssh` for `known_hosts`; a read-only mount over `/root/.ssh` would break host-key persistence.
- Mount is read-only; the private key never enters the image (no `COPY`), so rebuilt/pushed images contain no secrets.
- If the key lives at `/root/.ssh` on the EC2 host rather than `/home/ubuntu/.ssh`, set `LOMA_SSH_DIR=/root/.ssh` in the deploy `.env` — no code change needed.

## Pre-merge checklist
- [ ] Confirm the **private** key `id_rsa` exists in the host's `~/.ssh` (the `.pub` on the target is only half the pair)
- [ ] Confirm the host path (`/home/ubuntu/.ssh` vs `/root/.ssh`) and set `LOMA_SSH_DIR` if needed

## Testing
- `docker-compose.yml` validated with `yaml.safe_load` (parses cleanly)
- Dockerfile change is an additive apt package + a `printf`-generated config file; not built here (no Docker daemon in the agent sandbox)
- End-to-end verification after deploy: `docker compose exec loma-backend ssh 98.83.133.237 'hostname'` — happy to run this from inside the container once merged and deployed

## Notes
- This PR was generated by Loma based on the request above
- Please review carefully before merging
