### PR TITLE
feat: per-chat cost chip + personal My Usage page

### DIFF
--- a/agent/opencode_runtime.py
+++ b/agent/opencode_runtime.py
@@ -695,9 +695,13 @@ def _usage_from_info(info: dict) -> tuple[dict | None, float | None]:
     tokens = info.get("tokens") or {}
     if not tokens and info.get("cost") is None:
         return None, None
+    cache = tokens.get("cache") or {}
+    # Anthropic-API key names so downstream (observer) sees one shape.
     return {
         "input_tokens": tokens.get("input", 0),
         "output_tokens": tokens.get("output", 0),
+        "cache_read_input_tokens": cache.get("read", 0),
+        "cache_creation_input_tokens": cache.get("write", 0),
     }, info.get("cost")
 
 
@@ -746,8 +750,8 @@ def _tool_display_input(tool_name: str, state: dict) -> str:
 
 def _merge_usage(total_usage: dict, usage: dict | None, cost: float | None) -> float:
     if usage:
-        total_usage["input_tokens"] = total_usage.get("input_tokens", 0) + int(usage.get("input_tokens") or 0)
-        total_usage["output_tokens"] = total_usage.get("output_tokens", 0) + int(usage.get("output_tokens") or 0)
+        for key in ("input_tokens", "output_tokens", "cache_read_input_tokens", "cache_creation_input_tokens"):
+            total_usage[key] = total_usage.get(key, 0) + int(usage.get(key) or 0)
     return float(cost or 0)
 
 

--- a/api/my_usage_routes.py
+++ b/api/my_usage_routes.py
@@ -1,0 +1,148 @@
+"""Personal AI-usage routes — the current user's own spend and tokens.
+
+Unlike /api/cost-stats and /api/token-usage (org-wide, analytics), these
+answer "what am *I* spending?" and need no special role. Ownership is
+matched on metadata.user_name, which holds the user's email for dashboard
+chats (board-task runs fired headlessly included); flow/webhook runs are
+nobody's personal usage and are excluded, mirroring token-usage.
+"""
+import logging
+from datetime import datetime, timedelta, timezone
+
+from aiohttp import web
+
+from api.auth_helpers import ROLE_HIERARCHY, get_system_role, get_user_email
+from observability.db import get_db
+
+logger = logging.getLogger(__name__)
+
+
+async def handle_my_usage(request: web.Request) -> web.Response:
+    """GET /api/usage/me?days=30 — the caller's spend, tokens, and top chats."""
+    user_email = get_user_email(request)
+    if not user_email:
+        return web.json_response({"error": "Not authenticated"}, status=401)
+    db = get_db()
+    if db is None:
+        return web.json_response({"error": "Observability not configured"}, status=503)
+
+    days = min(max(int(request.query.get("days", 30)), 1), 365)
+    since = datetime.now(timezone.utc) - timedelta(days=days)
+    # Deleted chats still cost money — no deleted filter, the number is honest.
+    match = {
+        "started_at": {"$gte": since},
+        "cost": {"$ne": None},
+        "metadata.user_name": user_email,
+        "source": {"$nin": ["flow", "webhook"]},
+    }
+
+    pipeline = [
+        {"$match": match},
+        {"$facet": {
+            "totals": [
+                {"$group": {
+                    "_id": None,
+                    "total_cost_usd": {"$sum": {"$ifNull": ["$cost.total_cost_usd", 0]}},
+                    "input_tokens": {"$sum": {"$ifNull": ["$cost.input_tokens", 0]}},
+                    "output_tokens": {"$sum": {"$ifNull": ["$cost.output_tokens", 0]}},
+                    "conversations": {"$sum": 1},
+                }},
+            ],
+            "daily": [
+                {"$group": {
+                    "_id": {"$dateToString": {"format": "%Y-%m-%d", "date": "$started_at"}},
+                    "total_cost_usd": {"$sum": {"$ifNull": ["$cost.total_cost_usd", 0]}},
+                    "input_tokens": {"$sum": {"$ifNull": ["$cost.input_tokens", 0]}},
+                    "output_tokens": {"$sum": {"$ifNull": ["$cost.output_tokens", 0]}},
+                    "conversations": {"$sum": 1},
+                }},
+                {"$sort": {"_id": 1}},
+            ],
+            "top_chats": [
+                {"$sort": {"cost.total_cost_usd": -1}},
+                {"$limit": 5},
+                {"$project": {
+                    "_id": 0,
+                    "conversation_id": 1,
+                    "title": 1,
+                    "prompt": {"$substrCP": [{"$ifNull": ["$prompt", ""]}, 0, 100]},
+                    "started_at": 1,
+                    "status": 1,
+                    "total_cost_usd": {"$ifNull": ["$cost.total_cost_usd", 0]},
+                    "input_tokens": {"$ifNull": ["$cost.input_tokens", 0]},
+                    "output_tokens": {"$ifNull": ["$cost.output_tokens", 0]},
+                }},
+            ],
+        }},
+    ]
+
+    result = await db.conversations.aggregate(pipeline).to_list(1)
+    facets = result[0] if result else {}
+    totals = (facets.get("totals") or [{}])[0] if facets.get("totals") else {}
+    totals.pop("_id", None)
+    daily = [
+        {"date": d.pop("_id"), **d}
+        for d in facets.get("daily") or []
+    ]
+    top_chats = []
+    for chat in facets.get("top_chats") or []:
+        started = chat.get("started_at")
+        if isinstance(started, datetime):
+            chat["started_at"] = started.isoformat()
+        top_chats.append(chat)
+
+    return web.json_response({
+        "days": days,
+        "totals": {
+            "total_cost_usd": totals.get("total_cost_usd", 0),
+            "input_tokens": totals.get("input_tokens", 0),
+            "output_tokens": totals.get("output_tokens", 0),
+            "conversations": totals.get("conversations", 0),
+        },
+        "daily": daily,
+        "top_chats": top_chats,
+    })
+
+
+async def handle_conversation_cost(request: web.Request) -> web.Response:
+    """GET /api/conversations/{conversation_id}/cost — lightweight cost poll.
+
+    The chat page's cost chip refreshes on this; the full conversation
+    payload (messages, turns) would be wasteful at poll frequency.
+    """
+    user_email = get_user_email(request)
+    if not user_email:
+        return web.json_response({"error": "Not authenticated"}, status=401)
+    db = get_db()
+    if db is None:
+        return web.json_response({"error": "Observability not configured"}, status=503)
+
+    conversation_id = request.match_info["conversation_id"]
+    doc = await db.conversations.find_one(
+        {"conversation_id": conversation_id},
+        {"cost": 1, "total_turns": 1, "status": 1, "metadata.user_name": 1, "source": 1},
+    )
+    if doc is None:
+        return web.json_response({"error": "Not found"}, status=404)
+
+    # Owners see their own chats; analysts and above see everything (same
+    # visibility they already have through the conversations list).
+    owner = (doc.get("metadata") or {}).get("user_name", "")
+    is_analyst_up = ROLE_HIERARCHY.get(get_system_role(request), 0) >= ROLE_HIERARCHY["analyst"]
+    if owner != user_email and not is_analyst_up:
+        return web.json_response({"error": "Forbidden"}, status=403)
+
+    cost = doc.get("cost") or {}
+    return web.json_response({
+        "total_cost_usd": cost.get("total_cost_usd", 0),
+        "input_tokens": cost.get("input_tokens", 0),
+        "output_tokens": cost.get("output_tokens", 0),
+        "total_turns": doc.get("total_turns", 0),
+        "status": doc.get("status"),
+    })
+
+
+def setup_my_usage_routes(app: web.Application):
+    """Register personal usage routes."""
+    app.router.add_get("/api/usage/me", handle_my_usage)
+    app.router.add_get("/api/conversations/{conversation_id}/cost", handle_conversation_cost)

