### PR TITLE
feat(tasks): two-line card titles + task priority (low/medium/high/urgent)

### DIFF
--- a/api/task_routes.py
+++ b/api/task_routes.py
@@ -112,6 +112,7 @@ MAX_LANES = 10
 MAX_BOARD_PROMPT_LEN = 10000
 MAX_TAGS = 50
 MAX_TAGS_PER_TASK = 10
+TASK_PRIORITIES = ("low", "medium", "high", "urgent")
 MAX_TAG_NAME_LEN = 30
 TAG_COLORS = ("slate", "red", "orange", "amber", "green", "teal", "blue", "violet", "pink")
 # Attachments staged with a draft (base64 in the doc until the task starts).
@@ -215,6 +216,7 @@ def _task_view(task: dict, lane_ids: list[str]) -> dict:
         "task_started_at": _serialize(task.get("task_started_at")),
         "task_done_at": _serialize(task.get("task_done_at")),
         "task_tag_ids": task.get("task_tag_ids") or [],
+        "task_priority": task.get("task_priority") or None,
     }
 
 
@@ -225,6 +227,7 @@ _TASK_PROJECTION = {
     "task_created_at": 1, "task_staged_at": 1, "task_started_at": 1,
     "task_done_at": 1,
     "task_tag_ids": 1,
+    "task_priority": 1,
 }
 
 
@@ -316,6 +319,7 @@ async def handle_create_task(request: web.Request) -> web.Response:
         "task_started_at": now if start else None,
         "task_done_at": None,
         "task_tag_ids": [],
+        "task_priority": None,
     }
     await db.conversations.insert_one(doc)
 
@@ -406,7 +410,8 @@ async def handle_needs_input_count(request: web.Request) -> web.Response:
 async def handle_update_task(request: web.Request) -> web.Response:
     """PATCH /api/tasks/{conversation_id} — board moves, edits, add/remove.
 
-    Accepts any of: task_status, task_lane, task_rank, prompt, title, model, task_tag_ids.
+    Accepts any of: task_status, task_lane, task_rank, prompt, title, model,
+    task_tag_ids, task_priority.
     task_status: null removes the conversation from the board.
     """
     db = get_db()
@@ -542,6 +547,14 @@ async def handle_update_task(request: web.Request) -> web.Response:
         if any(not isinstance(tag_id, str) or tag_id not in allowed for tag_id in tag_ids):
             return web.json_response({"error": "Unknown tag"}, status=400)
         updates["task_tag_ids"] = tag_ids
+
+    if "task_priority" in body:
+        priority = body["task_priority"]
+        if priority is not None and priority not in TASK_PRIORITIES:
+            return web.json_response(
+                {"error": "task_priority must be low, medium, high, urgent or null"},
+                status=400)
+        updates["task_priority"] = priority
 
     if "title" in body:
         title = (body["title"] or "").strip() or None

