### PR TITLE
feat: taskboard UX — new-tab open, Done-column moves, new-task dialog shortcuts

### DIFF
--- a/api/task_routes.py
+++ b/api/task_routes.py
@@ -332,12 +332,13 @@ async def handle_update_task(request: web.Request) -> web.Response:
         # - "todo" holds both unstarted drafts and *parked* started tasks
         #   (active -> todo shelves a chat in a lane to recontinue later;
         #   sending a message flips it back to active in handle_chat).
+        #   done -> todo un-completes a task back into a staging lane.
         # - "active" from todo happens in handle_chat on first send, but is
         #   also allowed here for done->active (reopen) and for converting an
         #   existing chat into a task (current is None).
-        if target == "todo" and current not in ("todo", "active"):
+        if target == "todo" and current not in ("todo", "active", "done"):
             return web.json_response(
-                {"error": "Only active tasks can move to a staging lane"}, status=400)
+                {"error": "Only active or done tasks can move to a staging lane"}, status=400)
         if target == "active" and not has_run and current == "todo":
             return web.json_response(
                 {"error": "Start the task by sending its prompt, not by PATCH"}, status=400)
@@ -348,14 +349,14 @@ async def handle_update_task(request: web.Request) -> web.Response:
         updates["task_status"] = target
         if target == "done" and current != "done":
             updates["task_done_at"] = now
-        if target == "active" and current == "done":
+        if target in ("active", "todo") and current == "done":
             updates["task_done_at"] = None
         if target == "active" and current is None:
             # Converting an existing chat into a board task.
             updates["task_created_at"] = conversation.get("task_created_at") or now
-        if target == "todo" and current == "active":
-            # Parking: land in the requested lane (validated below) or the
-            # task's previous lane, defaulting to the first lane.
+        if target == "todo" and current in ("active", "done"):
+            # Parking (or un-completing): land in the requested lane (validated
+            # below) or the task's previous lane, defaulting to the first lane.
             updates["task_staged_at"] = now
             if "task_lane" not in body and not conversation.get("task_lane"):
                 owner = (conversation.get("metadata") or {}).get("user_name") or user_email

--- a/dashboard/src/components/tasks/TaskBoard.tsx
+++ b/dashboard/src/components/tasks/TaskBoard.tsx
@@ -118,7 +118,7 @@ export function TaskBoard({ board, onBoardChange, onRefresh, onEditDraft, onAddT
             }
           : t),
       () => updateTask(task.conversation_id, {
-        ...(task.task_status === "active" ? { task_status: "todo" as const } : {}),
+        ...(task.task_status !== "todo" ? { task_status: "todo" as const } : {}),
         task_lane: laneId,
         ...(rank !== undefined ? { task_rank: rank } : {}),
       }),
