### PR TITLE
feat: animated elapsed-time indicator above composer

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -304,6 +304,31 @@
 .typing-dot:nth-child(2) { animation-delay: 0.15s; }
 .typing-dot:nth-child(3) { animation-delay: 0.3s; }
 
+/* Working indicator above composer */
+@keyframes workingSlideIn {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.working-indicator {
+  animation: workingSlideIn 0.25s ease-out both;
+}
+
+@keyframes workingGridDot {
+  0%, 100% { opacity: 0.3; }
+  50% { opacity: 1; }
+}
+
+.working-grid-dot {
+  animation: workingGridDot 1.2s ease-in-out infinite;
+}
+
 /* Chat message fade-in */
 @keyframes messageFadeIn {
   from {

--- a/dashboard/src/components/ChatPanel.tsx
+++ b/dashboard/src/components/ChatPanel.tsx
@@ -1453,7 +1453,7 @@ export default function ChatPanel({
           </div>
 
           {/* Input — the bottom nav below it owns the home-indicator safe area */}
-          <div className="sticky bottom-0 border-t border-border bg-muted/30 px-3 pt-2.5 pb-2.5 shrink-0">
+          <div className="sticky bottom-0 px-3 pt-2.5 pb-2.5 shrink-0">
             <form
               onSubmit={(e) => {
                 e.preventDefault();

--- a/dashboard/src/components/ChatPanel.tsx
+++ b/dashboard/src/components/ChatPanel.tsx
@@ -1442,17 +1442,18 @@ export default function ChatPanel({
                 </div>
               )}
 
+              {isStreaming && (
+                <div className="max-w-3xl mx-auto px-3">
+                  <WorkingIndicator elapsedSeconds={streamElapsedSeconds} />
+                </div>
+              )}
+
               <div ref={messagesEndRef} />
             </div>
           </div>
 
           {/* Input — the bottom nav below it owns the home-indicator safe area */}
           <div className="sticky bottom-0 border-t border-border bg-muted/30 px-3 pt-2.5 pb-2.5 shrink-0">
-            {isStreaming && (
-              <div className="max-w-3xl mx-auto">
-                <WorkingIndicator elapsedSeconds={streamElapsedSeconds} />
-              </div>
-            )}
             <form
               onSubmit={(e) => {
                 e.preventDefault();

--- a/dashboard/src/components/ChatPanel.tsx
+++ b/dashboard/src/components/ChatPanel.tsx
@@ -1453,7 +1453,7 @@ export default function ChatPanel({
           </div>
 
           {/* Input — the bottom nav below it owns the home-indicator safe area */}
-          <div className="sticky bottom-0 px-3 pt-2.5 pb-2.5 shrink-0">
+          <div className="sticky bottom-0 bg-background px-3 pt-2.5 pb-2.5 shrink-0">
             <form
               onSubmit={(e) => {
                 e.preventDefault();

--- a/dashboard/src/components/ChatPanel.tsx
+++ b/dashboard/src/components/ChatPanel.tsx
@@ -182,6 +182,31 @@ function formatResponseTime(seconds: number): string {
   return `${Math.round(seconds)}s`;
 }
 
+function WorkingIndicator({ elapsedSeconds }: { elapsedSeconds: number }) {
+  const display = elapsedSeconds < 10
+    ? `${elapsedSeconds.toFixed(1)}s`
+    : elapsedSeconds < 60
+      ? `${elapsedSeconds.toFixed(0)}s`
+      : `${Math.floor(elapsedSeconds / 60)}m ${Math.floor(elapsedSeconds % 60).toString().padStart(2, "0")}s`;
+
+  return (
+    <div className="working-indicator flex items-center gap-2 py-1.5 text-[12px] text-muted-foreground/70">
+      <span className="grid grid-cols-3 gap-[3px]">
+        {Array.from({ length: 9 }, (_, i) => (
+          <span
+            key={i}
+            className="working-grid-dot block w-[3px] h-[3px] rounded-full bg-current"
+            style={{ animationDelay: `${(i % 3) * 0.15 + Math.floor(i / 3) * 0.1}s` }}
+          />
+        ))}
+      </span>
+      <span className="tabular-nums font-mono text-[12px]">
+        {display}
+      </span>
+    </div>
+  );
+}
+
 function stampLatestAssistantDuration(items: ChatItem[], responseTimeSeconds: number): ChatItem[] {
   const updated = [...items];
   for (let i = updated.length - 1; i >= 0; i--) {
@@ -633,10 +658,11 @@ export default function ChatPanel({
     }
 
     const tick = () => {
-      setStreamElapsedSeconds(Math.max(0, Math.floor((performance.now() - streamStartedAt) / 1000)));
+      const raw = (performance.now() - streamStartedAt) / 1000;
+      setStreamElapsedSeconds(Math.max(0, Math.round(raw * 10) / 10));
     };
     tick();
-    const interval = window.setInterval(tick, 1000);
+    const interval = window.setInterval(tick, 100);
     return () => window.clearInterval(interval);
   }, [isStreaming, streamStartedAt]);
 
@@ -1422,6 +1448,11 @@ export default function ChatPanel({
 
           {/* Input — the bottom nav below it owns the home-indicator safe area */}
           <div className="sticky bottom-0 border-t border-border bg-muted/30 px-3 pt-2.5 pb-2.5 shrink-0">
+            {isStreaming && (
+              <div className="max-w-3xl mx-auto">
+                <WorkingIndicator elapsedSeconds={streamElapsedSeconds} />
+              </div>
+            )}
             <form
               onSubmit={(e) => {
                 e.preventDefault();

--- a/dashboard/src/components/LayoutShell.tsx
+++ b/dashboard/src/components/LayoutShell.tsx
@@ -95,7 +95,7 @@ export default function LayoutShell({ children }: { children: React.ReactNode })
         // dvh (not vh) so the iOS Safari URL bar doesn't cause overflow; in
         // the installed PWA, --app-h tracks the visual viewport so the layout
         // shrinks above the on-screen keyboard (dvh ignores it on iOS).
-        "ml-0 flex flex-col transition-all duration-200 pt-[env(safe-area-inset-top)] md:pt-0",
+        "ml-0 flex flex-col transition-all duration-200 pt-[env(safe-area-inset-top)] md:pt-0 bg-background",
         standalone ? "h-[var(--app-h,100dvh)]" : "h-dvh",
         sidebarCollapsed ? "md:ml-[56px]" : "md:ml-[220px]"
       )}>


### PR DESCRIPTION
## Summary
- Adds a pulsing 3x3 dot grid animation with a live elapsed-time counter above the text input bar while the agent is working
- Timer updates at 100ms for smooth decimal display (<10s shows "9.0s", 10-60s shows "15s", 60s+ shows "1m 05s")
- Slides in smoothly when streaming starts, disappears when it ends

## Test plan
- [ ] Send a message in any chat and verify the dot grid + timer appears above the input bar
- [ ] Confirm the timer counts up smoothly with decimal precision
- [ ] Verify the indicator disappears when the agent finishes responding
- [ ] Check it looks correct in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)