### PR TITLE
fix(chat): don't auto-scroll when user has scrolled up

### DIFF
--- a/dashboard/src/components/ChatPanel.tsx
+++ b/dashboard/src/components/ChatPanel.tsx
@@ -620,7 +620,21 @@ export default function ChatPanel({
   const [editingQueuedText, setEditingQueuedText] = useState("");
   const editingQueuedIndexRef = useRef<number | null>(null);
 
-  const scrollToBottom = useCallback(() => {
+  // Tracks whether the user is pinned to (near) the bottom of the message list.
+  // When they scroll up to read earlier messages, streaming auto-scroll is
+  // suppressed so the view doesn't yank them back down.
+  const isAtBottomRef = useRef(true);
+  const handleMessagesScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
+    const el = e.currentTarget;
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    isAtBottomRef.current = distanceFromBottom < 120;
+  }, []);
+
+  // By default auto-scroll only follows when the user is already at the bottom.
+  // Pass { force: true } for user-initiated actions (e.g. sending a message)
+  // that should always snap to the latest content.
+  const scrollToBottom = useCallback((opts?: { force?: boolean }) => {
+    if (!opts?.force && !isAtBottomRef.current) return;
     setTimeout(() => {
       messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
     }, 50);
@@ -821,7 +835,9 @@ export default function ChatPanel({
           if (inputRef.current) inputRef.current.style.height = "auto";
         });
       }
-      scrollToBottom();
+      // User sent a message — always snap down and resume following the stream.
+      isAtBottomRef.current = true;
+      scrollToBottom({ force: true });
       return;
     }
     const message = systemContext && overrideMessage
@@ -857,6 +873,9 @@ export default function ChatPanel({
     }
     if (!fromQueue) {
       setItems((prev) => [...prev, { role: "user", content: displayMessage, fileNames, files: filesToSend }]);
+      // User sent a message — always snap down and resume following the stream.
+      isAtBottomRef.current = true;
+      scrollToBottom({ force: true });
     }
     setIsStreaming(true);
     setStreamStartedAt(performance.now());
@@ -1381,7 +1400,7 @@ export default function ChatPanel({
             </div>
           )}
           {/* Messages */}
-          <div className="flex-1 overflow-y-auto px-3 py-4">
+          <div className="flex-1 overflow-y-auto px-3 py-4" onScroll={handleMessagesScroll}>
             <div className="space-y-3 max-w-3xl mx-auto">
               {items.map((item, i) => {
                 if (item.role === "steps") {


### PR DESCRIPTION
## Summary
- On the chat page (`dashboard/src/components/ChatPanel.tsx`), streaming auto-scroll no longer yanks the view to the bottom when the user has scrolled up to read earlier messages while Loma is still writing.
- Sending a new message still force-snaps to the bottom (so you always see your own message and the incoming reply) and resumes following the stream.

## Context
Re-do of the fix in the correct repo. Original request: "If the user has scrolled up on the chat page and Loma has written new text, don't auto scroll down - it spoils the user experience." (A prior draft was opened against the wrong repo.)

## Changes
- `dashboard/src/components/ChatPanel.tsx`
  - Added an `isAtBottomRef` + `onScroll` handler (`handleMessagesScroll`) on the messages container that tracks whether the user is within ~120px of the bottom.
  - `scrollToBottom()` now only scrolls during streaming when the user is at the bottom; it accepts `{ force: true }` for user-initiated actions.
  - Sending a message (both the normal path and the queued-while-streaming path) sets `isAtBottomRef = true` and force-scrolls, so it always snaps down and re-follows.

## Behavior summary
- At bottom → keeps following the response (unchanged)
- Scrolled up mid-response → stays put (the fix)
- You send a message → snaps to bottom and resumes following

## Testing
- Manual reasoning + local diff review. Could not run a typecheck in this environment (dashboard `node_modules` not installed). Please verify on a preview deploy: scroll up mid-response to confirm the view holds, then send a message to confirm it snaps back down.

## Notes
- This PR was generated by the Plotline IE Bot based on the request above. Draft — please review before merging.