@@ -148,8 +148,15 @@ export function TaskBoard({ board, onBoardChange, onRefresh, onEditDraft, onAddT
     // (including chats parked in a lane) opens the conversation.
     if (task.task_status === "todo" && !task.status) {
       onEditDraft(task);
+      return;
+    }
+    const url = `${basePath}/chat?continue=${task.conversation_id}`;
+    // Running / Needs input / Done cards open in a new tab so the board
+    // stays put; parked lane chats keep in-place navigation.
+    if (task.column === "working" || task.column === "needs_input" || task.column === "done") {
+      window.open(url, "_blank", "noopener,noreferrer");
     } else {
-      router.push(`${basePath}/chat?continue=${task.conversation_id}`);
+      router.push(url);
     }
   };
 
@@ -196,6 +203,11 @@ export function TaskBoard({ board, onBoardChange, onRefresh, onEditDraft, onAddT
     }
     if (target === "done") {
       markDone(task);
+      return;
+    }
+    if (target === "needs_input") {
+      // Only reachable from Done (see canMove) — same effect as Reopen.
+      reopen(task);
       return;
     }
 

--- a/dashboard/src/components/tasks/TaskCard.tsx
+++ b/dashboard/src/components/tasks/TaskCard.tsx
@@ -120,11 +120,11 @@ export function TaskCard({
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
               {(() => {
-                // Staged cards move between other lanes; needs-input cards
-                // park into any lane to be recontinued later.
+                // Staged cards move between other lanes; needs-input and
+                // done cards park into any lane to be recontinued later.
                 const targetLanes = isStaged
                   ? lanes.filter((lane) => lane.id !== task.task_lane)
-                  : task.column === "needs_input" ? lanes : [];
+                  : task.column === "needs_input" || task.column === "done" ? lanes : [];
                 return targetLanes.length > 0 && (
                   <DropdownMenuSub>
                     <DropdownMenuSubTrigger>Move to</DropdownMenuSubTrigger>

--- a/dashboard/src/components/tasks/TaskDialog.tsx
+++ b/dashboard/src/components/tasks/TaskDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, type KeyboardEvent, type ReactNode } from "react";
 import {
   Dialog,
   DialogContent,
@@ -32,6 +32,17 @@ interface TaskDialogProps {
     values: { title: string; prompt: string; lane: string; model: string },
     start: boolean,
   ) => Promise<void>;
+}
+
+const isMac = typeof navigator !== "undefined" && /Mac|iP(hone|ad|od)/.test(navigator.platform);
+const modKey = isMac ? "\u2318" : "Ctrl";
+
+function Kbd({ children }: { children: ReactNode }) {
+  return (
+    <kbd className="pointer-events-none ml-1 rounded border border-current/25 px-1 font-sans text-[10px] font-normal leading-4 opacity-70">
+      {children}
+    </kbd>
+  );
 }
 
 export function TaskDialog({ open, onOpenChange, lanes, task, defaultLane, onSubmit }: TaskDialogProps) {
@@ -92,9 +103,24 @@ export function TaskDialog({ open, onOpenChange, lanes, task, defaultLane, onSub
     }
   };
 
+  // Cmd/Ctrl+Enter = add & start; plain Enter = add. Textareas keep Enter
+  // for newlines and buttons/selects keep their native Enter behavior.
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key !== "Enter" || busy) return;
+    if (e.metaKey || e.ctrlKey) {
+      e.preventDefault();
+      void submit(true);
+      return;
+    }
+    const el = e.target as HTMLElement;
+    if (el.tagName === "TEXTAREA" || el.tagName === "BUTTON") return;
+    e.preventDefault();
+    void submit(false);
+  };
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-lg">
+      <DialogContent className="sm:max-w-lg" onKeyDown={handleKeyDown}>
         <DialogHeader>
           <DialogTitle>{task ? "Task details" : "New task"}</DialogTitle>
         </DialogHeader>
@@ -158,9 +184,11 @@ export function TaskDialog({ open, onOpenChange, lanes, task, defaultLane, onSub
           </Button>
           <Button variant="outline" onClick={() => submit(false)} disabled={busy}>
             {task ? "Save" : "Add"}
+            <Kbd>{"\u23CE"}</Kbd>
           </Button>
           <Button onClick={() => submit(true)} disabled={busy}>
             {task ? "Save & start" : "Add & start"}
+            <Kbd>{modKey} {"\u23CE"}</Kbd>
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/dashboard/src/components/tasks/transitions.ts
+++ b/dashboard/src/components/tasks/transitions.ts
@@ -13,7 +13,7 @@ import type { Task } from "@/lib/api";
  * | staged lane  | yes              | draft only (=start)| no          | parked only   |
  * | working      | no               | —                  | (derived)   | yes           |
  * | needs_input  | yes (=park)      | (by replying)      | —           | yes           |
- * | done         | no               | no                 | no          | — (reopen via menu) |
+ * | done         | yes (=park)      | no                 | yes (=reopen) | —           |
  */
 export function canMove(task: Task, from: string, to: string, laneIds: string[]): boolean {
   if (from === to) return true; // reorder within any column
@@ -29,7 +29,8 @@ export function canMove(task: Task, from: string, to: string, laneIds: string[])
   }
   if (from === "needs_input") return to === "done" || toStaged; // park to recontinue later
   if (from === "working") return to === "done";
-  return false; // done: reopen via context menu only
+  if (from === "done") return to === "needs_input" || toStaged; // reopen or park back
+  return false;
 }
 
 /** Midpoint rank for dropping between two neighbors in a column. */


### PR DESCRIPTION
## Summary
- Clicking a task card in **Running / Needs input / Done** now opens the conversation in a **new browser tab** instead of navigating away from the board
- **Done** tasks can now be moved back to **Needs input** (reopen) or any **staging lane** (Todo) — via both drag-and-drop and the card's "Move to" menu
- The **new-task dialog** gains keyboard shortcuts: **Enter** = Add, **Cmd/Ctrl+Enter** = Add & start, with visible `⏎` / `⌘⏎` hints on the footer CTAs

## Context
Direct request from Adarsh (taskboard UX improvements) — no Linear ticket.

## Changes
- `dashboard/src/components/tasks/TaskBoard.tsx` — `openTask` opens working/needs_input/done cards via `window.open(..., "_blank", "noopener,noreferrer")` (drafts still open the editor; parked lane chats keep in-place navigation). `handleDragEnd` handles drops on Needs input (reopen, only reachable from Done). `moveToLane` now sends `task_status: "todo"` for done tasks too, so the backend accepts the lane change
- `dashboard/src/components/tasks/transitions.ts` — `canMove` allows `done → needs_input` (reopen) and `done → staging lane` (park back); transition-matrix doc updated
- `dashboard/src/components/tasks/TaskCard.tsx` — "Move to <lane>" menu items now offered on Done cards (Reopen stays as the needs-input path)
- `dashboard/src/components/tasks/TaskDialog.tsx` — `onKeyDown` on the dialog: plain Enter submits Add/Save (textareas keep Enter for newlines, buttons keep native behavior), Cmd/Ctrl+Enter submits Add & start / Save & start; platform-aware `⌘`/`Ctrl` kbd hints rendered next to both CTAs
- `api/task_routes.py` — PATCH transition matrix kept in sync with the client: `done → todo` allowed (clears `task_done_at`, stamps `task_staged_at`, defaults lane/rank like parking)

## Testing
- `tsc --noEmit` passes on the dashboard
- `python3 -m py_compile api/task_routes.py` passes
- No existing tests cover `api/task_routes.py` or the board components; manual verification recommended: (1) click cards in each column, (2) drag a Done card to Needs input and to a lane, (3) use the Done card's "Move to" menu, (4) Enter / Cmd+Enter in the new-task modal including inside the Details textarea

## Notes
- Parked chats sitting in staging lanes still open in the same tab — only the three states called out in the request open in a new tab. Easy to extend if desired
- This PR was generated by Loma based on the request above; please review before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)