--- a/api/my_usage_routes.py
+++ b/api/my_usage_routes.py
@@ -77,6 +77,9 @@ async def handle_my_usage(request: web.Request) -> web.Response:
                     "total_cost_usd": {"$sum": {"$ifNull": ["$cost.total_cost_usd", 0]}},
                     "input_tokens": {"$sum": {"$ifNull": ["$cost.input_tokens", 0]}},
                     "output_tokens": {"$sum": {"$ifNull": ["$cost.output_tokens", 0]}},
+                    # Absent on conversations recorded before cache capture.
+                    "cache_read_tokens": {"$sum": {"$ifNull": ["$cost.cache_read_tokens", 0]}},
+                    "cache_creation_tokens": {"$sum": {"$ifNull": ["$cost.cache_creation_tokens", 0]}},
                     "conversations": {"$sum": 1},
                 }},
             ],
@@ -134,6 +137,8 @@ async def handle_my_usage(request: web.Request) -> web.Response:
             "total_cost_usd": totals.get("total_cost_usd", 0),
             "input_tokens": totals.get("input_tokens", 0),
             "output_tokens": totals.get("output_tokens", 0),
+            "cache_read_tokens": totals.get("cache_read_tokens", 0),
+            "cache_creation_tokens": totals.get("cache_creation_tokens", 0),
             "conversations": totals.get("conversations", 0),
         },
         "daily": daily,
@@ -174,6 +179,8 @@ async def handle_conversation_cost(request: web.Request) -> web.Response:
         "total_cost_usd": cost.get("total_cost_usd", 0),
         "input_tokens": cost.get("input_tokens", 0),
         "output_tokens": cost.get("output_tokens", 0),
