### PR TITLE
feat: manual reordering in every tasks-board column

### DIFF
--- a/api/task_routes.py
+++ b/api/task_routes.py
@@ -93,9 +93,30 @@ def derive_column(task: dict, lane_ids: list[str]) -> str:
     return "needs_input"
 
 
+def _effective_rank(task: dict, column: str, lane_ids: list[str]) -> float:
+    """Manual sort key for any column: the stored rank, or a recency fallback
+    (negated epoch → newest first when ascending). Emitting this for every
+    card means a drag-reorder can always slot an explicit rank between two
+    neighbors, in derived columns as well as staging lanes."""
+    rank = task.get("task_rank")
+    if rank is not None:
+        return rank
+    if column in lane_ids:
+        ts = task.get("task_staged_at") or task.get("task_created_at")
+    elif column == "working":
+        ts = task.get("started_at")
+    elif column == "done":
+        ts = task.get("task_done_at")
+    else:  # needs_input
+        ts = task.get("finished_at")
+    ts = ts or task.get("task_created_at") or task.get("started_at")
+    return -ts.timestamp() if isinstance(ts, datetime) else 0.0
+
+
 def _task_view(task: dict, lane_ids: list[str]) -> dict:
     """Shape a conversation doc into the board card payload."""
     prompt = task.get("prompt") or ""
+    column = derive_column(task, lane_ids)
     return {
         "conversation_id": task.get("conversation_id"),
         "title": task.get("title") or None,
@@ -104,8 +125,8 @@ def _task_view(task: dict, lane_ids: list[str]) -> dict:
         "status": task.get("status"),
         "task_status": task.get("task_status"),
         "task_lane": task.get("task_lane"),
-        "task_rank": task.get("task_rank"),
-        "column": derive_column(task, lane_ids),
+        "task_rank": _effective_rank(task, column, lane_ids),
+        "column": column,
         "total_turns": task.get("total_turns", 0),
         "started_at": _serialize(task.get("started_at")),
         "finished_at": _serialize(task.get("finished_at")),
@@ -214,26 +235,12 @@ async def handle_list_tasks(request: web.Request) -> web.Response:
         _TASK_PROJECTION,
     ).to_list(500)
 
-    views = [_task_view(t, lane_ids) for t in tasks]
-
-    def sort_key(view):
-        column = view["column"]
-        if column in lane_ids:
-            return view.get("task_rank") or 0
-        # Newest first for the derived/done columns.
-        stamp = {
-            "working": view.get("started_at"),
-            "needs_input": view.get("finished_at"),
-            "done": view.get("task_done_at"),
-        }.get(column) or ""
-        return stamp
-
-    staged = sorted([v for v in views if v["column"] in lane_ids], key=sort_key)
-    others = sorted(
-        [v for v in views if v["column"] not in lane_ids],
-        key=sort_key, reverse=True,
+    # Every column orders by effective rank (manual rank, or recency fallback
+    # baked in by _task_view) — so all columns are manually reorderable.
+    ordered = sorted(
+        (_task_view(t, lane_ids) for t in tasks),
+        key=lambda view: view["task_rank"],
     )
-    ordered = staged + others
 
     counts: dict[str, int] = {lane_id: 0 for lane_id in lane_ids}
     counts.update({"working": 0, "needs_input": 0, "done": 0})

--- a/dashboard/src/components/tasks/TaskBoard.tsx
+++ b/dashboard/src/components/tasks/TaskBoard.tsx
@@ -57,6 +57,11 @@ export function TaskBoard({ board, onBoardChange, onRefresh, onEditDraft, onAddT
     for (const task of board.tasks) {
       (map[task.column] ??= []).push(task);
     }
+    // Rank-sort client-side so optimistic reorders move cards immediately
+    // (the server emits an effective rank for every card).
+    for (const list of Object.values(map)) {
+      list.sort((a, b) => (a.task_rank ?? 0) - (b.task_rank ?? 0));
+    }
     return map;
   }, [board.tasks, columns]);
 
@@ -119,7 +124,7 @@ export function TaskBoard({ board, onBoardChange, onRefresh, onEditDraft, onAddT
       }),
     );
 
