### PR TITLE
fix: persist Codex logins across container recreation (missing volume mount)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,10 @@ services:
       # Persist connected Claude Code accounts (CLAUDE_USERS_DIR) across container
       # recreation — otherwise `claude login` creds are lost on every rebuild/redeploy.
       - loma-claude-users:/opt/claude-users
+      # Same persistence for connected Codex (ChatGPT subscription) accounts
+      # (CODEX_USERS_DIR) — otherwise `codex login` creds are lost on every
+      # rebuild/redeploy while Claude logins survive.
+      - loma-codex-users:/opt/codex-users
       - loma-workspace:/opt/loma-workspace
       - ${LOMA_SECRETS_DIR:-/home/ubuntu/secrets}:/home/ubuntu/secrets:ro
       # Host SSH key dir (key authorized on 98.83.133.237), mounted read-only at a
@@ -75,4 +79,5 @@ services:
 volumes:
   loma-skill-assets:
   loma-claude-users:
+  loma-codex-users:
   loma-workspace:


### PR DESCRIPTION
## Problem
Connected Codex (ChatGPT subscription) accounts are lost every time the container is rebuilt/redeployed — users have to re-run `codex login` after each deploy, while Claude logins survive.

## Root cause
`docker-compose.yml` persists Claude credentials via a named volume:

```yaml
- loma-claude-users:/opt/claude-users
```

but the Codex pool (#86) never got the equivalent mount. `CODEX_USERS_DIR` defaults to `/opt/codex-users` (`agent/codex_pool.py`, `api/codex_auth_routes.py`), so every account's `auth.json` was written to the container's ephemeral writable layer and wiped on recreate.

## Fix
Mount a `loma-codex-users` named volume at `/opt/codex-users`, mirroring the Claude one exactly.

## Verification
- `docker compose config` parses / YAML valid
- `scripts/check_public_content.py` clean
- After deploying: connect a Codex account, `docker compose up -d --force-recreate loma-backend`, and confirm the Integrations card still shows **Connected** and the pool warms without re-login

## Note for existing environments
This fixes persistence *going forward* — any login done before this change was in the old container layer and is already gone, so one final `codex login` is needed after the first deploy with this mount (it will then land on the volume and survive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)