+        "cache_read_tokens": cost.get("cache_read_tokens", 0),
+        "cache_creation_tokens": cost.get("cache_creation_tokens", 0),
         "total_turns": doc.get("total_turns", 0),
         "status": doc.get("status"),
     })

--- a/api/my_usage_routes.py
+++ b/api/my_usage_routes.py
@@ -17,8 +17,27 @@ from observability.db import get_db
 logger = logging.getLogger(__name__)
 
 
+def _parse_timezone(request: web.Request) -> str | None:
+    """Validate an IANA timezone from ?tz= so daily buckets match the
+    user's local days (Mongo groups in UTC otherwise)."""
+    tz_param = request.query.get("tz", "").strip()
+    if not tz_param:
+        return None
+    try:
+        from zoneinfo import ZoneInfo
+
+        ZoneInfo(tz_param)
+        return tz_param
+    except Exception:
+        return None
+
+
 async def handle_my_usage(request: web.Request) -> web.Response:
-    """GET /api/usage/me?days=30 — the caller's spend, tokens, and top chats."""
+    """GET /api/usage/me?days=30 — the caller's spend, tokens, and top chats.
+
+    ?since=<ISO> overrides days for exact windows (e.g. "today" starting at
+    the user's local midnight); ?tz=<IANA> aligns the daily buckets.
+    """
     user_email = get_user_email(request)
     if not user_email:
         return web.json_response({"error": "Not authenticated"}, status=401)
@@ -26,8 +45,21 @@ async def handle_my_usage(request: web.Request) -> web.Response:
     if db is None:
         return web.json_response({"error": "Observability not configured"}, status=503)
 
-    days = min(max(int(request.query.get("days", 30)), 1), 365)
+    days: int | None = min(max(int(request.query.get("days", 30)), 1), 365)
     since = datetime.now(timezone.utc) - timedelta(days=days)
