### PR TITLE
fix: keyboard-friendly task dialog on phones; details optional, start-gated

### DIFF
--- a/api/task_routes.py
+++ b/api/task_routes.py
@@ -236,10 +236,10 @@ async def handle_create_task(request: web.Request) -> web.Response:
         return web.json_response({"error": "Invalid JSON"}, status=400)
 
     prompt = (body.get("prompt") or "").strip()
-    if not prompt:
-        return web.json_response({"error": "prompt is required"}, status=400)
-
     title = (body.get("title") or "").strip() or None
+    if not prompt and not title:
+        return web.json_response({"error": "A title or details are required"}, status=400)
+
     model = (body.get("model") or "").strip()
 
     files = body.get("files") or []
@@ -263,8 +263,10 @@ async def handle_create_task(request: web.Request) -> web.Response:
         return web.json_response({"error": "Unknown lane"}, status=400)
 
     # start=true (quick-add): the task fires immediately in the background
-    # instead of waiting as a staged draft.
+    # instead of waiting as a staged draft. Starting needs actual details.
     start = bool(body.get("start"))
+    if start and not prompt:
+        return web.json_response({"error": "Details are required to start"}, status=400)
 
     now = datetime.now(timezone.utc)
     # Draft doc mirrors observer.start()'s shape, but the run hasn't begun:
@@ -494,8 +496,14 @@ async def handle_update_task(request: web.Request) -> web.Response:
         if current != "todo" or has_run:
             return web.json_response({"error": "Only drafts can be edited"}, status=400)
         prompt = (body["prompt"] or "").strip()
-        if not prompt:
-            return web.json_response({"error": "prompt cannot be empty"}, status=400)
+        # Details are optional as long as the task keeps a title.
+        effective_title = (
+            (body.get("title") or "").strip()
+            if "title" in body else (conversation.get("title") or "")
+        )
+        if not prompt and not effective_title:
+            return web.json_response(
+                {"error": "A title or details are required"}, status=400)
         updates["prompt"] = prompt
 
     if "model" in body:

