### PR TITLE
feat: phone bottom nav — Tasks (badged), New, Chats

### DIFF
--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -4,7 +4,9 @@ import ChatWithArtifacts from "../components/ChatWithArtifacts";
 
 export default function Home() {
   return (
-    <div className="h-[calc(100dvh-3rem)] flex flex-col -mx-6 lg:-mx-8 -my-6">
+    // Phones: fill the layout's flex slot — the bottom nav takes real height,
+    // so a 100dvh-based height overflows. Desktop keeps the original sizing.
+    <div className="h-[calc(100dvh-3rem)] max-md:h-auto max-md:flex-1 max-md:min-h-0 flex flex-col -mx-6 lg:-mx-8 -my-6 max-md:-my-3">
       <ChatWithArtifacts />
     </div>
   );

--- a/dashboard/src/components/BottomNav.tsx
+++ b/dashboard/src/components/BottomNav.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { RiAddLine, RiCheckboxLine, RiHistoryLine } from "@remixicon/react";
+import { useTaskAttention } from "@/lib/TaskAttentionContext";
+import { useKeyboardVisible } from "@/hooks/useKeyboardVisible";
+import { cn } from "@/lib/utils";
+
+/** Phone-only bottom tab bar — the board, quick capture, and recent chats
+ * are one thumb-tap away from anywhere (the floating menu keeps the rest).
+ * Hides while the keyboard is open so typing gets the full height back. */
+export default function BottomNav() {
+  const pathname = usePathname();
+  const { needsInputCount } = useTaskAttention();
+  const keyboardOpen = useKeyboardVisible();
+
+  if (keyboardOpen) return null;
+
+  const tabs = [
+    {
+      name: "Tasks",
+      href: "/tasks",
+      icon: RiCheckboxLine,
+      active: pathname.startsWith("/tasks"),
+      badge: needsInputCount,
+    },
+    {
+      name: "New",
+      href: "/",
+      icon: RiAddLine,
+      active: pathname === "/",
+    },
+    {
+      name: "Chats",
+      href: "/conversations",
+      icon: RiHistoryLine,
+      active: pathname.startsWith("/conversations"),
+    },
+  ];
+
+  return (
+    <nav className="md:hidden shrink-0 grid grid-cols-3 border-t border-border bg-background pb-[max(0.25rem,env(safe-area-inset-bottom))]">
+      {tabs.map((tab) => (
+        <Link
+          key={tab.name}
+          href={tab.href}
+          prefetch
+          className={cn(
+            "flex flex-col items-center gap-0.5 pt-2 pb-1 press-scale",
+            tab.active ? "text-foreground" : "text-muted-foreground",
+          )}
+        >
+          <span className="relative">
+            <tab.icon size={22} />
+            {(tab.badge ?? 0) > 0 && (
+              <span className="absolute -top-1 -right-2 flex h-4 min-w-4 items-center justify-center rounded-full bg-amber-500 px-1 text-[10px] font-semibold leading-none text-white">
+                {tab.badge}
+              </span>
+            )}
+          </span>
+          <span className="text-[10px] font-medium">{tab.name}</span>
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/dashboard/src/components/ChatPanel.tsx
+++ b/dashboard/src/components/ChatPanel.tsx
@@ -1420,8 +1420,8 @@ export default function ChatPanel({
             </div>
           </div>
 
-          {/* Input — bottom safe-area padding clears the iPhone home indicator */}
-          <div className="sticky bottom-0 border-t border-border bg-muted/30 px-3 pt-2.5 pb-[calc(0.625rem+env(safe-area-inset-bottom))] shrink-0">
+          {/* Input — the bottom nav below it owns the home-indicator safe area */}
+          <div className="sticky bottom-0 border-t border-border bg-muted/30 px-3 pt-2.5 pb-2.5 shrink-0">
             <form
               onSubmit={(e) => {
                 e.preventDefault();

--- a/dashboard/src/components/LayoutShell.tsx
+++ b/dashboard/src/components/LayoutShell.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback, useEffect, Suspense } from "react";
 import { usePathname } from "next/navigation";
 import { signOut } from "next-auth/react";
 import Sidebar from "./Sidebar";
+import BottomNav from "./BottomNav";
 import CrosscutIcon from "./CrosscutIcon";
 import ViewportHeightSync from "./ViewportHeightSync";
 import { useUser } from "../lib/UserContext";
@@ -102,6 +103,7 @@ export default function LayoutShell({ children }: { children: React.ReactNode })
           "flex-1 w-full flex flex-col min-h-0",
           pathname.startsWith("/skills") ? "overflow-hidden" : "px-3 md:px-3 lg:px-4 py-3"
         )}>{children}</div>
+        <BottomNav />
       </main>
     </>
   );

--- a/dashboard/src/components/tasks/QuickAddTask.tsx
+++ b/dashboard/src/components/tasks/QuickAddTask.tsx
@@ -57,7 +57,7 @@ export function QuickAddTask({ onAdded }: QuickAddTaskProps) {
   };
 
   return (
-    <div className="shrink-0 border-t border-border bg-background px-3 pt-2 pb-[calc(0.5rem+env(safe-area-inset-bottom))]">
+    <div className="shrink-0 border-t border-border bg-background px-3 pt-2 pb-2">
       <input
         ref={fileInputRef}
         type="file"

--- a/dashboard/src/hooks/useKeyboardVisible.ts
+++ b/dashboard/src/hooks/useKeyboardVisible.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/** True while the on-screen keyboard is likely open — the visual viewport
+ * is meaningfully shorter than the layout viewport. Used to hide chrome
+ * (e.g. the bottom nav) so typing gets the full height back. */
+export function useKeyboardVisible(): boolean {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const vv = window.visualViewport;
+    if (!vv) return;
+    const onResize = () => setVisible(window.innerHeight - vv.height > 140);
+    vv.addEventListener("resize", onResize);
+    onResize();
+    return () => vv.removeEventListener("resize", onResize);
+  }, []);
+
+  return visible;
+}


### PR DESCRIPTION
## What

A persistent bottom tab bar on phones (`md:hidden` — desktop is byte-identical), so the tasks board is one thumb-tap away from anywhere in the app:

- **Tasks** — the board, with the amber **needs-input count badge** (same 5s poll as the sidebar badge), visible even while deep in a chat
- **New** — fresh chat composer for quick capture
- **Chats** — the Activity list, for hopping between parallel running chats

Everything else (Flows, Skills, Admin…) stays behind the floating menu button.

## Behavior details

- **Hides while the keyboard is open** (visualViewport heuristic, new `useKeyboardVisible` hook) — typing gets the full height back, like Slack
- Owns the home-indicator safe area (`env(safe-area-inset-bottom)`); the chat + tasks quick-add composers drop their own safe-area padding so spacing doesn't double-stack above the nav
- In-flow (not fixed), so the chat composer naturally sits directly above it — no overlap management
- Active tab tinted; `press-scale` tap feedback

## Also fixes

The home page sized itself `h-[calc(100dvh-3rem)]`, overflowing by the nav's height on phones — it now fills the layout's flex slot on mobile (desktop sizing untouched).

## Verified (390px viewport)

- Nav pinned to the bottom on home/chat/tasks; badge shows live count; links navigate; active state correct
- Chat composer bottom edge exactly meets nav top edge; zero vertical overflow on chat and tasks; home fits its slot exactly (701/701px)
- Desktop (1500px): nav absent, layout unchanged

## Note

Stacked on #73 (branch base `adarsh/dictation`) — merge #73 first and GitHub will retarget this to `main` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)