--- a/dashboard/src/components/tasks/MobileTaskBoard.tsx
+++ b/dashboard/src/components/tasks/MobileTaskBoard.tsx
@@ -26,7 +26,7 @@ export function MobileTaskBoard({
   const {
     laneIds, tasksByColumn,
     startTask, markDone, reopen, moveToLane,
-    removeFromBoard, deleteDraft, openTask,
+    removeFromBoard, deleteDraft, openTask, setTaskPriority,
   } = useTaskBoardActions({
     board, onBoardChange, onRefresh, onEditDraft, onError,
     openActiveInNewTab: false, selectedTagIds, // window.open is hostile in the standalone PWA
@@ -118,6 +118,7 @@ export function MobileTaskBoard({
             onMoveToLane={moveToLane}
             onRemoveFromBoard={removeFromBoard}
             onDeleteDraft={deleteDraft}
+            onSetPriority={setTaskPriority}
           />
         ))}
         {tasks.length === 0 && (

--- a/dashboard/src/components/tasks/MobileTaskCard.tsx
+++ b/dashboard/src/components/tasks/MobileTaskCard.tsx
@@ -21,8 +21,9 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import ClientTimestamp from "@/components/ClientTimestamp";
-import type { BoardLane, Task } from "@/lib/api";
-import { isDraft as isDraftTask, isStaged as isStagedTask, taskDot, taskTimestamp } from "./taskDisplay";
+import type { BoardLane, Task, TaskPriority } from "@/lib/api";
+import { isDraft as isDraftTask, isStaged as isStagedTask, priorityDisplay, taskDot, taskTimestamp } from "./taskDisplay";
+import { PriorityMenuItems, TaskPriorityTag } from "./TaskPriority";
 
 interface MobileTaskCardProps {
   task: Task;
@@ -34,13 +35,14 @@ interface MobileTaskCardProps {
   onMoveToLane: (task: Task, laneId: string) => void;
   onRemoveFromBoard: (task: Task) => void;
   onDeleteDraft: (task: Task) => void;
+  onSetPriority: (task: Task, priority: TaskPriority | null) => void;
 }
 
 /** Touch-first card for the mobile inbox: no drag, actions always visible,
  * larger tap targets. Menus replace drag for moves. */
 export function MobileTaskCard({
   task, lanes, onOpen, onStart, onMarkDone, onReopen,
-  onMoveToLane, onRemoveFromBoard, onDeleteDraft,
+  onMoveToLane, onRemoveFromBoard, onDeleteDraft, onSetPriority,
 }: MobileTaskCardProps) {
   const isStaged = isStagedTask(task);
   const isDraft = isDraftTask(task);
@@ -62,12 +64,15 @@ export function MobileTaskCard({
       <div className="flex items-start gap-2">
         {dot && <span className={cn("mt-2 h-2 w-2 shrink-0 rounded-full", dot)} />}
         <div className="min-w-0 flex-1 py-0.5">
-          <div className="truncate text-[13px]">
+          <div className="line-clamp-2 break-words text-[13px]">
             {task.title || task.prompt}
           </div>
           <div className="mt-0.5 flex items-center gap-2 text-xs text-muted-foreground">
             <ClientTimestamp iso={timestamp} variant="short" placeholder="—" />
             {task.total_turns > 0 && <span>{task.total_turns} turns</span>}
+          </div>
+          <div className="mt-1 flex items-center gap-1 overflow-hidden">
+            <TaskPriorityTag task={task} onSetPriority={onSetPriority} />
           </div>
         </div>
         <div
@@ -100,6 +105,15 @@ export function MobileTaskCard({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
+              <DropdownMenuSub>
+                <DropdownMenuSubTrigger>
+                  <span className="flex-1">Priority</span>
+                  <span className="text-xs text-muted-foreground">{priorityDisplay(task.task_priority)?.label ?? "None"}</span>
+                </DropdownMenuSubTrigger>
+                <DropdownMenuSubContent className="w-40">
+                  <PriorityMenuItems task={task} onSetPriority={onSetPriority} />
+                </DropdownMenuSubContent>
+              </DropdownMenuSub>
               {targetLanes.length > 0 && (
                 <DropdownMenuSub>
                   <DropdownMenuSubTrigger>Move to</DropdownMenuSubTrigger>

--- a/dashboard/src/components/tasks/TaskBoard.tsx
+++ b/dashboard/src/components/tasks/TaskBoard.tsx
@@ -44,7 +44,7 @@ export function TaskBoard({ board, onBoardChange, onRefresh, onEditDraft, onAddT
   const {
     laneIds, columns, tasksByColumn,
     startTask, markDone, reopen, moveToLane, reorderInColumn,
-    removeFromBoard, deleteDraft, openTask, setTaskModel, setTaskTags, createAndAssignTag,
+    removeFromBoard, deleteDraft, openTask, setTaskModel, setTaskPriority, setTaskTags, createAndAssignTag,
   } = useTaskBoardActions({ board, onBoardChange, onRefresh, onEditDraft, onError, selectedTagIds });
 
   const resolveColumn = (overId: string): string | null => {
@@ -138,6 +138,7 @@ export function TaskBoard({ board, onBoardChange, onRefresh, onEditDraft, onAddT
                 onRemoveFromBoard={removeFromBoard}
                 onDeleteDraft={deleteDraft}
                 onSetModel={setTaskModel}
+                onSetPriority={setTaskPriority}
                 onSetTags={setTaskTags}
                 onCreateTag={createAndAssignTag}
               />
@@ -148,7 +149,7 @@ export function TaskBoard({ board, onBoardChange, onRefresh, onEditDraft, onAddT
       <DragOverlay>
         {activeTask && (
           <div className="rounded-md border bg-card px-3 py-2 text-[13px] shadow-md">
-            {activeTask.title || activeTask.prompt}
+            <div className="line-clamp-2 break-words">{activeTask.title || activeTask.prompt}</div>
           </div>
         )}
       </DragOverlay>

--- a/dashboard/src/components/tasks/TaskCard.tsx
+++ b/dashboard/src/components/tasks/TaskCard.tsx
@@ -11,9 +11,10 @@ import {
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import ClientTimestamp from "@/components/ClientTimestamp";
-import type { AgentModel, BoardLane, Task, TaskTag } from "@/lib/api";
+import type { AgentModel, BoardLane, Task, TaskPriority, TaskTag } from "@/lib/api";
 import { isDraft as isDraftTask, isStaged as isStagedTask, taskDot, taskTimestamp } from "./taskDisplay";
 import { TaskCardMenu } from "./TaskCardMenu";
+import { TaskPriorityTag } from "./TaskPriority";
 
 interface TaskCardProps {
   task: Task;
@@ -28,13 +29,14 @@ interface TaskCardProps {
   onRemoveFromBoard: (task: Task) => void;
   onDeleteDraft: (task: Task) => void;
   onSetModel: (task: Task, model: string) => void;
+  onSetPriority: (task: Task, priority: TaskPriority | null) => void;
   onSetTags: (task: Task, tagIds: string[]) => void;
   onCreateTag: (task: Task, name: string) => void;
 }
 
 export function TaskCard({
   task, lanes, tags, models, onOpen, onStart, onMarkDone, onReopen,
-  onMoveToLane, onRemoveFromBoard, onDeleteDraft, onSetModel, onSetTags, onCreateTag,
+  onMoveToLane, onRemoveFromBoard, onDeleteDraft, onSetModel, onSetPriority, onSetTags, onCreateTag,
 }: TaskCardProps) {
   const isStaged = isStagedTask(task);
   const isDraft = isDraftTask(task);
@@ -67,19 +69,18 @@ export function TaskCard({
       <div className="flex items-start gap-2">
         {dot && <span className={cn("mt-1.5 h-2 w-2 shrink-0 rounded-full", dot)} />}
         <div className="min-w-0 flex-1">
-          <div className="truncate text-[13px]">
+          <div className="line-clamp-2 break-words text-[13px]">
             {task.title || task.prompt}
           </div>
           <div className="mt-0.5 flex items-center gap-2 text-xs text-muted-foreground">
             <ClientTimestamp iso={timestamp} variant="short" placeholder="—" />
             {task.total_turns > 0 && <span>{task.total_turns} turns</span>}
           </div>
-          {assignedTags.length > 0 && (
-            <div className="mt-1 flex gap-1 overflow-hidden">
-              {assignedTags.slice(0, 2).map((tag) => <span key={tag.id} className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">{tag.name}</span>)}
-              {assignedTags.length > 2 && <span className="text-[10px] text-muted-foreground">+{assignedTags.length - 2}</span>}
-            </div>
-          )}
+          <div className="mt-1 flex items-center gap-1 overflow-hidden">
+            <TaskPriorityTag task={task} onSetPriority={onSetPriority} />
+            {assignedTags.slice(0, 2).map((tag) => <span key={tag.id} className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">{tag.name}</span>)}
+            {assignedTags.length > 2 && <span className="text-[10px] text-muted-foreground">+{assignedTags.length - 2}</span>}
+          </div>
         </div>
         <div
           // Hover-revealed on pointer devices; always visible on touch
@@ -110,7 +111,7 @@ export function TaskCard({
             open={menuOpen} onOpenChange={setMenuOpen}
             onMoveToLane={onMoveToLane} onReopen={onReopen}
             onRemoveFromBoard={onRemoveFromBoard} onDeleteDraft={onDeleteDraft}
-            onSetModel={onSetModel} onSetTags={onSetTags} onCreateTag={onCreateTag}>
+            onSetModel={onSetModel} onSetPriority={onSetPriority} onSetTags={onSetTags} onCreateTag={onCreateTag}>
               <Button variant="ghost" size="icon" className="h-6 w-6">
                 <RiMoreLine className="h-3.5 w-3.5" />
               </Button>

--- a/dashboard/src/components/tasks/TaskCardMenu.tsx
+++ b/dashboard/src/components/tasks/TaskCardMenu.tsx
@@ -13,8 +13,9 @@ import {
   DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator,
   DropdownMenuSub, DropdownMenuSubContent, DropdownMenuSubTrigger, DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import type { AgentModel, BoardLane, Task, TaskTag } from "@/lib/api";
-import { isDraft as isDraftTask, isStaged as isStagedTask } from "./taskDisplay";
+import type { AgentModel, BoardLane, Task, TaskPriority, TaskTag } from "@/lib/api";
+import { isDraft as isDraftTask, isStaged as isStagedTask, priorityDisplay } from "./taskDisplay";
+import { PriorityMenuItems } from "./TaskPriority";
 
 export interface TaskCardMenuProps {
   task: Task; lanes: BoardLane[]; tags: TaskTag[]; models: AgentModel[];
@@ -25,6 +26,7 @@ export interface TaskCardMenuProps {
   onRemoveFromBoard: (task: Task) => void;
   onDeleteDraft: (task: Task) => void;
   onSetModel: (task: Task, model: string) => void;
+  onSetPriority: (task: Task, priority: TaskPriority | null) => void;
   onSetTags: (task: Task, tagIds: string[]) => void;
   onCreateTag: (task: Task, name: string) => void;
   children: React.ReactNode;
@@ -33,7 +35,7 @@ export interface TaskCardMenuProps {
 /** One task actions menu shared by the overflow button and card right-click. */
 export function TaskCardMenu({ task, lanes, tags, models, open, onOpenChange,
   onMoveToLane, onReopen, onRemoveFromBoard, onDeleteDraft,
-  onSetModel, onSetTags, onCreateTag, children }: TaskCardMenuProps) {
+  onSetModel, onSetPriority, onSetTags, onCreateTag, children }: TaskCardMenuProps) {
   const [query, setQuery] = useState("");
   const isDraft = isDraftTask(task);
   const isStaged = isStagedTask(task);
@@ -73,6 +75,15 @@ export function TaskCardMenu({ task, lanes, tags, models, open, onOpenChange,
                 <span className="flex-1 truncate">{model.label}</span>{task.model === model.id && <RiCheckLine />}
               </DropdownMenuItem>
             ))}
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            <span className="flex-1">Priority</span>
+            <span className="text-xs text-muted-foreground">{priorityDisplay(task.task_priority)?.label ?? "None"}</span>
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="w-40">
+            <PriorityMenuItems task={task} onSetPriority={onSetPriority} />
           </DropdownMenuSubContent>
         </DropdownMenuSub>
         <DropdownMenuSub>

--- a/dashboard/src/components/tasks/TaskPriority.tsx
+++ b/dashboard/src/components/tasks/TaskPriority.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { RiCheckLine } from "@remixicon/react";
+import { cn } from "@/lib/utils";
+import {
+  DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import type { Task, TaskPriority } from "@/lib/api";
+import { TASK_PRIORITIES, priorityDisplay } from "./taskDisplay";
+
+/** Menu items for picking a task priority — shared by the card tag's own
+ * dropdown and the Priority submenu in the card actions menu. */
+export function PriorityMenuItems({ task, onSetPriority }: {
+  task: Task;
+  onSetPriority: (task: Task, priority: TaskPriority | null) => void;
+}) {
+  return (
+    <>
+      {TASK_PRIORITIES.map((priority) => (
+        <DropdownMenuItem key={priority.id} onClick={() => onSetPriority(task, priority.id)}>
+          <span className="w-4 text-center">{priority.symbol}</span>
+          <span className="flex-1">{priority.label}</span>
+          {task.task_priority === priority.id && <RiCheckLine />}
+        </DropdownMenuItem>
+      ))}
+      <DropdownMenuSeparator />
+      <DropdownMenuItem onClick={() => onSetPriority(task, null)}>
+        <span className="w-4 text-center">—</span>
+        <span className="flex-1">No priority</span>
+        {!task.task_priority && <RiCheckLine />}
+      </DropdownMenuItem>
+    </>
+  );
+}
+
+/** The clickable priority tag on a task card. Always rendered so priority is
+ * settable in one click; unset shows a muted "Priority" affordance. */
+export function TaskPriorityTag({ task, onSetPriority }: {
+  task: Task;
+  onSetPriority: (task: Task, priority: TaskPriority | null) => void;
+}) {
+  const display = priorityDisplay(task.task_priority);
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          title="Set priority"
+          // Keep the card's click (open) and pointerdown (drag) handlers out.
+          onClick={(e) => e.stopPropagation()}
+          onPointerDown={(e) => e.stopPropagation()}
+          className={cn(
+            "shrink-0 rounded border px-1.5 py-0.5 text-[10px] leading-4 cursor-pointer",
+            "hover:bg-muted",
+            display
+              ? "border-transparent bg-muted text-muted-foreground"
+              : "border-dashed text-muted-foreground/60",
+          )}
+        >
+          {display ? `${display.symbol} ${display.label}` : "Priority"}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="start" className="w-40"
+        onClick={(e) => e.stopPropagation()}
+        onPointerDown={(e) => e.stopPropagation()}
+      >
+        <PriorityMenuItems task={task} onSetPriority={onSetPriority} />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/dashboard/src/components/tasks/taskDisplay.ts
+++ b/dashboard/src/components/tasks/taskDisplay.ts
@@ -1,4 +1,4 @@
-import type { Task } from "@/lib/api";
+import type { Task, TaskPriority } from "@/lib/api";
 
 // Shared card display derivations for the desktop TaskCard and MobileTaskCard.
 
@@ -19,6 +19,19 @@ export function taskDot(task: Task): string | undefined {
   if (isError) return "bg-red-500";
   if (isParked(task)) return "bg-muted-foreground/40"; // paused, not demanding attention
   return columnDotStyles[task.column];
+}
+
+/** Priority levels in menu order (most urgent first). Text + symbol only —
+ * no color coding by design. */
+export const TASK_PRIORITIES: Array<{ id: TaskPriority; symbol: string; label: string }> = [
+  { id: "urgent", symbol: "\u203c", label: "Urgent" },
+  { id: "high", symbol: "\u2191", label: "High" },
+  { id: "medium", symbol: "\u2192", label: "Medium" },
+  { id: "low", symbol: "\u2193", label: "Low" },
+];
+
+export function priorityDisplay(priority: TaskPriority | null | undefined) {
+  return TASK_PRIORITIES.find((p) => p.id === priority) ?? null;
 }
 
 export function taskTimestamp(task: Task): string | null {

--- a/dashboard/src/components/tasks/useTaskBoardActions.ts
+++ b/dashboard/src/components/tasks/useTaskBoardActions.ts
@@ -9,6 +9,7 @@ import {
   createTaskTag,
   type BoardLane,
   type Task,
+  type TaskPriority,
   type TasksBoardResponse,
 } from "@/lib/api";
 
@@ -149,6 +150,12 @@ export function useTaskBoardActions({
       () => updateTask(task.conversation_id, { model }),
     );
 
+  const setTaskPriority = (task: Task, task_priority: TaskPriority | null) =>
+    mutate(
+      (tasks) => tasks.map((t) => t.conversation_id === task.conversation_id ? { ...t, task_priority } : t),
+      () => updateTask(task.conversation_id, { task_priority }),
+    );
+
   const setTaskTags = (task: Task, task_tag_ids: string[]) =>
     mutate(
       (tasks) => tasks.map((t) => t.conversation_id === task.conversation_id ? { ...t, task_tag_ids } : t),
@@ -203,6 +210,7 @@ export function useTaskBoardActions({
     removeFromBoard,
     deleteDraft,
     setTaskModel,
+    setTaskPriority,
     setTaskTags,
     createAndAssignTag,
     openTask,

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -972,6 +972,8 @@ export interface TaskTag {
   created_at: string;
 }
 
+export type TaskPriority = "low" | "medium" | "high" | "urgent";
+
 export interface Task {
   conversation_id: string;
   title: string | null;
@@ -991,6 +993,7 @@ export interface Task {
   task_started_at: string | null;
   task_done_at: string | null;
   task_tag_ids: string[];
+  task_priority: TaskPriority | null;
 }
 
 export interface TasksBoardResponse {
@@ -1051,6 +1054,7 @@ export async function updateTask(
     title?: string;
     model?: string;
     task_tag_ids?: string[];
+    task_priority?: TaskPriority | null;
   },
 ): Promise<{ task: Task | null }> {
   const res = await fetch(`${API_BASE}/api/tasks/${conversationId}`, {


### PR DESCRIPTION
## Summary

Two improvements to the Tasks board:

1. **Two-line card titles** — task card titles now wrap to two lines before truncating with `…` (previously clamped at one line). Applied to the desktop card, mobile card, and the drag overlay.
2. **Task priority** — each task can be assigned a priority: `‼ Urgent`, `↑ High`, `→ Medium`, `↓ Low` (text + symbol only, no color coding, per spec). Priority can be changed two ways:
   - Clicking the priority tag on the card (an unset task shows a muted dashed `Priority` affordance, so it's always one click away)
   - A **Priority** submenu in the card's right-click / overflow menu (shows the current value, includes "No priority" to clear)

## Changes

**Backend** (`api/task_routes.py`)
- New `task_priority` field: included in `_task_view`, `_TASK_PROJECTION`, and new-task docs
- `PATCH /api/tasks/{id}` accepts `task_priority` with validation — must be `low | medium | high | urgent | null`, otherwise `400`

**Frontend** (`dashboard/`)
- `lib/api.ts` — `TaskPriority` type, `Task.task_priority`, `updateTask` support
- `components/tasks/taskDisplay.ts` — `TASK_PRIORITIES` (symbols + labels) and `priorityDisplay()` shared helpers
- `components/tasks/TaskPriority.tsx` (new) — `TaskPriorityTag` (clickable card tag) + `PriorityMenuItems` (shared menu items)
- `TaskCard.tsx` / `MobileTaskCard.tsx` — `line-clamp-2` titles, priority tag, prop threading
- `TaskCardMenu.tsx` / mobile menu — Priority submenu with current-value hint and checkmark
- `useTaskBoardActions.ts` — `setTaskPriority` optimistic mutation
- `TaskBoard.tsx` / `MobileTaskBoard.tsx` — wiring; drag overlay also clamps at 2 lines

## Testing

Verified end-to-end on a local isolated stack (backend + dashboard against a throwaway DB), driving the real UI with Playwright at 1440×900.

**API checks (against the live local backend):**
- `POST /api/tasks` → `201`, response includes `"task_priority": null` ✅
- `PATCH` with `task_priority: "extreme"` → `400` `{"error":"task_priority must be low, medium, high, urgent or null"}` ✅
- `PATCH` with `task_priority: "low"` → `200`, response echoes `"task_priority": "low"` ✅

**UI checks (screenshots):**

1. Board with a long-title card clamped at **two lines + ellipsis**, and unset `Priority` tags on both cards:
![board](https://cdn.plotline.so/loma-images/loma-pr-artifacts/task-priority/loma-feat-1-board.png)

2. Clicking the priority tag opens the picker (`‼ Urgent / ↑ High / → Medium / ↓ Low / — No priority`):
![tag menu](https://cdn.plotline.so/loma-images/loma-pr-artifacts/task-priority/loma-feat-2-tag-menu.png)

3. `‼ Urgent` set via the tag click:
![urgent set](https://cdn.plotline.so/loma-images/loma-pr-artifacts/task-priority/loma-feat-3-urgent-set.png)

4. Right-click context menu with the **Priority** submenu (current value shown as `None`):
![context menu](https://cdn.plotline.so/loma-images/loma-pr-artifacts/task-priority/loma-feat-4-context-menu.png)

5. After a full page reload — `↑ High` and `‼ Urgent` persisted on their cards:
![after reload](https://cdn.plotline.so/loma-images/loma-pr-artifacts/task-priority/loma-feat-5-after-reload.png)

**Other checks:**
- `tsc --noEmit` → clean
- Card click/drag unaffected: the tag stops `click`/`pointerdown` propagation so opening the picker neither opens the task nor starts a drag
- Removing a task from the board keeps `task_priority` on the conversation doc (same behavior as tags), so re-adding restores it

🤖 Generated with [Claude Code](https://claude.com/claude-code)