### PR TITLE
feat: quick-add task composer on the desktop board

### DIFF
--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -25,6 +25,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { TaskBoard } from "@/components/tasks/TaskBoard";
 import { MobileTaskBoard } from "@/components/tasks/MobileTaskBoard";
+import { QuickAddTask } from "@/components/tasks/QuickAddTask";
 import { TaskDialog } from "@/components/tasks/TaskDialog";
 import { AddChatDialog } from "@/components/tasks/AddChatDialog";
 import { BoardSettingsDialog } from "@/components/tasks/BoardSettingsDialog";
@@ -205,14 +206,20 @@ export default function TasksPage() {
             onError={setError}
           />
         ) : (
-          <TaskBoard
-            board={board}
-            onBoardChange={setBoard}
-            onRefresh={refresh}
-            onEditDraft={(task) => { setEditingTask(task); setTaskDialogOpen(true); }}
-            onAddTask={(laneId) => { setEditingTask(null); setNewTaskLane(laneId); setTaskDialogOpen(true); }}
-            onError={setError}
-          />
+          <>
+            <TaskBoard
+              board={board}
+              onBoardChange={setBoard}
+              onRefresh={refresh}
+              onEditDraft={(task) => { setEditingTask(task); setTaskDialogOpen(true); }}
+              onAddTask={(laneId) => { setEditingTask(null); setNewTaskLane(laneId); setTaskDialogOpen(true); }}
+              onError={setError}
+            />
+            {/* Desktop capture box — mirrors the PWA. Mobile renders its own
+                inside MobileTaskBoard, so only add it here. Fires the task
+                immediately (start: true); it lands in Working on refresh. */}
+            <QuickAddTask onAdded={refresh} />
+          </>
         )
       ) : (
         <div className="flex gap-4">

--- a/dashboard/src/components/tasks/QuickAddTask.tsx
+++ b/dashboard/src/components/tasks/QuickAddTask.tsx
@@ -15,10 +15,11 @@ interface QuickAddTaskProps {
   onAdded: () => void;
 }
 
-/** Bottom-pinned capture box on the mobile tasks board — the same composer
- * controls as chat (model picker, attachments). Typing here fires the task
- * immediately: the agent starts running in the background (survives closing
- * the app) and the backend titles the task from the prompt with an LLM. */
+/** Bottom-pinned capture box on the tasks board (mobile and desktop) — the
+ * same composer controls as chat (model picker, attachments). Typing here
+ * fires the task immediately: the agent starts running in the background
+ * (survives closing the app) and the backend titles the task from the prompt
+ * with an LLM. */
 export function QuickAddTask({ onAdded }: QuickAddTaskProps) {
   const [value, setValue] = useState("");
   const [files, setFiles] = useState<ChatFile[]>([]);
@@ -70,6 +71,9 @@ export function QuickAddTask({ onAdded }: QuickAddTaskProps) {
           }
         }}
       />
+      {/* Centered + width-capped so the composer stays readable on the wide
+          desktop board; on a phone max-w-3xl is simply full width. */}
+      <div className="mx-auto w-full max-w-3xl">
       {error && <p className="mb-1 text-xs text-destructive">{error}</p>}
       <PendingFilesStrip files={files} onRemove={(i) => setFiles((prev) => prev.filter((_, idx) => idx !== i))} />
       <div className="flex flex-col bg-muted border border-border rounded-2xl focus-within:border-gray-300 transition-colors">
@@ -129,6 +133,7 @@ export function QuickAddTask({ onAdded }: QuickAddTaskProps) {
             </Button>
           </div>
         </div>
+      </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## What

The bottom-pinned capture box that's already on the PWA/mobile board now also appears on the **desktop** tasks board — so you can fire off a task straight from a prompt without opening the New task dialog.

![desktop board with a bottom composer reading "What do you need done?"]

## How

- Reuses the existing `QuickAddTask` component (same controls as the chat composer: model picker, attachments, dictation). Typing fires the task immediately (`start: true`) — it starts running headless and lands in **Working** on the next poll.
- Capped the composer at `max-w-3xl` centered so it reads well on a wide board (no-op at phone width).
- Rendered under `TaskBoard` on the **desktop branch only** — mobile already renders its own inside `MobileTaskBoard`, so there's no doubling.

## Verified (desktop, 1680px)

- Composer pins to the bottom, centered at 768px, with model picker + mic + attach + send
- Typed a prompt → send → `createTask` returns `column: working`, box clears, task lands in Working (test task deleted afterward)
- Board columns still lead with Needs input; `tsc` + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)