-  const reorderInLane = (task: Task, rank: number) =>
+  const reorderInColumn = (task: Task, rank: number) =>
     mutate(
       (tasks) => tasks
         .map((t) => (t.conversation_id === task.conversation_id ? { ...t, task_rank: rank } : t)),
@@ -168,6 +173,23 @@ export function TaskBoard({ board, onBoardChange, onRefresh, onEditDraft, onAddT
     const target = resolveColumn(overId);
     if (!target || !canMove(task, task.column, target, laneIds)) return;
 
+    // Position relative to the card we dropped on (or column end).
+    const columnTasks = (tasksByColumn[target] ?? []).filter(
+      (t) => t.conversation_id !== task.conversation_id,
+    );
+    let index = columnTasks.findIndex((t) => t.conversation_id === overId);
+    if (index === -1) index = columnTasks.length;
+    const before = index > 0 ? columnTasks[index - 1].task_rank : null;
+    const after = index < columnTasks.length ? columnTasks[index].task_rank : null;
+    const rank = rankBetween(before, after);
+
+    // Same-column drop = manual reorder, in any column — check this before
+    // the transition branches or a reorder inside Working would start a task.
+    if (target === task.column) {
+      reorderInColumn(task, rank);
+      return;
+    }
+
     if (target === "working") {
       startTask(task);
       return;
@@ -177,21 +199,7 @@ export function TaskBoard({ board, onBoardChange, onRefresh, onEditDraft, onAddT
       return;
     }
 
-    // Staged lane: position relative to the card we dropped on (or lane end).
-    const laneTasks = (tasksByColumn[target] ?? []).filter(
-      (t) => t.conversation_id !== task.conversation_id,
-    );
-    let index = laneTasks.findIndex((t) => t.conversation_id === overId);
-    if (index === -1) index = laneTasks.length;
-    const before = index > 0 ? laneTasks[index - 1].task_rank : null;
-    const after = index < laneTasks.length ? laneTasks[index].task_rank : null;
-    const rank = rankBetween(before, after);
-
-    if (target === task.column) {
-      reorderInLane(task, rank);
-    } else {
-      moveToLane(task, target, rank);
-    }
+    moveToLane(task, target, rank);
   };
 
   return (

--- a/dashboard/src/components/tasks/transitions.ts
+++ b/dashboard/src/components/tasks/transitions.ts
@@ -16,7 +16,7 @@ import type { Task } from "@/lib/api";
  * | done         | no               | no                 | no          | — (reopen via menu) |
  */
 export function canMove(task: Task, from: string, to: string, laneIds: string[]): boolean {
-  if (from === to) return laneIds.includes(from); // same-lane reorder only
+  if (from === to) return true; // reorder within any column
   const fromStaged = laneIds.includes(from);
   const toStaged = laneIds.includes(to);
   const isDraft = !task.status;
@@ -32,9 +32,11 @@ export function canMove(task: Task, from: string, to: string, laneIds: string[])
   return false; // done: reopen via context menu only
 }
 
-/** Midpoint rank for dropping between two neighbors in a staged lane. */
+/** Midpoint rank for dropping between two neighbors in a column. */
 export function rankBetween(before: number | null, after: number | null): number {
-  if (before === null && after === null) return -Date.now();
+  // Empty column: negated epoch *seconds* — same scale as the backend's
+  // recency fallback so defaults and manual ranks stay comparable.
+  if (before === null && after === null) return -Date.now() / 1000;
   if (before === null) return (after as number) - 1;
   if (after === null) return before + 1;
   return (before + after) / 2;


### PR DESCRIPTION
## What

Follow-up to #63 (this commit just missed the squash-merge): cards can now be drag-reordered **within any column** — Working / Needs input / Done included, not just staging lanes.

## How

- The server emits an **effective rank** for every card: the stored `task_rank` if the user has dragged it, otherwise a recency fallback (negated epoch seconds → newest first, matching prior behavior). Columns look identical until you rearrange them.
- All columns sort by that rank server-side, and client-side too so optimistic reorders move the card instantly.
- A same-column drop writes a midpoint rank between the neighbors. Resolved **before** the transition branches — otherwise a reorder inside Working would have re-triggered the start flow.
- Frontend empty-column fallback switched from epoch-ms to epoch-seconds to match the backend scale.

Note: a task's manual rank follows it across columns, so a prioritized needs-input queue keeps its order as items cycle through Working.

## Tested

Rank PATCH + re-fetch confirms reordering in the Done column against a live backend; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)