### PR TITLE
feat: composer dictation via gpt-4o-transcribe

### DIFF
--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -4,11 +4,16 @@ from config.app_config import APP_NAME
 
 logger = logging.getLogger(__name__)
 
-PROMPT_SETTING_KEYS = ("identity_guidelines", "company_information")
+PROMPT_SETTING_KEYS = ("identity_guidelines", "company_information", "dictation_vocabulary")
 PROMPT_SETTING_TITLES = {
     "identity_guidelines": "Identity & Guidelines",
     "company_information": "Company Information",
+    "dictation_vocabulary": "Dictation Vocabulary",
 }
+
+# Settings injected into the agent system prompt. dictation_vocabulary is
+# admin-edited through the same UI but only feeds the /api/transcribe hint.
+RULEBOOK_KEYS = ("identity_guidelines", "company_information")
 
 _prompt_settings_cache: dict[str, str] = {}
 _loma_skill_index_cache = "No Loma skills are configured yet."
@@ -21,6 +26,11 @@ def set_prompt_settings_cache(settings: dict[str, str]) -> None:
         key: (settings.get(key) or "").strip()
         for key in PROMPT_SETTING_KEYS
     }
+
+
+def get_prompt_setting(key: str) -> str:
+    """Read one prompt setting from the in-memory cache ("" if unset)."""
+    return _prompt_settings_cache.get(key, "")
 
 
 def set_loma_skill_index_cache(skill_index_text: str) -> None:
