### PR TITLE
feat: Needs input as the leftmost board column

### DIFF
--- a/dashboard/src/components/tasks/useTaskBoardActions.ts
+++ b/dashboard/src/components/tasks/useTaskBoardActions.ts
@@ -17,6 +17,9 @@ export const SYSTEM_COLUMNS = [
   { id: "done", name: "Done" },
 ];
 
+const NEEDS_INPUT_COLUMN = SYSTEM_COLUMNS.find((c) => c.id === "needs_input")!;
+const TRAILING_SYSTEM_COLUMNS = SYSTEM_COLUMNS.filter((c) => c.id !== "needs_input");
+
 export interface TaskBoardActionsOptions {
   board: TasksBoardResponse;
   /** Optimistically replace board state; server truth reconciles via polling. */
@@ -38,8 +41,10 @@ export function useTaskBoardActions({
   const router = useRouter();
 
   const laneIds = useMemo(() => board.lanes.map((lane) => lane.id), [board.lanes]);
+  // Needs input sits leftmost — the attention column is the first thing you
+  // see — then the staging lanes, then Working/Done.
   const columns: Array<BoardLane | { id: string; name: string }> = useMemo(
-    () => [...board.lanes, ...SYSTEM_COLUMNS],
+    () => [NEEDS_INPUT_COLUMN, ...board.lanes, ...TRAILING_SYSTEM_COLUMNS],
     [board.lanes],
   );
 


### PR DESCRIPTION
## What

On the desktop kanban, **Needs input** now sits leftmost — before the staging lanes — so the tasks waiting on you are the first thing you see:

`Needs input → …lanes (Follow up, Backlog, Todo) → Working → Done`

Previously the lanes came first and Needs input was buried in the middle of the system columns. The mobile inbox already led with Needs input; this aligns the desktop board.

## How

One-line reorder of the `columns` memo in [useTaskBoardActions.ts](dashboard/src/components/tasks/useTaskBoardActions.ts) (shared by the desktop board). Ordering only — drag/drop, transitions, and ranking are keyed on column ids and unaffected.

## Verified

Desktop board at 1280px reads left-to-right: Needs input, Follow up, Backlog, Todo, Working, Done. `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)