### PR TITLE
fix: detect harness-auto-backgrounded Agent calls so runs don't finish prematurely

### DIFF
--- a/agent/client.py
+++ b/agent/client.py
@@ -1254,14 +1254,31 @@ async def stream_agent(
                         for block in content:
                             if not isinstance(block, ToolResultBlock):
                                 continue
-                            # Foreground Agent calls resolve here. Background
-                            # Agent calls do NOT: their tool result is just the
-                            # launch ack, so they stay pending until a terminal
-                            # task lifecycle message arrives.
-                            pending_subagent_tool_ids.discard(block.tool_use_id)
                             logger.info("[TOOL RESULT] tool_use_id=%s, is_error=%s",
                                         block.tool_use_id, getattr(block, "is_error", False))
                             result_text = _extract_result_text(block)
+                            # Foreground Agent calls resolve here. Background
+                            # Agent calls do NOT: their tool result is just the
+                            # launch ack, so they stay pending until a terminal
+                            # task lifecycle message arrives. The harness can
+                            # auto-background an Agent call even when the model
+                            # never passed run_in_background=true, so background
+                            # status must be inferred from the RESULT (launch
+                            # ack), not from the tool input.
+                            if block.tool_use_id in pending_subagent_tool_ids:
+                                if (
+                                    not getattr(block, "is_error", False)
+                                    and _is_async_agent_launch_ack(result_text)
+                                ):
+                                    pending_subagent_tool_ids.discard(block.tool_use_id)
+                                    pending_background_tool_ids.add(block.tool_use_id)
+                                    logger.info(
+                                        "[SUBAGENT] Agent call %s was auto-backgrounded by the "
+                                        "harness (launch ack received); awaiting task lifecycle "
+                                        "completion", block.tool_use_id,
+                                    )
+                                else:
+                                    pending_subagent_tool_ids.discard(block.tool_use_id)
                             logger.info("[TOOL OUTPUT] %.500s%s", result_text, "..." if len(result_text) > 500 else "")
                             if observer:
                                 await observer.record_tool_result(
@@ -1309,6 +1326,19 @@ async def stream_agent(
                                             yield artifact
                 elif isinstance(message, TaskStartedMessage):
                     tool_use_id = message.tool_use_id or ""
+                    # Authoritative background signal: a task started for one of
+                    # our Agent calls. If the call is still tracked as
+                    # foreground (auto-backgrounded without run_in_background
+                    # in the input, and the launch ack not yet seen or not
+                    # recognized), promote it to background tracking so the run
+                    # cannot finish before the task completes.
+                    if tool_use_id in pending_subagent_tool_ids:
+                        pending_subagent_tool_ids.discard(tool_use_id)
+                        pending_background_tool_ids.add(tool_use_id)
+                        logger.info(
+                            "[SUBAGENT] Task %s started for Agent call %s — reclassified as background",
+                            message.task_id, tool_use_id,
+                        )
                     if tool_use_id in pending_background_tool_ids:
                         background_task_to_tool[message.task_id] = tool_use_id
                         logger.info(
@@ -1536,6 +1566,24 @@ def _truncate_json(obj, max_len: int = 500) -> str:
     if len(s) > max_len:
         return s[:max_len] + "..."
     return s
+
+
+def _is_async_agent_launch_ack(text: str) -> bool:
+    """Detect the harness's launch acknowledgment for a backgrounded Agent call.
+
+    The CLI may run an Agent call asynchronously EVEN WHEN the model did not
+    pass run_in_background=true (auto-backgrounding). In that case the tool
+    result is only a launch ack, not the sub-agent's report, and completion
+    arrives later via task lifecycle messages. Request-time classification by
+    tool input is therefore unreliable; this result-shape check (plus
+    TaskStartedMessage.tool_use_id) is what actually distinguishes the two.
+    """
+    if not text:
+        return False
+    head = text[:400]
+    if "Async agent launched" in head:
+        return True
+    return "agentId:" in head and "background" in head
 
 
 def _extract_result_text(block) -> str:


### PR DESCRIPTION
## Problem

Third occurrence of the "stuck / prematurely finished run around sub-agents" family. With #67 deployed (verified: server process started 23:04, `client.py` mtime 23:02), chat `8c53e222-eeb2-41bf-8da7-bc4a7c2e4847` launched an Explore Agent at 23:21:30 and the run finished at 23:21:42 — while the background exploration was still running. Its report was orphaned.

## Root cause

#67 classifies an Agent call as background **only if the model passed `run_in_background: true` in the tool input**:

```python
is_background = bool(isinstance(block.input, dict) and block.input.get("run_in_background"))
```

But the CLI can **auto-background** an Agent call the model issued *without* that flag. Evidence from the `turns` collection for this incident:

- Agent call input: `{"description": ..., "subagent_type": "Explore", "prompt": ...}` — **no `run_in_background` key at all**
- Its tool result: `"Async agent launched successfully.\nagentId: a995f358… The agent is working in the background. You will be notified automatically when it completes."` with a task `output_file` path — i.e. the standard background-task system.

So the call was filed into `pending_subagent_tool_ids` (foreground), the launch-ack ToolResultBlock drained it, and the next `ResultMessage` saw nothing pending → `observer.finish()` — the #66 premature-finish bug resurfacing through a different door. The task's `task_started` / `task_notification` lifecycle messages *did* arrive, but were silently ignored because the guard `if tool_use_id in pending_background_tool_ids` never matched.

**Lesson: background-ness cannot be determined from the request. It must be inferred from the response signals.**

## Fix

Classify by what the harness actually did, in two redundant places (either alone suffices; both close ordering races and future wording changes):

1. **ToolResultBlock handler** — if a pending *foreground* Agent call's result matches the async launch ack (`_is_async_agent_launch_ack`: "Async agent launched" or `agentId:` + "background" in the head of the result), move it from `pending_subagent_tool_ids` to `pending_background_tool_ids` instead of resolving it. Error results still resolve as before.
2. **TaskStartedMessage handler** — authoritative, typed signal: if a task starts whose `tool_use_id` is still tracked as foreground, promote it to background tracking (then map `task_id → tool_use_id` as before). `pending_subagent_tool_ids` only ever contains Agent tool ids, so background Bash tasks are unaffected.

Resolution of background calls is unchanged from #67: terminal `TaskNotificationMessage` / `TaskUpdatedMessage`, with the 600s idle-timeout backstop so a lost lifecycle message can still never wedge a run in "running".

## Verification

- `ast.parse` clean (the SyntaxWarning at ~line 1479 is pre-existing).
- Replayed the incident sequence against the new logic: launch ack at 23:21:30 now reclassifies the call as background → `ResultMessage` at 23:21:42 has `pending_background_tool_ids` non-empty → run stays open awaiting the task's terminal lifecycle message, then finishes on the model's follow-up `ResultMessage`.

## Incident lineage

- #60: waited for sub-agents but the drain signal never fired → hang
- #66: drained on ToolResultBlock → premature finish for explicit background agents
- #67: input-flag classification → premature finish for **auto-backgrounded** agents (this bug)
- This PR: response-signal classification

🤖 Generated with [Claude Code](https://claude.com/claude-code)