### PR TITLE
feat: make Tasks the default page; move Home → Chat in the nav

### DIFF
--- a/dashboard/src/app/chat/page.tsx
+++ b/dashboard/src/app/chat/page.tsx
@@ -200,7 +200,7 @@ function ChatPageContent() {
             }}
             onDelete={async (cid) => {
               await removeConversation(cid);
-              router.push(`${basePath}/`);
+              router.push(`${basePath}/tasks`);
             }}
             onTogglePin={togglePin}
             onAssignProject={async (cid, pid) => {
@@ -327,7 +327,7 @@ function ChatPageContent() {
                 }}
                 onDelete={async (cid) => {
                   await removeConversation(cid);
-                  router.push(`${basePath}/`);
+                  router.push(`${basePath}/tasks`);
                 }}
                 onTogglePin={togglePin}
                 onAssignProject={async (cid, pid) => {
@@ -367,7 +367,7 @@ function ChatPageContent() {
                         size="sm"
                         onClick={async () => {
                           await removeConversation(activeConversationId);
-                          router.push(`${basePath}/`);
+                          router.push(`${basePath}/tasks`);
                         }}
                         className="flex-1 bg-red-600 hover:bg-red-700 text-white"
                       >

--- a/dashboard/src/app/conversations/[id]/page.tsx
+++ b/dashboard/src/app/conversations/[id]/page.tsx
@@ -128,7 +128,7 @@ export default function ConversationDetailPage() {
         <Breadcrumb>
           <BreadcrumbList>
             <BreadcrumbItem>
-              <BreadcrumbLink href={`${basePath}/`}>Conversations</BreadcrumbLink>
+              <BreadcrumbLink href={`${basePath}/conversations`}>Conversations</BreadcrumbLink>
             </BreadcrumbItem>
             <BreadcrumbSeparator />
             <BreadcrumbItem>
@@ -173,7 +173,7 @@ export default function ConversationDetailPage() {
             </Button>
           )}
           <Button asChild size="sm" variant="outline">
-            <a href={`${basePath}/`}>
+            <a href={`${basePath}/chat`}>
               <RiAddLine size={14} />
               New
             </a>

--- a/dashboard/src/app/login/page.tsx
+++ b/dashboard/src/app/login/page.tsx
@@ -48,7 +48,7 @@ function LoginContent() {
       password,
       setupToken,
       redirect: false,
-      callbackUrl: "/",
+      callbackUrl: "/tasks",
     });
     setIsSubmitting(false);
 
@@ -81,11 +81,11 @@ function LoginContent() {
         email,
         password,
         redirect: false,
-        callbackUrl: "/",
+        callbackUrl: "/tasks",
       });
       setIsSubmitting(false);
       if (result?.ok) {
-        router.push("/");
+        router.push("/tasks");
         router.refresh();
         return;
       }
@@ -257,7 +257,7 @@ function LoginContent() {
               variant="outline"
               className="w-full"
               size="lg"
-              onClick={() => signIn("google", { callbackUrl: "/" })}
+              onClick={() => signIn("google", { callbackUrl: "/tasks" })}
             >
               <svg className="w-5 h-5" viewBox="0 0 24 24">
                 <path

--- a/dashboard/src/app/page.tsx
+++ b/dashboard/src/app/page.tsx
@@ -1,13 +1,21 @@
 "use client";
 
-import ChatWithArtifacts from "../components/ChatWithArtifacts";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { RiLoader4Line } from "@remixicon/react";
+import { basePath } from "../lib/api";
 
-export default function Home() {
+/** The tasks board is the app's home now — send the root there. The chat
+ * experience lives at /chat (the sidebar "Chat" item). router.replace in the
+ * app router doesn't prepend basePath, so we add it explicitly. */
+export default function RootRedirect() {
+  const router = useRouter();
+  useEffect(() => {
+    router.replace(`${basePath}/tasks`);
+  }, [router]);
   return (
-    // Phones: fill the layout's flex slot — the bottom nav takes real height,
-    // so a 100dvh-based height overflows. Desktop keeps the original sizing.
-    <div className="h-[calc(100dvh-3rem)] max-md:h-auto max-md:flex-1 max-md:min-h-0 flex flex-col -mx-6 lg:-mx-8 -my-6 max-md:-my-3">
-      <ChatWithArtifacts />
+    <div className="flex flex-1 items-center justify-center">
+      <RiLoader4Line className="h-5 w-5 animate-spin text-muted-foreground" />
     </div>
   );
 }

--- a/dashboard/src/components/BottomNav.tsx
+++ b/dashboard/src/components/BottomNav.tsx
@@ -27,9 +27,9 @@ export default function BottomNav() {
     },
     {
       name: "New",
-      href: "/",
+      href: "/chat",
       icon: RiAddLine,
-      active: pathname === "/",
+      active: pathname.startsWith("/chat"),
     },
     {
       name: "Usage",

--- a/dashboard/src/components/Sidebar.tsx
+++ b/dashboard/src/components/Sidebar.tsx
@@ -53,15 +53,15 @@ type NavItem = {
 
 const navigation: NavItem[] = [
   {
-    name: "Home",
-    href: "/",
-    icon: <RiChat1Line size={16} />,
-  },
-  {
     name: "Tasks",
     href: "/tasks",
     badgeKey: "tasks",
     icon: <RiCheckboxLine size={16} />,
+  },
+  {
+    name: "Chat",
+    href: "/chat",
+    icon: <RiChat1Line size={16} />,
   },
   {
     name: "Activity",
@@ -350,7 +350,7 @@ export default function Sidebar({
     <>
       {/* Logo + collapse toggle + close button */}
       <div className={cn("flex items-center justify-between", collapsed ? "flex-col gap-1 px-2 pt-2 pb-1" : "px-3 pt-3 pb-2")}>
-        <Link href="/" prefetch onClick={onClose} className={cn("flex items-center gap-2", collapsed && "justify-center")}>
+        <Link href="/tasks" prefetch onClick={onClose} className={cn("flex items-center gap-2", collapsed && "justify-center")}>
           <CrosscutIcon size={collapsed ? 22 : 20} />
           {!collapsed && (
             <span className="font-[family-name:var(--font-logo)] text-base font-bold tracking-[0.5px] text-foreground/80">


### PR DESCRIPTION
## What

The tasks board is the app's landing page now. The chat experience moves to the `/chat` route and shows up as a **Chat** nav item just below Tasks (renamed from "Home").

## Changes

- **Root `/` redirects to `/tasks`** — client `router.replace`, basePath-aware (matches the app's convention since app-router `router` doesn't auto-prepend basePath), with a small spinner during the hop.
- **Sidebar:** Tasks is first; "Home" → **"Chat"** (`/chat`) moved to second; the logo now links to `/tasks`.
- **Bottom nav (mobile):** the "New" tab now targets `/chat` (it pointed at `/`, which now redirects to Tasks).
- **Login:** post-auth pushes + Google OAuth `callbackUrl` → `/tasks`, so sign-in lands directly on the board (no redirect hop).
- **Follow-through on the `/` meaning change:** chat-delete now returns to `/tasks`; the conversation-detail "New" button targets `/chat`; and I fixed the mislabeled "Conversations" breadcrumb (it pointed at `/`) to actually go to `/conversations`.

`/chat` with no params already renders the same fresh new-chat composer as the old home, so nothing is lost.

## Verified locally

- `/` → redirects to `/tasks`
- Sidebar order: **Tasks, Chat, Activity, My Usage, Flows, Skills, Webhook Logs**
- Clicking **Chat** → `/chat` renders the new-chat composer ("What do you need to get done?"), nav item active
- `tsc` clean; no new lint errors (the 2 Sidebar eslint errors pre-exist on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)