+    since_param = request.query.get("since", "").strip()
+    if since_param:
+        try:
+            parsed = datetime.fromisoformat(since_param.replace("Z", "+00:00"))
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            # Sanity-bound custom windows the same way as ?days.
+            floor = datetime.now(timezone.utc) - timedelta(days=365)
+            since = max(parsed, floor)
+            days = None
+        except ValueError:
+            return web.json_response({"error": "Invalid since timestamp"}, status=400)
+    tz_name = _parse_timezone(request)
     # Deleted chats still cost money — no deleted filter, the number is honest.
     match = {
         "started_at": {"$gte": since},
@@ -50,7 +82,11 @@ async def handle_my_usage(request: web.Request) -> web.Response:
             ],
             "daily": [
                 {"$group": {
-                    "_id": {"$dateToString": {"format": "%Y-%m-%d", "date": "$started_at"}},
+                    "_id": {"$dateToString": {
+                        "format": "%Y-%m-%d",
+                        "date": "$started_at",
+                        **({"timezone": tz_name} if tz_name else {}),
+                    }},
                     "total_cost_usd": {"$sum": {"$ifNull": ["$cost.total_cost_usd", 0]}},
                     "input_tokens": {"$sum": {"$ifNull": ["$cost.input_tokens", 0]}},
                     "output_tokens": {"$sum": {"$ifNull": ["$cost.output_tokens", 0]}},
@@ -93,6 +129,7 @@ async def handle_my_usage(request: web.Request) -> web.Response:
 
     return web.json_response({
         "days": days,
+        "since": since.isoformat(),
         "totals": {
             "total_cost_usd": totals.get("total_cost_usd", 0),
             "input_tokens": totals.get("input_tokens", 0),

--- a/api/routes.py
+++ b/api/routes.py
@@ -1760,6 +1760,10 @@ def setup_api_routes(app: web.Application):
     from api.transcribe_routes import setup_transcribe_routes
     setup_transcribe_routes(app)
 
+    # Personal AI-usage routes (my spend + per-chat cost)
+    from api.my_usage_routes import setup_my_usage_routes
+    setup_my_usage_routes(app)
+
     # File serving routes (binary artifact previews)
     from api.file_routes import setup_file_routes
     setup_file_routes(app)

--- a/dashboard/src/app/chat/page.tsx
+++ b/dashboard/src/app/chat/page.tsx
@@ -19,6 +19,7 @@ import type { Artifact } from "../../components/ArtifactViewer";
 import type { ChatFile } from "../../lib/api";
 import { rebuildItemsFromConversation } from "../../components/ChatPanel";
 import ChatContextMenu from "../../components/ChatContextMenu";
+import { CostChip } from "../../components/CostChip";
 import ChatWithArtifacts from "../../components/ChatWithArtifacts";
 import { fetchConversation, fetchFlow, basePath } from "../../lib/api";
 import { useUser } from "../../lib/UserContext";
@@ -184,7 +185,8 @@ function ChatPageContent() {
           right (mirrors the floating hamburger on the left). ChatContextMenu
           carries pin/rename/board/project/delete. */}
       {activeConversationId && (
-        <div className="md:hidden fixed right-3 top-[max(0.5rem,env(safe-area-inset-top))] z-30">
+        <div className="md:hidden fixed right-3 top-[max(0.5rem,env(safe-area-inset-top))] z-30 flex items-center gap-2">
+          <CostChip conversationId={activeConversationId} />
           <ChatContextMenu
             conversationId={activeConversationId}
             conversationTitle={conversationTitle || promptPreview || "Untitled"}
@@ -286,6 +288,8 @@ function ChatPageContent() {
           {/* Action buttons — visible once a conversation exists */}
           {activeConversationId && (
             <div className="flex items-center gap-1 flex-shrink-0">
+              {/* Live chat cost */}
+              <CostChip conversationId={activeConversationId} className="h-8 mr-1" />
               {/* Pin / Unpin */}
               <Tooltip>
                 <TooltipTrigger asChild>

--- a/dashboard/src/app/my-usage/page.tsx
+++ b/dashboard/src/app/my-usage/page.tsx
@@ -36,22 +36,34 @@ function StatCard({ icon, label, value }: { icon: React.ReactNode; label: string
   );
 }
 
+type Range = "today" | "7" | "30" | "90";
+
 /** "My usage" — the signed-in user's own AI spend. Org-wide numbers live on
  * Analytics (and Claude-subscription limits on /usage); this page is
  * deliberately me-only so it needs no special role. */
 export default function MyUsagePage() {
-  const [days, setDays] = useState(30);
+  const [range, setRange] = useState<Range>("today");
   const [data, setData] = useState<MyUsageResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   // Stale data stays visible while a new range loads — no skeleton flash.
   useEffect(() => {
     let cancelled = false;
-    fetchMyUsage(days)
+    // Daily buckets (and "today") follow the browser's timezone.
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    let opts: Parameters<typeof fetchMyUsage>[0];
+    if (range === "today") {
+      const midnight = new Date();
+      midnight.setHours(0, 0, 0, 0);
+      opts = { since: midnight.toISOString(), tz };
+    } else {
+      opts = { days: Number(range), tz };
+    }
+    fetchMyUsage(opts)
       .then((d) => { if (!cancelled) setData(d); })
       .catch((e) => { if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load"); });
     return () => { cancelled = true; };
-  }, [days]);
+  }, [range]);
 
   return (
     <div className="flex-1 min-h-0 overflow-y-auto">
@@ -60,8 +72,9 @@ export default function MyUsagePage() {
           <h1 className="text-lg md:text-xl font-heading font-semibold text-foreground">My usage</h1>
           <p className="text-[13px] text-muted-foreground">What your chats and tasks have spent</p>
         </div>
-        <Tabs value={String(days)} onValueChange={(v) => setDays(Number(v))}>
+        <Tabs value={range} onValueChange={(v) => setRange(v as Range)}>
           <TabsList>
+            <TabsTrigger value="today">Today</TabsTrigger>
             <TabsTrigger value="7">7d</TabsTrigger>
             <TabsTrigger value="30">30d</TabsTrigger>
             <TabsTrigger value="90">90d</TabsTrigger>
@@ -102,7 +115,8 @@ export default function MyUsagePage() {
             />
           </div>
 
-          {data.daily.length > 0 && (
+          {/* A one-bar chart says nothing — Today skips it */}
+          {data.daily.length > 1 && (
             <Card className="mt-3 p-3">
               <div className="mb-2 text-xs text-muted-foreground">Daily spend</div>
               <div className="h-40">

--- a/dashboard/src/app/my-usage/page.tsx
+++ b/dashboard/src/app/my-usage/page.tsx
@@ -24,14 +24,22 @@ function formatTokens(n: number): string {
   return String(n);
 }
 
-function StatCard({ icon, label, value }: { icon: React.ReactNode; label: string; value: string }) {
+function StatCard({ icon, label, value, sub }: {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  sub?: string;
+}) {
   return (
     <Card className="p-3">
       <div className="flex items-center gap-2 text-xs text-muted-foreground">
         {icon}
         {label}
       </div>
-      <div className="mt-1 text-lg font-heading font-semibold tabular-nums">{value}</div>
+      <div className="mt-1 text-lg font-heading font-semibold tabular-nums">
+        {value}
+        {sub && <span className="ml-1.5 text-xs font-normal text-muted-foreground">{sub}</span>}
+      </div>
     </Card>
   );
 }
@@ -107,6 +115,13 @@ export default function MyUsagePage() {
               icon={<RiUploadLine size={14} />}
               label="Tokens in"
               value={formatTokens(data.totals.input_tokens)}
+              // Cache reads/writes are billed too — the $ figure doesn't add
+              // up from fresh tokens alone on long agentic runs.
+              sub={
+                data.totals.cache_read_tokens + data.totals.cache_creation_tokens > 0
+                  ? `+${formatTokens(data.totals.cache_read_tokens + data.totals.cache_creation_tokens)} cached`
+                  : undefined
+              }
             />
             <StatCard
               icon={<RiDownloadLine size={14} />}

--- a/dashboard/src/app/my-usage/page.tsx
+++ b/dashboard/src/app/my-usage/page.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import {
+  Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis,
+} from "recharts";
+import {
+  RiChat1Line,
+  RiDownloadLine,
+  RiMoneyDollarCircleLine,
+  RiUploadLine,
+} from "@remixicon/react";
+import { Card } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import ClientTimestamp from "@/components/ClientTimestamp";
+import { formatUsd } from "@/components/CostChip";
+import { fetchMyUsage, type MyUsageResponse } from "@/lib/api";
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}
+
+function StatCard({ icon, label, value }: { icon: React.ReactNode; label: string; value: string }) {
+  return (
+    <Card className="p-3">
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        {icon}
+        {label}
+      </div>
+      <div className="mt-1 text-lg font-heading font-semibold tabular-nums">{value}</div>
+    </Card>
+  );
+}
+
+/** "My usage" — the signed-in user's own AI spend. Org-wide numbers live on
+ * Analytics (and Claude-subscription limits on /usage); this page is
+ * deliberately me-only so it needs no special role. */
+export default function MyUsagePage() {
+  const [days, setDays] = useState(30);
+  const [data, setData] = useState<MyUsageResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Stale data stays visible while a new range loads — no skeleton flash.
+  useEffect(() => {
+    let cancelled = false;
+    fetchMyUsage(days)
+      .then((d) => { if (!cancelled) setData(d); })
+      .catch((e) => { if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load"); });
+    return () => { cancelled = true; };
+  }, [days]);
+
+  return (
+    <div className="flex-1 min-h-0 overflow-y-auto">
+      <div className="pwa-header-offset flex items-center justify-between gap-2">
+        <div>
+          <h1 className="text-lg md:text-xl font-heading font-semibold text-foreground">My usage</h1>
+          <p className="text-[13px] text-muted-foreground">What your chats and tasks have spent</p>
+        </div>
+        <Tabs value={String(days)} onValueChange={(v) => setDays(Number(v))}>
+          <TabsList>
+            <TabsTrigger value="7">7d</TabsTrigger>
+            <TabsTrigger value="30">30d</TabsTrigger>
+            <TabsTrigger value="90">90d</TabsTrigger>
+          </TabsList>
+        </Tabs>
+      </div>
+
+      {error && <p className="mt-4 text-[13px] text-destructive">{error}</p>}
+
+      {!data && !error && (
+        <div className="mt-4 grid grid-cols-2 gap-2 md:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, i) => <Skeleton key={i} className="h-[74px] rounded-xl" />)}
+        </div>
+      )}
+
+      {data && (
+        <>
+          <div className="mt-4 grid grid-cols-2 gap-2 md:grid-cols-4">
+            <StatCard
+              icon={<RiMoneyDollarCircleLine size={14} />}
+              label="Spent"
+              value={formatUsd(data.totals.total_cost_usd)}
+            />
+            <StatCard
+              icon={<RiChat1Line size={14} />}
+              label="Chats"
+              value={String(data.totals.conversations)}
+            />
+            <StatCard
+              icon={<RiUploadLine size={14} />}
+              label="Tokens in"
+              value={formatTokens(data.totals.input_tokens)}
+            />
+            <StatCard
+              icon={<RiDownloadLine size={14} />}
+              label="Tokens out"
+              value={formatTokens(data.totals.output_tokens)}
+            />
+          </div>
+
+          {data.daily.length > 0 && (
+            <Card className="mt-3 p-3">
+              <div className="mb-2 text-xs text-muted-foreground">Daily spend</div>
+              <div className="h-40">
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={data.daily} margin={{ top: 4, right: 4, bottom: 0, left: -18 }}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" vertical={false} />
+                    <XAxis
+                      dataKey="date"
+                      tick={{ fontSize: 10 }}
+                      tickFormatter={(d: string) => d.slice(5)}
+                      stroke="var(--muted-foreground)"
+                    />
+                    <YAxis
+                      tick={{ fontSize: 10 }}
+                      tickFormatter={(v: number) => `$${v}`}
+                      stroke="var(--muted-foreground)"
+                    />
+                    <Tooltip
+                      formatter={(value) => [formatUsd(Number(value)), "Spend"]}
+                      contentStyle={{ fontSize: 12, borderRadius: 8 }}
+                    />
+                    <Bar dataKey="total_cost_usd" fill="var(--color-brand-500, #8a7350)" radius={[3, 3, 0, 0]} />
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            </Card>
+          )}
+
+          <Card className="mt-3 mb-4 p-0 overflow-hidden">
+            <div className="px-3 pt-3 pb-2 text-xs text-muted-foreground">Costliest chats</div>
+            {data.top_chats.length === 0 ? (
+              <p className="px-3 pb-3 text-[13px] text-muted-foreground">Nothing yet in this window.</p>
+            ) : (
+              <ul className="divide-y divide-border">
+                {data.top_chats.map((chat) => (
+                  <li key={chat.conversation_id}>
+                    <Link
+                      href={`/chat?continue=${chat.conversation_id}`}
+                      className="flex items-center gap-3 px-3 py-2.5 hover:bg-muted/50"
+                    >
+                      <div className="min-w-0 flex-1">
+                        <div className="truncate text-[13px]">{chat.title || chat.prompt || "Untitled"}</div>
+                        <div className="mt-0.5 flex items-center gap-2 text-xs text-muted-foreground">
+                          {chat.started_at && <ClientTimestamp iso={chat.started_at} variant="short" placeholder="—" />}
+                          <span>{formatTokens(chat.input_tokens)} in · {formatTokens(chat.output_tokens)} out</span>
+                        </div>
+                      </div>
+                      <span className="shrink-0 text-[13px] font-medium tabular-nums">
+                        {formatUsd(chat.total_cost_usd)}
+                      </span>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </Card>
+        </>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/components/BottomNav.tsx
+++ b/dashboard/src/components/BottomNav.tsx
@@ -2,12 +2,12 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { RiAddLine, RiCheckboxLine, RiHistoryLine } from "@remixicon/react";
+import { RiAddLine, RiCheckboxLine, RiMoneyDollarCircleLine } from "@remixicon/react";
 import { useTaskAttention } from "@/lib/TaskAttentionContext";
 import { useKeyboardVisible } from "@/hooks/useKeyboardVisible";
 import { cn } from "@/lib/utils";
 
-/** Phone-only bottom tab bar — the board, quick capture, and recent chats
+/** Phone-only bottom tab bar — the board, quick capture, and personal spend
  * are one thumb-tap away from anywhere (the floating menu keeps the rest).
  * Hides while the keyboard is open so typing gets the full height back. */
 export default function BottomNav() {
@@ -32,10 +32,10 @@ export default function BottomNav() {
       active: pathname === "/",
     },
     {
-      name: "Chats",
-      href: "/conversations",
-      icon: RiHistoryLine,
-      active: pathname.startsWith("/conversations"),
+      name: "Usage",
+      href: "/my-usage",
+      icon: RiMoneyDollarCircleLine,
+      active: pathname.startsWith("/my-usage"),
     },
   ];
 

--- a/dashboard/src/components/CostChip.tsx
+++ b/dashboard/src/components/CostChip.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { RiArrowRightUpLine } from "@remixicon/react";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { fetchConversationCost, type ConversationCost } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+const POLL_MS = 12_000;
+
+export function formatUsd(v: number): string {
+  if (v >= 0.01) return `$${v.toFixed(2)}`;
+  if (v > 0) return "<1¢";
+  return "$0.00";
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}
+
+/** Live spend counter for one chat. Polls the lightweight cost endpoint
+ * (turn costs land when turns finish, so 12s is plenty); tap/click opens
+ * the token breakdown with a link to the full usage page. */
+export function CostChip({ conversationId, className }: {
+  conversationId: string;
+  className?: string;
+}) {
+  const [cost, setCost] = useState<ConversationCost | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = () => {
+      fetchConversationCost(conversationId)
+        .then((c) => { if (!cancelled) setCost(c); })
+        .catch(() => {});
+    };
+    load(); // always fetch on mount — only the poll respects hidden tabs
+    const interval = setInterval(() => {
+      if (!document.hidden) load();
+    }, POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [conversationId]);
+
+  if (!cost) return null;
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          title="Chat cost so far"
+          className={cn(
+            "h-9 px-3 flex items-center rounded-full border border-border bg-background/80 backdrop-blur",
+            "text-xs font-medium tabular-nums text-muted-foreground press-scale",
+            className,
+          )}
+        >
+          {formatUsd(cost.total_cost_usd)}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-56 p-3 text-[13px]">
+        <div className="mb-2 font-medium">Spent on this chat</div>
+        <dl className="space-y-1 text-muted-foreground">
+          <div className="flex justify-between">
+            <dt>Total</dt>
+            <dd className="tabular-nums text-foreground">{formatUsd(cost.total_cost_usd)}</dd>
+          </div>
+          <div className="flex justify-between">
+            <dt>Tokens in</dt>
+            <dd className="tabular-nums">{formatTokens(cost.input_tokens)}</dd>
+          </div>
+          <div className="flex justify-between">
+            <dt>Tokens out</dt>
+            <dd className="tabular-nums">{formatTokens(cost.output_tokens)}</dd>
+          </div>
+          <div className="flex justify-between">
+            <dt>Turns</dt>
+            <dd className="tabular-nums">{cost.total_turns}</dd>
+          </div>
+        </dl>
+        <Link
+          href="/my-usage"
+          className="mt-2.5 flex items-center gap-1 text-xs text-brand-600 hover:underline"
+        >
+          See all my usage <RiArrowRightUpLine size={12} />
+        </Link>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/dashboard/src/components/CostChip.tsx
+++ b/dashboard/src/components/CostChip.tsx
@@ -79,6 +79,20 @@ export function CostChip({ conversationId, className }: {
             <dt>Tokens out</dt>
             <dd className="tabular-nums">{formatTokens(cost.output_tokens)}</dd>
           </div>
+          {/* Cache traffic is billed too — without it the totals above can't
+              explain the $ figure. Zero (hidden) on pre-capture chats. */}
+          {cost.cache_read_tokens > 0 && (
+            <div className="flex justify-between">
+              <dt>Cache read</dt>
+              <dd className="tabular-nums">{formatTokens(cost.cache_read_tokens)}</dd>
+            </div>
+          )}
+          {cost.cache_creation_tokens > 0 && (
+            <div className="flex justify-between">
+              <dt>Cache write</dt>
+              <dd className="tabular-nums">{formatTokens(cost.cache_creation_tokens)}</dd>
+            </div>
+          )}
           <div className="flex justify-between">
             <dt>Turns</dt>
             <dd className="tabular-nums">{cost.total_turns}</dd>

--- a/dashboard/src/components/Sidebar.tsx
+++ b/dashboard/src/components/Sidebar.tsx
@@ -24,6 +24,7 @@ import {
   RiChat1Line,
   RiCheckboxLine,
   RiGridLine,
+  RiMoneyDollarCircleLine,
   RiTimeLine,
   RiBookOpenLine,
   RiDownloadLine,
@@ -66,6 +67,11 @@ const navigation: NavItem[] = [
     name: "Activity",
     href: "/conversations",
     icon: <RiGridLine size={16} />,
+  },
+  {
+    name: "My Usage",
+    href: "/my-usage",
+    icon: <RiMoneyDollarCircleLine size={16} />,
   },
   {
     name: "Flows",

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -1103,6 +1103,9 @@ export interface MyUsageResponse {
     total_cost_usd: number;
     input_tokens: number;
     output_tokens: number;
+    /** 0 on conversations recorded before cache capture */
+    cache_read_tokens: number;
+    cache_creation_tokens: number;
     conversations: number;
   };
   daily: MyUsageDay[];
@@ -1130,6 +1133,9 @@ export interface ConversationCost {
   total_cost_usd: number;
   input_tokens: number;
   output_tokens: number;
+  /** 0 on conversations recorded before cache capture */
+  cache_read_tokens: number;
+  cache_creation_tokens: number;
   total_turns: number;
   status: string | null;
 }

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -1074,3 +1074,56 @@ export async function transcribeAudio(blob: Blob, filename: string): Promise<str
   if (!res.ok) throw new Error(body.error || `Transcription failed: ${res.status}`);
   return body.text || "";
 }
+
+// ---------- Personal AI usage ----------
+
+export interface MyUsageDay {
+  date: string;
+  total_cost_usd: number;
+  input_tokens: number;
+  output_tokens: number;
+  conversations: number;
+}
+
+export interface MyUsageTopChat {
+  conversation_id: string;
+  title?: string | null;
+  prompt: string;
+  started_at?: string;
+  status?: string;
+  total_cost_usd: number;
+  input_tokens: number;
+  output_tokens: number;
+}
+
+export interface MyUsageResponse {
+  days: number;
+  totals: {
+    total_cost_usd: number;
+    input_tokens: number;
+    output_tokens: number;
+    conversations: number;
+  };
+  daily: MyUsageDay[];
+  top_chats: MyUsageTopChat[];
+}
+
+export async function fetchMyUsage(days: number): Promise<MyUsageResponse> {
+  const res = await fetch(`${API_BASE}/api/usage/me?days=${days}`);
+  if (!res.ok) throw new Error(`Failed to fetch usage: ${res.status}`);
+  return res.json();
+}
+
+export interface ConversationCost {
+  total_cost_usd: number;
+  input_tokens: number;
+  output_tokens: number;
+  total_turns: number;
+  status: string | null;
+}
+
+export async function fetchConversationCost(conversationId: string): Promise<ConversationCost> {
+  const res = await fetch(`${API_BASE}/api/conversations/${conversationId}/cost`);
+  if (!res.ok) throw new Error(`Failed to fetch cost: ${res.status}`);
+  return res.json();
+}

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -1097,7 +1097,8 @@ export interface MyUsageTopChat {
 }
 
 export interface MyUsageResponse {
-  days: number;
+  days: number | null;
+  since: string;
   totals: {
     total_cost_usd: number;
     input_tokens: number;
@@ -1108,8 +1109,19 @@ export interface MyUsageResponse {
   top_chats: MyUsageTopChat[];
 }
 
-export async function fetchMyUsage(days: number): Promise<MyUsageResponse> {
-  const res = await fetch(`${API_BASE}/api/usage/me?days=${days}`);
+export async function fetchMyUsage(opts: {
+  /** Rolling window in days (ignored when `since` is set) */
+  days?: number;
+  /** Exact window start (ISO) — e.g. local midnight for "today" */
+  since?: string;
+  /** IANA timezone so daily buckets match the user's local days */
+  tz?: string;
+}): Promise<MyUsageResponse> {
+  const params = new URLSearchParams();
+  if (opts.since) params.set("since", opts.since);
+  else if (opts.days) params.set("days", String(opts.days));
+  if (opts.tz) params.set("tz", opts.tz);
+  const res = await fetch(`${API_BASE}/api/usage/me?${params}`);
   if (!res.ok) throw new Error(`Failed to fetch usage: ${res.status}`);
   return res.json();
 }

--- a/observability/observer.py
+++ b/observability/observer.py
@@ -274,6 +274,10 @@ class ConversationObserver:
 
         input_tokens = usage.get("input_tokens", 0) if usage else 0
         output_tokens = usage.get("output_tokens", 0) if usage else 0
+        # Cache tokens dominate long agentic runs and are billed — without
+        # them the stored token counts can't explain total_cost_usd.
+        cache_read_tokens = usage.get("cache_read_input_tokens", 0) if usage else 0
+        cache_creation_tokens = usage.get("cache_creation_input_tokens", 0) if usage else 0
         agent_cost = round(total_cost_usd, 6) if total_cost_usd is not None else 0
 
         if self.turn_offset > 0:
@@ -284,6 +288,8 @@ class ConversationObserver:
                     {"$inc": {
                         "cost.input_tokens": input_tokens,
                         "cost.output_tokens": output_tokens,
+                        "cost.cache_read_tokens": cache_read_tokens,
+                        "cost.cache_creation_tokens": cache_creation_tokens,
                         "cost.agent_cost_usd": agent_cost,
                         "cost.total_cost_usd": agent_cost,
                     }},
@@ -300,6 +306,8 @@ class ConversationObserver:
             cost_data = {
                 "input_tokens": input_tokens,
                 "output_tokens": output_tokens,
+                "cache_read_tokens": cache_read_tokens,
+                "cache_creation_tokens": cache_creation_tokens,
                 "agent_cost_usd": agent_cost,
                 "confidence_cost_usd": 0,
                 "total_cost_usd": agent_cost,


### PR DESCRIPTION
## What

Cost visibility for the chat-as-task workflow, two layers:

### 1. Per-chat cost chip
A live **$ pill** showing what the chat has spent so far — floating next to the ⋯ button on phones, in the header on desktop. Tap/click it for the breakdown (tokens in/out, turns) and a link to the usage page. Ticks up as the agent works (12s poll against a new lightweight endpoint; hidden tabs skip polls but the mount fetch always runs).

### 2. `/my-usage` — "My usage" page
Your own AI spend (org-wide stays on Analytics; Claude-subscription limits stay on `/usage`):
- 7/30/90-day toggle, stat cards (spent, chats, tokens in/out)
- Daily-spend bar chart
- **Costliest chats** — top 5 by $, each linking back into its chat

Reachable from the **bottom nav (Chats tab → Usage)** and a new sidebar "My Usage" entry. The Activity list remains in the sidebar.

## Backend

- `GET /api/usage/me?days=N` — $facet aggregation over the caller's conversations (`metadata.user_name`), flow/webhook runs excluded (mirroring token-usage), deleted chats included (they still cost money). No role needed — it's me-only by construction.
- `GET /api/conversations/{id}/cost` — projection-only cost poll; owner or analyst+ visibility.

## Verified locally (real prod data)

- `/api/usage/me`: $782.73 / 165 chats / 8.3M in / 3.0M out over 30d, daily series + top chats correct
- Chip on a real chat: `$0.29` → popover `115.6k in · 1.7k out · 1 turn` → usage link
- 390px: bottom nav shows Tasks (badged) | New | Usage with correct active states; chart + cards render; top chats link to `/chat?continue=…`
- Desktop: chip sits in the chat header; kanban/sidebar untouched otherwise

## Note

Stacked on #75 — merge that first and this retargets to `main` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)