### PR TITLE
fix: Codex read loop dies on >64KiB stdout lines, killing turns that run commands

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -65,6 +65,15 @@ CODEX_CONNECT_TIMEOUT_SECONDS = int(os.environ.get("CODEX_CONNECT_TIMEOUT", "90"
 CODEX_TURN_TIMEOUT_SECONDS = int(os.environ.get("CODEX_TURN_TIMEOUT", "1800"))
 CODEX_EVENT_IDLE_TIMEOUT_SECONDS = int(os.environ.get("CODEX_EVENT_IDLE_TIMEOUT", "300"))
 
+# codex app-server embeds full command/tool output in single JSON lines
+# (a 100 KB command output arrives as one ~130 KB ``item/completed`` line),
+# so the read loop splits lines manually instead of using readline() with
+# asyncio's 64 KiB default limit. This is only a safety valve for truly
+# pathological lines.
+CODEX_MAX_LINE_BYTES = int(os.environ.get("CODEX_MAX_LINE_BYTES", str(64 * 1024 * 1024)))
+_READ_CHUNK_BYTES = 65536
+_STDERR_TAIL_BYTES = 16384
+
 
 def default_codex_model() -> str:
     return os.environ.get("CODEX_MODEL", DEFAULT_CODEX_MODEL)
@@ -243,6 +252,8 @@ class CodexWorker:
         self._pending: dict[int, asyncio.Future] = {}
         self._events: asyncio.Queue[dict] = asyncio.Queue()
         self._reader_task: asyncio.Task | None = None
+        self._stderr_task: asyncio.Task | None = None
+        self._stderr_tail = b""
         self.thread_id: str | None = None
         self.available_models: list[dict] = []
         self.last_rate_limits: dict | None = None
@@ -282,46 +293,77 @@ class CodexWorker:
     async def _respond(self, req_id, result: dict) -> None:
         await self._send({"jsonrpc": "2.0", "id": req_id, "result": result})
 
+    async def _handle_line(self, raw: bytes) -> None:
+        line = raw.decode("utf-8", errors="ignore").strip()
+        if not line:
+            return
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            logger.debug("Codex worker non-JSON line: %.200s", line)
+            return
+
+        if "id" in msg and ("result" in msg or "error" in msg):
+            future = self._pending.get(msg["id"])
+            if future is not None and not future.done():
+                if "error" in msg:
+                    future.set_exception(_classify_rpc_error(msg["error"]))
+                else:
+                    future.set_result(msg.get("result") or {})
+            return
+
+        method = msg.get("method") or ""
+        if "id" in msg:
+            # Server -> client request. approval_policy is "never", but
+            # auto-approve defensively if an approval request arrives.
+            # v2 decisions use accept/decline; legacy uses approved.
+            if method.endswith("requestApproval"):
+                await self._respond(msg["id"], {"decision": "accept"})
+            elif method in ("execCommandApproval", "applyPatchApproval"):
+                await self._respond(msg["id"], {"decision": "approved"})
+            else:
+                await self._respond(msg["id"], {})
+            return
+
+        await self._events.put(msg)
+
     async def _read_loop(self) -> None:
-        """Route stdout lines to pending request futures or the event queue."""
+        """Route stdout lines to pending request futures or the event queue.
+
+        Reads in chunks and splits lines manually: ``readline()`` enforces
+        asyncio's 64 KiB stream limit and raises on longer lines, but codex
+        routinely emits ``item/completed`` notifications far larger than that
+        (the full command/tool output is embedded in one JSON line). A crashed
+        read loop here is indistinguishable from a dead worker to run_turn(),
+        so it must only exit on real EOF.
+        """
         assert self._proc is not None and self._proc.stdout is not None
         try:
+            buf = b""
+            drop_until_newline = False
             while True:
-                raw = await self._proc.stdout.readline()
-                if not raw:
+                chunk = await self._proc.stdout.read(_READ_CHUNK_BYTES)
+                if not chunk:
+                    if not drop_until_newline and buf.strip():
+                        await self._handle_line(buf)
                     break
-                line = raw.decode("utf-8", errors="ignore").strip()
-                if not line:
-                    continue
-                try:
-                    msg = json.loads(line)
-                except json.JSONDecodeError:
-                    logger.debug("Codex worker non-JSON line: %.200s", line)
-                    continue
-
-                if "id" in msg and ("result" in msg or "error" in msg):
-                    future = self._pending.get(msg["id"])
-                    if future is not None and not future.done():
-                        if "error" in msg:
-                            future.set_exception(_classify_rpc_error(msg["error"]))
-                        else:
-                            future.set_result(msg.get("result") or {})
-                    continue
-
-                method = msg.get("method") or ""
-                if "id" in msg:
-                    # Server -> client request. approval_policy is "never", but
-                    # auto-approve defensively if an approval request arrives.
-                    # v2 decisions use accept/decline; legacy uses approved.
-                    if method.endswith("requestApproval"):
-                        await self._respond(msg["id"], {"decision": "accept"})
-                    elif method in ("execCommandApproval", "applyPatchApproval"):
-                        await self._respond(msg["id"], {"decision": "approved"})
-                    else:
-                        await self._respond(msg["id"], {})
-                    continue
-
-                await self._events.put(msg)
+                buf += chunk
+                while True:
+                    newline = buf.find(b"\n")
+                    if newline == -1:
+                        break
+                    line, buf = buf[:newline], buf[newline + 1:]
+                    if drop_until_newline:
+                        drop_until_newline = False
+                        continue
+                    await self._handle_line(line)
+                if len(buf) > CODEX_MAX_LINE_BYTES:
+                    logger.error(
+                        "Codex worker line exceeded %d bytes; dropping it (account=%s)",
+                        CODEX_MAX_LINE_BYTES, self.account.get("email"),
+                    )
+                    buf = b""
+                    drop_until_newline = True
         except asyncio.CancelledError:
             raise
         except Exception:
@@ -329,6 +371,42 @@ class CodexWorker:
         finally:
             # Unblock any waiter
             await self._events.put({"method": "__closed"})
+
+    async def _stderr_loop(self) -> None:
+        """Drain stderr into a bounded tail buffer for crash diagnostics.
+
+        stderr used to go to DEVNULL, which made worker deaths undiagnosable
+        in production (the app-server's panic/error output was discarded).
+        """
+        assert self._proc is not None and self._proc.stderr is not None
+        try:
+            while True:
+                chunk = await self._proc.stderr.read(8192)
+                if not chunk:
+                    break
+                self._stderr_tail = (self._stderr_tail + chunk)[-_STDERR_TAIL_BYTES:]
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # pragma: no cover - diagnostics only
+            pass
+
+    def stderr_tail_text(self) -> str:
+        return self._stderr_tail.decode("utf-8", errors="ignore").strip()
+
+    def _closed_error(self) -> CodexError:
+        """Build an accurate error for the read loop ending mid-turn."""
+        returncode = self._proc.returncode if self._proc else None
+        if returncode is None:
+            message = (
+                "Codex worker stream reader failed mid-turn "
+                "(app-server process is still running — client-side read error)"
+            )
+        else:
+            message = f"Codex worker process exited mid-turn (exit code {returncode})"
+        tail = self.stderr_tail_text()
+        if tail:
+            message = f"{message}; stderr tail: {tail[-500:]}"
+        return _classify_rpc_error({"message": message})
 
     # ── Lifecycle ────────────────────────────────────────────────────
 
@@ -349,9 +427,10 @@ class CodexWorker:
             env=env,
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.PIPE,
         )
         self._reader_task = asyncio.create_task(self._read_loop())
+        self._stderr_task = asyncio.create_task(self._stderr_loop())
 
         await self._request(
             "initialize",
@@ -392,6 +471,9 @@ class CodexWorker:
         if self._reader_task is not None:
             self._reader_task.cancel()
             self._reader_task = None
+        if self._stderr_task is not None:
+            self._stderr_task.cancel()
+            self._stderr_task = None
         if self._proc is not None and self._proc.returncode is None:
             self._proc.terminate()
             try:
@@ -432,7 +514,7 @@ class CodexWorker:
                 )
 
             if msg.get("method") == "__closed":
-                raise CodexError("Codex worker process exited mid-turn")
+                raise self._closed_error()
 
             for event in _normalize_v2_event(msg, self.thread_id):
                 yield event

--- a/dashboard/src/components/ChatPanel.tsx
+++ b/dashboard/src/components/ChatPanel.tsx
@@ -1388,7 +1388,7 @@ export default function ChatPanel({
                           {accountInfo.model ? `${accountInfo.model} via ` : ""}
                           {accountInfo.account_email || "unknown"}
                         </strong>
-                        &apos;s Claude subscription for this task
+                        &apos;s {accountInfo.runtime === "codex" ? "ChatGPT" : "Claude"} subscription for this task
                         {typeof accountInfo.pool_available === "number" && typeof accountInfo.pool_size === "number"
                           ? <> &middot; {accountInfo.pool_available}/{accountInfo.pool_size} available</>
                           : null}

--- a/tests/test_codex_pool.py
+++ b/tests/test_codex_pool.py
@@ -289,3 +289,105 @@ def test_status_shape(tmp_path, monkeypatch):
     assert status["available"] == 0
     assert sorted(status["accounts"]) == ["a@example.com", "b@example.com"]
     assert status["accounts_on_cooldown"] == ["a@example.com"]
+
+
+# ── Read loop: oversized single-line notifications (regression) ──────────
+#
+# codex app-server embeds full command output in one ``item/completed`` JSON
+# line; a ~100 KB command output arrives as a single ~130 KB line, which
+# exceeds asyncio's 64 KiB readline() limit. The read loop must consume it
+# without dying (a dead read loop is reported as a mid-turn worker exit).
+
+
+class _FakeProc:
+    def __init__(self, stdout, returncode=None, stderr=None):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.stdin = None
+        self.returncode = returncode
+
+
+def test_read_loop_survives_lines_over_64kib():
+    import asyncio
+    from agent.codex_runtime import CodexWorker
+
+    async def scenario():
+        reader = asyncio.StreamReader(limit=2**16)  # the default readline limit
+        big_output = "x" * 200_000  # > 3x the 64 KiB limit
+        notification = json.dumps({
+            "jsonrpc": "2.0",
+            "method": "item/completed",
+            "params": {"item": {"id": "call_1", "type": "commandExecution",
+                                 "exitCode": 0, "aggregatedOutput": big_output}},
+        })
+        reader.feed_data((notification + "\n").encode())
+        reader.feed_data(b'{"jsonrpc": "2.0", "method": "turn/completed", "params": {"turn": {"status": "completed"}}}\n')
+        reader.feed_eof()
+
+        worker = CodexWorker.__new__(CodexWorker)
+        worker.account = {"email": "dev@example.com"}
+        worker._pending = {}
+        worker._events = asyncio.Queue()
+        worker._proc = _FakeProc(stdout=reader)
+
+        await worker._read_loop()
+
+        first = worker._events.get_nowait()
+        assert first["method"] == "item/completed"
+        assert first["params"]["item"]["aggregatedOutput"] == big_output
+        second = worker._events.get_nowait()
+        assert second["method"] == "turn/completed"
+        closed = worker._events.get_nowait()
+        assert closed["method"] == "__closed"
+
+    import asyncio as _asyncio
+    _asyncio.run(scenario())
+
+
+def test_read_loop_drops_pathological_line_and_recovers(monkeypatch):
+    import asyncio
+    import agent.codex_runtime as codex_runtime
+    from agent.codex_runtime import CodexWorker
+
+    monkeypatch.setattr(codex_runtime, "CODEX_MAX_LINE_BYTES", 1024)
+
+    async def scenario():
+        reader = asyncio.StreamReader()
+        reader.feed_data(b'{"pathological": "' + b"y" * 5000 + b'"')  # no newline yet
+        reader.feed_data(b'"}\n')  # pathological line ends
+        reader.feed_data(b'{"jsonrpc": "2.0", "method": "turn/completed", "params": {}}\n')
+        reader.feed_eof()
+
+        worker = CodexWorker.__new__(CodexWorker)
+        worker.account = {"email": "dev@example.com"}
+        worker._pending = {}
+        worker._events = asyncio.Queue()
+        worker._proc = _FakeProc(stdout=reader)
+
+        await worker._read_loop()
+
+        # The oversized line is dropped; the next line still routes.
+        event = worker._events.get_nowait()
+        assert event["method"] == "turn/completed"
+        closed = worker._events.get_nowait()
+        assert closed["method"] == "__closed"
+
+    asyncio.run(scenario())
+
+
+def test_closed_error_distinguishes_exit_from_reader_failure():
+    from agent.codex_runtime import CodexWorker
+
+    worker = CodexWorker.__new__(CodexWorker)
+    worker._stderr_tail = b"thread panicked at 'oh no'"
+
+    # Process really exited: message carries the exit code + stderr tail.
+    worker._proc = _FakeProc(stdout=None, returncode=137)
+    err = worker._closed_error()
+    assert "exit code 137" in str(err)
+    assert "oh no" in str(err)
+
+    # Process still running: the reader failed client-side.
+    worker._proc = _FakeProc(stdout=None, returncode=None)
+    err = worker._closed_error()
+    assert "still running" in str(err)


### PR DESCRIPTION
## Summary
- Fixes the "Codex worker process exited mid-turn" failure whenever a turn runs a CLI command with sizeable output (reported in the dashboard chat and diagnosed on [#86](https://github.com/plotlinelabs/loma/pull/86#issuecomment-4953155179))
- This fix was originally pushed to the #86 branch **after** that PR was squash-merged, so it never landed on `main` — this PR carries the exact commit forward

## Root cause
- `codex app-server` embeds a command's entire output in a **single JSON line** (`item/completed`) — a 108 KB command output arrives as one ~129 KB line
- `CodexWorker._read_loop` used `stdout.readline()`, which enforces asyncio's **64 KiB default line limit** and raises `ValueError` on anything longer
- The catch-all enqueued `__closed`, `run_turn()` misreported it as a process exit, and the pool's single-use discard SIGTERMed the perfectly healthy app-server — making it look like codex "exits" whenever a command runs (text-only turns emit small lines, which is why they worked)
- Compounding: worker stderr went to `DEVNULL`, so real app-server failures were undiagnosable

## Changes
- `agent/codex_runtime.py`
  - Chunked stdout reads with manual line splitting — no line-length limit (64 MB safety valve drops pathological lines with a warning instead of killing the reader)
  - stderr captured into a bounded tail buffer and included in failure messages
  - Mid-turn errors now distinguish `process exited (code N)` from `client-side reader failed`, preserving auth/rate-limit classification
- `dashboard/src/components/ChatPanel.tsx` — status line said "via …'s **Claude** subscription" for Codex models; now says **ChatGPT** subscription
- `tests/test_codex_pool.py` — 3 new regression tests: oversized single-line events, pathological-line recovery, and the new error-message shapes

## Testing
- `python3 -m pytest tests/test_codex_pool.py -q` → **19 passed**
- `scripts/check_public_content.py` → clean
- Verified end-to-end against the real pinned CLI (`@openai/codex@0.144.1`): reproduced the failure with a 108 KB command output on the old reader, then ran the fixed worker — the same turn streamed the full `exec_command_end` payload (108,894 bytes) and completed with `task_complete`

## Notes
- Identical content to commit `f525d14` on the (already-merged) `feat/codex-account-pool` branch, rebased onto `main`
- This PR was generated by the Plotline IE Bot based on the request above
- Please review carefully before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)