--- a/dashboard/src/components/tasks/MobileTaskCard.tsx
+++ b/dashboard/src/components/tasks/MobileTaskCard.tsx
@@ -75,7 +75,7 @@ export function MobileTaskCard({
           onClick={(e) => e.stopPropagation()}
           onPointerDown={(e) => e.stopPropagation()}
         >
-          {isDraft && (
+          {isDraft && !!task.prompt.trim() && (
             <Button
               variant="ghost" size="icon" className="h-8 w-8"
               title="Start"

--- a/dashboard/src/components/tasks/TaskCard.tsx
+++ b/dashboard/src/components/tasks/TaskCard.tsx
@@ -82,7 +82,7 @@ export function TaskCard({
           onClick={(e) => e.stopPropagation()}
           onPointerDown={(e) => e.stopPropagation()}
         >
-          {isDraft && (
+          {isDraft && !!task.prompt.trim() && (
             <Button
               variant="ghost" size="icon" className="h-6 w-6"
               title="Start"

--- a/dashboard/src/components/tasks/TaskDialog.tsx
+++ b/dashboard/src/components/tasks/TaskDialog.tsx
@@ -145,12 +145,14 @@ export function TaskDialog({ open, onOpenChange, lanes, task, defaultLane, onSub
               rows={6}
             />
           </div>
-          <div className="flex gap-3">
+          {/* Stacked on phones — side by side the long model label forces a
+              horizontal overflow; min-w-0 lets the triggers truncate. */}
+          <div className="flex gap-3 max-md:flex-col">
             {lanes.length > 1 && (
-              <div className="flex-1 space-y-1.5">
+              <div className="flex-1 min-w-0 space-y-1.5">
                 <Label>Lane</Label>
                 <Select value={lane} onValueChange={setLane}>
-                  <SelectTrigger className="w-full">
+                  <SelectTrigger className="w-full max-w-full">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
@@ -162,10 +164,10 @@ export function TaskDialog({ open, onOpenChange, lanes, task, defaultLane, onSub
               </div>
             )}
             {models.length > 0 && (
-              <div className="flex-1 space-y-1.5">
+              <div className="flex-1 min-w-0 space-y-1.5">
                 <Label>Model</Label>
                 <Select value={model} onValueChange={setModel}>
-                  <SelectTrigger className="w-full">
+                  <SelectTrigger className="w-full max-w-full">
                     <SelectValue placeholder="Default" />
                   </SelectTrigger>
                   <SelectContent>

--- a/dashboard/src/components/tasks/TaskDialog.tsx
+++ b/dashboard/src/components/tasks/TaskDialog.tsx
@@ -86,11 +86,12 @@ export function TaskDialog({ open, onOpenChange, lanes, task, defaultLane, onSub
     };
   }, [open]);
 
+  // A task needs at least a title to exist, and details to be startable.
+  const canSave = !!(title.trim() || prompt.trim());
+  const canStart = !!prompt.trim();
+
   const submit = async (start: boolean) => {
-    if (!prompt.trim()) {
-      setError("Details are required");
-      return;
-    }
+    if (start ? !canStart : !canSave) return;
     setBusy(true);
     setError(null);
     try {
@@ -182,11 +183,15 @@ export function TaskDialog({ open, onOpenChange, lanes, task, defaultLane, onSub
           <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={busy}>
             Cancel
           </Button>
-          <Button variant="outline" onClick={() => submit(false)} disabled={busy}>
+          <Button variant="outline" onClick={() => submit(false)} disabled={busy || !canSave}>
             {task ? "Save" : "Add"}
             <Kbd>{"\u23CE"}</Kbd>
           </Button>
-          <Button onClick={() => submit(true)} disabled={busy}>
+          <Button
+            onClick={() => submit(true)}
+            disabled={busy || !canStart}
+            title={canStart ? undefined : "Add details to start the agent"}
+          >
             {task ? "Save & start" : "Add & start"}
             <Kbd>{modKey} {"\u23CE"}</Kbd>
           </Button>

--- a/dashboard/src/components/tasks/transitions.ts
+++ b/dashboard/src/components/tasks/transitions.ts
@@ -23,7 +23,9 @@ export function canMove(task: Task, from: string, to: string, laneIds: string[])
 
   if (fromStaged) {
     if (toStaged) return true;
-    if (to === "working") return isDraft; // parked chats restart by replying in the chat
+    // Starting sends the draft's details — a title-only draft has nothing to
+    // send. Parked chats restart by replying in the chat.
+    if (to === "working") return isDraft && !!task.prompt.trim();
     if (to === "done") return !isDraft;
     return false;
   }

--- a/dashboard/src/components/ui/dialog.tsx
+++ b/dashboard/src/components/ui/dialog.tsx
@@ -62,6 +62,10 @@ function DialogContent({
         data-slot="dialog-content"
         className={cn(
           "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-[13px] text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          // Phones: anchor to the top and scroll internally so the on-screen
+          // keyboard never hides fields or footer buttons (--app-h tracks the
+          // visual viewport in the installed PWA).
+          "max-md:top-[max(0.75rem,env(safe-area-inset-top))] max-md:translate-y-0 max-md:max-h-[calc(var(--app-h,100dvh)-max(0.75rem,env(safe-area-inset-top))-0.75rem)] max-md:overflow-y-auto",
           className
         )}
         {...props}

--- a/dashboard/src/components/ui/dialog.tsx
+++ b/dashboard/src/components/ui/dialog.tsx
@@ -65,7 +65,7 @@ function DialogContent({
           // Phones: anchor to the top and scroll internally so the on-screen
           // keyboard never hides fields or footer buttons (--app-h tracks the
           // visual viewport in the installed PWA).
-          "max-md:top-[max(0.75rem,env(safe-area-inset-top))] max-md:translate-y-0 max-md:max-h-[calc(var(--app-h,100dvh)-max(0.75rem,env(safe-area-inset-top))-0.75rem)] max-md:overflow-y-auto",
+          "max-md:top-[max(0.75rem,env(safe-area-inset-top))] max-md:translate-y-0 max-md:max-h-[calc(var(--app-h,100dvh)-max(0.75rem,env(safe-area-inset-top))-0.75rem)] max-md:overflow-y-auto max-md:overflow-x-hidden max-md:[&>*]:min-w-0",
           className
         )}
         {...props}


### PR DESCRIPTION
## What

Two commits that just missed the #71 squash-merge:

1. **Keyboard-friendly dialogs on phones** — dialogs anchor to the top and scroll internally (sized against the live visual viewport) instead of vertical centering, so the iOS keyboard no longer hides fields or the footer buttons. The New task modal was unusable in the PWA with the keyboard open.

2. **Details optional; starting requires them** (desktop + mobile) — a task can be saved with just a title (backend: title-or-details to save). Starting still requires details: "Add & start"/"Save & start" disable, the card ▶ hides on title-only drafts, drag-to-Working rejects, and the backend enforces it independently (including quick-add `start: true`).

3. **Dialog horizontal-overflow fix** — the long model label in the side-by-side Lane/Model row forced the dialog wider than the phone (horizontal scroll). Lane/Model stack vertically on <768px with truncating triggers; the mobile dialog shell clips x-overflow defensively.

## Tested

Validation matrix against a live backend (title-only create ✓, empty-both rejected ✓, start-without-details rejected ✓, PATCH combinations ✓); dialog measured at 390px: `scrollWidth === clientWidth`, all fields + footer visible top-anchored; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)