@@ -163,7 +173,7 @@ SYSTEM_PROMPT_WRAPPER = """
 def load_rulebook() -> str:
     """Load core prompt settings from the Mongo-backed in-memory cache."""
     sections = []
-    for key in PROMPT_SETTING_KEYS:
+    for key in RULEBOOK_KEYS:
         content = (_prompt_settings_cache.get(key) or "").strip()
         if content:
             title = PROMPT_SETTING_TITLES[key]

--- a/api/prompt_setting_defaults.py
+++ b/api/prompt_setting_defaults.py
@@ -11,6 +11,10 @@ DEFAULT_PROMPT_SETTINGS = {
         "Add your company's product context, terminology, repositories, support "
         "processes, and operating guidelines here from the Loma dashboard."
     ),
+    "dictation_vocabulary": (
+        "Loma, OpenCode, Claude, Anthropic, MongoDB, aiohttp, Next.js, PWA, "
+        "Slack, webhook, kanban, repo, PR, API, MCP, agent, prompt, dashboard."
+    ),
 }
 
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -1756,6 +1756,10 @@ def setup_api_routes(app: web.Application):
     from api.push_routes import setup_push_routes
     setup_push_routes(app)
 
+    # Speech-to-text routes (composer dictation)
+    from api.transcribe_routes import setup_transcribe_routes
+    setup_transcribe_routes(app)
+
     # File serving routes (binary artifact previews)
     from api.file_routes import setup_file_routes
     setup_file_routes(app)

--- a/api/transcribe_routes.py
+++ b/api/transcribe_routes.py
@@ -12,7 +12,9 @@ import os
 import aiohttp
 from aiohttp import web
 
+from agent.prompt import get_prompt_setting
 from api.auth_helpers import get_user_email
+from api.prompt_setting_defaults import get_default_prompt_setting
 
 logger = logging.getLogger(__name__)
 
@@ -25,13 +27,15 @@ MAX_AUDIO_BYTES = 20 * 1024 * 1024
 # not worth an API call.
 MIN_AUDIO_BYTES = 1024
 
-# Vocabulary hint — biases the model toward product names and the jargon
-# that on-device dictation reliably mangles.
-VOCAB_PROMPT = (
-    "Loma, Plotline, OpenCode, Claude, Anthropic, MongoDB, Atlas, aiohttp, "
-    "Next.js, PWA, Slack, Linear, HubSpot, Grain, webhook, kanban, repo, PR, "
-    "API, MCP, VAPID, STT, agent, prompt, dashboard."
-)
+
+def _vocab_prompt() -> str:
+    """Vocabulary hint — biases the model toward product names and the jargon
+    that on-device dictation reliably mangles. Admin-edited via the dashboard
+    ("Dictation Vocabulary" prompt setting); generic tech terms by default."""
+    return (
+        get_prompt_setting("dictation_vocabulary").strip()
+        or get_default_prompt_setting("dictation_vocabulary")
+    )
 
 
 async def handle_transcribe(request: web.Request) -> web.Response:
@@ -68,7 +72,9 @@ async def handle_transcribe(request: web.Request) -> web.Response:
     form = aiohttp.FormData()
     form.add_field("file", audio, filename=filename, content_type=content_type)
     form.add_field("model", TRANSCRIBE_MODEL)
-    form.add_field("prompt", VOCAB_PROMPT)
+    vocab = _vocab_prompt()
+    if vocab:
+        form.add_field("prompt", vocab)
 
     try:
         timeout = aiohttp.ClientTimeout(total=60)

--- a/api/transcribe_routes.py
+++ b/api/transcribe_routes.py
@@ -1,0 +1,95 @@
+"""Speech-to-text route for composer dictation.
+
+The dashboard records audio with MediaRecorder (audio/mp4 on iOS Safari,
+audio/webm on Chrome) and posts the blob here; we forward it to OpenAI's
+transcription API and return plain text. Server-side so the API key stays
+private and quality beats on-device engines (Web Speech API is also broken
+in installed iOS PWAs, which is the primary dictation surface).
+"""
+import logging
+import os
+
+import aiohttp
+from aiohttp import web
+
+from api.auth_helpers import get_user_email
+
+logger = logging.getLogger(__name__)
+
+OPENAI_TRANSCRIBE_URL = "https://api.openai.com/v1/audio/transcriptions"
+TRANSCRIBE_MODEL = "gpt-4o-transcribe"
+
+# OpenAI rejects >25MB; the client caps recordings at ~3 minutes anyway.
+MAX_AUDIO_BYTES = 20 * 1024 * 1024
+# A tap-and-immediate-stop produces a few hundred bytes of container header —
+# not worth an API call.
+MIN_AUDIO_BYTES = 1024
+
+# Vocabulary hint — biases the model toward product names and the jargon
+# that on-device dictation reliably mangles.
+VOCAB_PROMPT = (
+    "Loma, Plotline, OpenCode, Claude, Anthropic, MongoDB, Atlas, aiohttp, "
+    "Next.js, PWA, Slack, Linear, HubSpot, Grain, webhook, kanban, repo, PR, "
+    "API, MCP, VAPID, STT, agent, prompt, dashboard."
+)
+
+
+async def handle_transcribe(request: web.Request) -> web.Response:
+    """POST /api/transcribe — multipart audio in, {"text": ...} out."""
+    if not get_user_email(request):
+        return web.json_response({"error": "Not authenticated"}, status=401)
+
+    api_key = os.environ.get("OPENAI_API_KEY", "").strip()
+    if not api_key:
+        return web.json_response(
+            {"error": "Transcription is not configured (missing OPENAI_API_KEY)"},
+            status=503,
+        )
+
+    reader = await request.multipart()
+    audio: bytes | None = None
+    filename = "audio.webm"
+    content_type = "audio/webm"
+    async for part in reader:
+        if part.name != "audio":
+            continue
+        filename = part.filename or filename
+        content_type = part.headers.get("Content-Type") or content_type
+        audio = await part.read(decode=False)
+        break
+
+    if audio is None:
+        return web.json_response({"error": "No audio file in request"}, status=400)
+    if len(audio) < MIN_AUDIO_BYTES:
+        return web.json_response({"error": "Recording too short"}, status=400)
+    if len(audio) > MAX_AUDIO_BYTES:
+        return web.json_response({"error": "Recording too large"}, status=413)
+
+    form = aiohttp.FormData()
+    form.add_field("file", audio, filename=filename, content_type=content_type)
+    form.add_field("model", TRANSCRIBE_MODEL)
+    form.add_field("prompt", VOCAB_PROMPT)
+
+    try:
+        timeout = aiohttp.ClientTimeout(total=60)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.post(
+                OPENAI_TRANSCRIBE_URL,
+                data=form,
+                headers={"Authorization": f"Bearer {api_key}"},
+            ) as resp:
+                payload = await resp.json(content_type=None)
+                if resp.status != 200:
+                    message = (payload.get("error") or {}).get("message") or "Transcription failed"
+                    logger.error("[TRANSCRIBE] OpenAI %s: %s", resp.status, message)
+                    return web.json_response({"error": message}, status=502)
+    except Exception:
+        logger.exception("[TRANSCRIBE] request failed")
+        return web.json_response({"error": "Transcription failed"}, status=502)
+
+    return web.json_response({"text": (payload.get("text") or "").strip()})
+
+
+def setup_transcribe_routes(app: web.Application):
+    """Register transcription routes."""
+    app.router.add_post("/api/transcribe", handle_transcribe)

--- a/dashboard/src/components/ChatPanel.tsx
+++ b/dashboard/src/components/ChatPanel.tsx
@@ -7,6 +7,7 @@ import { useAgentModels } from "@/hooks/useAgentModels";
 import { filesToChatFiles } from "@/lib/chatFiles";
 import { ModelPicker } from "./composer/ModelPicker";
 import { PendingFilesStrip } from "./composer/PendingFilesStrip";
+import { DictationButton, appendDictation } from "./composer/DictationButton";
 import { streamChat, fetchConversation, basePath } from "../lib/api";
 import type { ChatEvent, ChatFile, ChatMessage, ClarifyQuestion, Turn, PersistedArtifact } from "../lib/api";
 import MarkdownContent from "./MarkdownContent";
@@ -1199,6 +1200,7 @@ export default function ChatPanel({
                     <ModelPicker models={agentModels} selectedModel={selectedModel} onSelect={selectModel} loadState={modelLoadState} disabled={isStreaming} />
                   </div>
                   <div className="flex items-center gap-1 shrink-0">
+                    <DictationButton onText={(t) => setInput((prev) => appendDictation(prev, t))} />
                     <Button
                       type="button"
                       variant="ghost"
@@ -1451,6 +1453,7 @@ export default function ChatPanel({
                     <ModelPicker models={agentModels} selectedModel={selectedModel} onSelect={selectModel} loadState={modelLoadState} disabled={isStreaming} />
                   </div>
                   <div className="flex items-center gap-1 shrink-0">
+                    <DictationButton onText={(t) => setInput((prev) => appendDictation(prev, t))} />
                     <Button
                       type="button"
                       variant="ghost"

--- a/dashboard/src/components/composer/DictationButton.tsx
+++ b/dashboard/src/components/composer/DictationButton.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { RiLoader4Line, RiMicLine, RiStopFill } from "@remixicon/react";
+import { Button } from "@/components/ui/button";
+import { useDictation } from "@/hooks/useDictation";
+import { cn } from "@/lib/utils";
+
+/** Append a transcript to existing composer text with sane spacing. */
+export function appendDictation(prev: string, text: string): string {
+  if (!prev) return text;
+  return prev + (/\s$/.test(prev) ? "" : " ") + text;
+}
+
+interface DictationButtonProps {
+  onText: (text: string) => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+/** Mic toggle for composers: tap to record, tap again to stop + transcribe
+ * (server-side, gpt-4o-transcribe). Hidden where MediaRecorder/getUserMedia
+ * are unavailable (e.g. plain HTTP). */
+export function DictationButton({ onText, disabled, className }: DictationButtonProps) {
+  const { state, seconds, error, supported, toggle } = useDictation(onText);
+
+  if (!supported) return null;
+
+  if (state === "recording") {
+    return (
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={toggle}
+        title="Stop and transcribe"
+        className={cn(
+          "h-7 gap-1.5 rounded-lg px-2 text-red-600 hover:text-red-600 hover:bg-red-500/10",
+          className,
+        )}
+      >
+        <span className="relative flex h-2 w-2">
+          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-red-500 opacity-60" />
+          <span className="relative inline-flex h-2 w-2 rounded-full bg-red-500" />
+        </span>
+        <span className="text-xs tabular-nums">
+          {Math.floor(seconds / 60)}:{String(seconds % 60).padStart(2, "0")}
+        </span>
+        <RiStopFill size={16} />
+      </Button>
+    );
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon-sm"
+      onClick={toggle}
+      disabled={disabled || state === "transcribing"}
+      title={error ?? "Dictate"}
+      className={cn(
+        error ? "text-destructive" : "text-muted-foreground hover:text-foreground",
+        className,
+      )}
+    >
+      {state === "transcribing"
+        ? <RiLoader4Line size={16} className="animate-spin" />
+        : <RiMicLine size={16} />}
+    </Button>
+  );
+}

--- a/dashboard/src/components/tasks/QuickAddTask.tsx
+++ b/dashboard/src/components/tasks/QuickAddTask.tsx
@@ -9,6 +9,7 @@ import { filesToChatFiles } from "@/lib/chatFiles";
 import { useAgentModels } from "@/hooks/useAgentModels";
 import { ModelPicker } from "@/components/composer/ModelPicker";
 import { PendingFilesStrip } from "@/components/composer/PendingFilesStrip";
+import { DictationButton, appendDictation } from "@/components/composer/DictationButton";
 
 interface QuickAddTaskProps {
   onAdded: () => void;
@@ -103,6 +104,7 @@ export function QuickAddTask({ onAdded }: QuickAddTaskProps) {
             />
           </div>
           <div className="flex items-center gap-1 shrink-0">
+            <DictationButton onText={(t) => setValue((prev) => appendDictation(prev, t))} />
             <Button
               type="button"
               variant="ghost"

--- a/dashboard/src/components/tasks/TaskDialog.tsx
+++ b/dashboard/src/components/tasks/TaskDialog.tsx
@@ -19,6 +19,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { DictationButton, appendDictation } from "@/components/composer/DictationButton";
 import { fetchAgentModels, type AgentModel, type BoardLane, type Task } from "@/lib/api";
 
 interface TaskDialogProps {
@@ -136,7 +137,13 @@ export function TaskDialog({ open, onOpenChange, lanes, task, defaultLane, onSub
             />
           </div>
           <div className="space-y-1.5">
-            <Label htmlFor="task-details">Details</Label>
+            <div className="flex h-6 items-center justify-between">
+              <Label htmlFor="task-details">Details</Label>
+              <DictationButton
+                onText={(t) => setPrompt((prev) => appendDictation(prev, t))}
+                className="-my-1"
+              />
+            </div>
             <Textarea
               id="task-details"
               value={prompt}

--- a/dashboard/src/hooks/useDictation.ts
+++ b/dashboard/src/hooks/useDictation.ts
@@ -1,0 +1,126 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { transcribeAudio } from "@/lib/api";
+
+/** Recording formats in preference order — Chrome/Firefox produce Opus webm,
+ * iOS/macOS Safari only support AAC mp4. Both upload fine to the backend. */
+const MIME_CANDIDATES = ["audio/webm;codecs=opus", "audio/webm", "audio/mp4"];
+
+const MAX_SECONDS = 180; // matches the backend size cap with headroom
+
+export type DictationState = "idle" | "recording" | "transcribing";
+
+/** Record mic audio with MediaRecorder and turn it into text via the
+ * backend's /api/transcribe. Toggle semantics: first call starts recording,
+ * second stops it and fires `onText` with the transcript. */
+export function useDictation(onText: (text: string) => void) {
+  const [state, setState] = useState<DictationState>("idle");
+  const [seconds, setSeconds] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const discardRef = useRef(false);
+  const onTextRef = useRef(onText);
+  onTextRef.current = onText;
+
+  const supported =
+    typeof window !== "undefined" &&
+    typeof MediaRecorder !== "undefined" &&
+    !!navigator.mediaDevices?.getUserMedia;
+
+  const cleanup = useCallback(() => {
+    if (timerRef.current) clearInterval(timerRef.current);
+    timerRef.current = null;
+    streamRef.current?.getTracks().forEach((t) => t.stop());
+    streamRef.current = null;
+    recorderRef.current = null;
+  }, []);
+
+  // Unmount mid-recording: kill the mic, drop the audio.
+  useEffect(
+    () => () => {
+      discardRef.current = true;
+      if (recorderRef.current?.state === "recording") recorderRef.current.stop();
+      cleanup();
+    },
+    [cleanup],
+  );
+
+  const start = useCallback(async () => {
+    setError(null);
+    let stream: MediaStream;
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    } catch {
+      setError("Microphone access denied");
+      return;
+    }
+    const mimeType = MIME_CANDIDATES.find((m) => MediaRecorder.isTypeSupported(m));
+    const recorder = new MediaRecorder(stream, mimeType ? { mimeType } : undefined);
+    const chunks: Blob[] = [];
+    recorder.ondataavailable = (e) => {
+      if (e.data.size > 0) chunks.push(e.data);
+    };
+    recorder.onstop = async () => {
+      const type = recorder.mimeType || mimeType || "audio/webm";
+      cleanup();
+      if (discardRef.current) {
+        setState("idle");
+        return;
+      }
+      const blob = new Blob(chunks, { type });
+      // A tap-and-immediate-stop is just container headers — skip the API call.
+      if (blob.size < 2048) {
+        setState("idle");
+        return;
+      }
+      setState("transcribing");
+      try {
+        const text = await transcribeAudio(blob, type.includes("mp4") ? "recording.mp4" : "recording.webm");
+        if (text) onTextRef.current(text);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Transcription failed");
+      } finally {
+        setState("idle");
+      }
+    };
+
+    discardRef.current = false;
+    streamRef.current = stream;
+    recorderRef.current = recorder;
+    recorder.start();
+    setSeconds(0);
+    setState("recording");
+    timerRef.current = setInterval(() => {
+      setSeconds((s) => {
+        // Hard cap — stop and transcribe what we have.
+        if (s + 1 >= MAX_SECONDS && recorderRef.current?.state === "recording") {
+          recorderRef.current.stop();
+        }
+        return s + 1;
+      });
+    }, 1000);
+  }, [cleanup]);
+
+  const toggle = useCallback(() => {
+    if (state === "transcribing") return;
+    if (state === "recording") {
+      if (recorderRef.current?.state === "recording") recorderRef.current.stop();
+      return;
+    }
+    void start();
+  }, [state, start]);
+
+  /** Stop and throw away the recording (no transcription). */
+  const cancel = useCallback(() => {
+    if (state !== "recording") return;
+    discardRef.current = true;
+    if (recorderRef.current?.state === "recording") recorderRef.current.stop();
+    setState("idle");
+  }, [state]);
+
+  return { state, seconds, error, supported, toggle, cancel };
+}

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -1063,3 +1063,14 @@ export async function saveBoardSettings(settings: {
   }
   return res.json();
 }
+
+// ---------- Dictation (speech-to-text) ----------
+
+export async function transcribeAudio(blob: Blob, filename: string): Promise<string> {
+  const form = new FormData();
+  form.append("audio", blob, filename);
+  const res = await fetch(`${API_BASE}/api/transcribe`, { method: "POST", body: form });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(body.error || `Transcription failed: ${res.status}`);
+  return body.text || "";
+}

--- a/dashboard/src/lib/prompt-settings-api.ts
+++ b/dashboard/src/lib/prompt-settings-api.ts
@@ -1,6 +1,9 @@
 const API_BASE = process.env.NEXT_PUBLIC_BASE_PATH || "";
 
-export type PromptSettingKey = "identity_guidelines" | "company_information";
+export type PromptSettingKey =
+  | "identity_guidelines"
+  | "company_information"
+  | "dictation_vocabulary";
 
 export interface PromptSetting {
   setting_key: PromptSettingKey;


### PR DESCRIPTION
## What

A mic button in every composer — chat (empty state + in-conversation), the Tasks quick-add box, and the New task dialog's Details field. Tap to record, tap again to stop; the audio is transcribed server-side with OpenAI `gpt-4o-transcribe` and the text is appended to the input for review before sending (never auto-sends).

## Why server-side STT

- The Web Speech API is broken in installed iOS PWAs — the primary dictation surface.
- `gpt-4o-transcribe` handles product vocabulary ("MongoDB", "PWA", "Loma", "webhook") that on-device dictation mangles; the request carries a jargon hint prompt.
- The OpenAI key stays on the server.

## How

**Backend** — `POST /api/transcribe` (new `api/transcribe_routes.py`): multipart audio in, `{text}` out. Auth-gated, 20MB/1KB size bounds, 502s surface OpenAI errors, 503 when `OPENAI_API_KEY` is missing. Accepts both recording formats browsers produce (Opus webm on Chrome, AAC mp4 on iOS/macOS Safari) — no transcoding.

**Frontend** — `useDictation` hook (MediaRecorder: toggle semantics, elapsed timer, 3-min hard cap, tap-and-immediate-stop discarded without an API call, mic tracks released on unmount) + `DictationButton` (idle mic → pulsing red dot with m:ss timer → transcribing spinner; hidden where MediaRecorder is unavailable). Transcript inserts with smart spacing so you can dictate → type → dictate again.

## Verified

- End-to-end with synthesized speech (macOS `say` → m4a → endpoint): *"Create a task to update the MongoDB indexes in the Loma dashboard and open a PR."* transcribed exactly, including "MongoDB" and "PR".
- Browser: full record → stop → upload → insert cycle via a stubbed audio stream; timer, state transitions, and textarea insertion all correct; mic present in all three composers (mobile width included).
- Validation: empty/tiny blob → 400, unauthenticated → 401.
- `tsc --noEmit` clean; no new lint warnings.

## Prod notes

Needs `OPENAI_API_KEY` on the prod box (already used for the GPT model catalog — likely present; the endpoint returns a clear 503 if not). Mic access requires HTTPS — already the case on prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)