### PR TITLE
fix: prevent stuck chat state after server restart

### DIFF
--- a/app.py
+++ b/app.py
@@ -38,7 +38,7 @@ from api.claude_auth_routes import setup_claude_auth_routes
 from api.file_routes import setup_file_routes
 from api.integration_routes import setup_integration_routes
 from api.prompt_settings_routes import setup_prompt_settings_routes
-from recovery import start_recovery_loop
+from recovery import start_recovery_loop, mark_all_running_interrupted
 from scheduler.engine import init_scheduler
 from agent.client import load_config, merge_db_integrations
 from agent.pool import init_pool
@@ -127,6 +127,10 @@ async def main():
     setup_file_routes(webhook_app)
     setup_integration_routes(webhook_app)
     setup_prompt_settings_routes(webhook_app)
+    async def on_shutdown(_app):
+        await mark_all_running_interrupted()
+
+    webhook_app.on_shutdown.append(on_shutdown)
     runner = web.AppRunner(webhook_app)
     await runner.setup()
     port = int(os.environ.get("WEBHOOK_PORT", "3000"))

--- a/dashboard/src/components/ChatPanel.tsx
+++ b/dashboard/src/components/ChatPanel.tsx
@@ -702,8 +702,12 @@ export default function ChatPanel({
     if (abortControllerRef.current) {
       abortControllerRef.current.abort();
       abortControllerRef.current = null;
+    } else if (isRecovering) {
+      setIsRecovering(false);
+      setIsStreaming(false);
+      setStreamStartedAt(null);
     }
-  }, []);
+  }, [isRecovering]);
 
   useEffect(() => {
     const handleEscapeKey = (e: KeyboardEvent) => {
@@ -728,20 +732,29 @@ export default function ChatPanel({
         const data = await fetchConversation(conversationId);
         if (stopped) return;
 
-        // Rebuild items from turns on every poll so new steps appear
+        // Rebuild items from turns on every poll so new steps appear,
+        // but preserve any locally-queued messages the user added.
         const { items: rebuilt } = rebuildItemsFromConversation(
           data.conversation.messages,
           data.conversation.prompt,
           data.conversation.final_response,
           data.turns,
         );
-        setItems(rebuilt);
+        setItems((prev) => {
+          const queued = prev.filter((item) => item.queued);
+          return queued.length > 0 ? [...rebuilt, ...queued] : rebuilt;
+        });
         scrollToBottom();
 
         if (data.conversation.status !== "running") {
           setIsRecovering(false);
           setIsStreaming(false);
-          if (data.conversation.status === "error" && !data.conversation.final_response) {
+          if (data.conversation.status === "interrupted") {
+            setItems((prev) => [
+              ...prev,
+              { role: "assistant", content: "The server restarted while processing your request. You can send a follow-up to continue." },
+            ]);
+          } else if (data.conversation.status === "error" && !data.conversation.final_response) {
             setItems((prev) => [
               ...prev,
               { role: "assistant", content: `Error: ${data.conversation.error || "Unknown error"}` },

--- a/recovery.py
+++ b/recovery.py
@@ -25,6 +25,34 @@ RECOVERY_WINDOW_MINUTES = int(os.environ.get("RECOVERY_WINDOW_MINUTES", "10"))
 HEARTBEAT_STALE_SECONDS = HEARTBEAT_INTERVAL_SECONDS * 2
 
 
+async def mark_all_running_interrupted():
+    """Mark all currently-running conversations as interrupted.
+
+    Called during graceful shutdown so the next server instance doesn't
+    have to wait for heartbeats to go stale.
+    """
+    db = get_db()
+    if db is None:
+        return
+    now = datetime.now(timezone.utc)
+    try:
+        result = await db.conversations.update_many(
+            {"status": "running"},
+            {"$set": {
+                "status": "interrupted",
+                "finished_at": now,
+                "error": "Server shutting down",
+            }},
+        )
+        if result.modified_count > 0:
+            logger.info(
+                "[RECOVERY] Graceful shutdown: marked %d running conversation(s) as interrupted",
+                result.modified_count,
+            )
+    except Exception:
+        logger.exception("[RECOVERY] Failed to mark conversations during shutdown")
+
+
 def start_recovery_loop():
     """Start a background task that periodically checks for interrupted conversations.
 
@@ -176,6 +204,19 @@ async def _resume_conversation(convo: dict):
         )
         await observer.resume()
 
+    # Dashboard chats don't need auto-resume — the user is already watching
+    # the chat and the frontend recovery poll will show the interrupted state.
+    # Resuming would re-run the agent silently, which is confusing.
+    if source == "dashboard":
+        logger.info(
+            "[RECOVERY] Skipping resume for dashboard conversation %s — marking interrupted",
+            conversation_id,
+        )
+        if observer:
+            observer._stop_heartbeat()
+            await observer.mark_interrupted("Server restarted during chat")
+        return
+
     # Map stored source to the agent's expected source parameter
     agent_source = "dashboard" if source == "dashboard" else "slack"
 
@@ -211,3 +252,6 @@ async def _resume_conversation(convo: dict):
         logger.exception(
             "[RECOVERY] Failed to resume conversation %s", conversation_id
         )
+        if observer:
+            observer._stop_heartbeat()
+            await observer.record_error("Recovery failed")


### PR DESCRIPTION
## Summary
- When deploying while a chat is running, conversations got permanently stuck in "running" status — the recovery loop's resume attempt could fail silently with its heartbeat leaking forever
- Frontend stop button was inert during recovery mode, and queued messages got wiped every 3s by the recovery poll

## Changes
- **Graceful shutdown handler** (`app.py`): marks all running conversations as interrupted on SIGTERM so the next instance doesn't wait 60s+ for stale heartbeats
- **Skip dashboard resume** (`recovery.py`): dashboard chats are marked interrupted instead of silently re-running the agent — the user can send a follow-up
- **Error handling in resume** (`recovery.py`): if resume fails, stops the heartbeat and records the error (prevents the "heartbeat forever" leak)
- **Frontend fixes** (`ChatPanel.tsx`): stop button exits recovery mode, queued messages survive polling, "server restarted" message shown on interrupted status

## Test plan
- [ ] Deploy while a dashboard chat is actively streaming → chat should show "server restarted" message within ~60s and allow follow-up
- [ ] Click stop button while in recovery polling state → should exit recovery and re-enable composer
- [ ] Queue messages during recovery mode → messages should stay visible in scroll area, editable and deletable
- [ ] Slack/Linear conversations should still auto-resume after restart (no change to non-dashboard behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)