### PR TITLE
feat: optional task deadline with calendar picker on task cards

### DIFF
--- a/api/task_routes.py
+++ b/api/task_routes.py
@@ -22,7 +22,7 @@ import logging
 import os
 import re
 import uuid
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 
 from aiohttp import web
 
@@ -113,6 +113,8 @@ MAX_BOARD_PROMPT_LEN = 10000
 MAX_TAGS = 50
 MAX_TAGS_PER_TASK = 10
 TASK_PRIORITIES = ("low", "medium", "high", "urgent")
+# Deadlines are date-only, stored as "YYYY-MM-DD" strings (timezone-agnostic).
+DEADLINE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 MAX_TAG_NAME_LEN = 30
 TAG_COLORS = ("slate", "red", "orange", "amber", "green", "teal", "blue", "violet", "pink")
 # Attachments staged with a draft (base64 in the doc until the task starts).
@@ -217,6 +219,7 @@ def _task_view(task: dict, lane_ids: list[str]) -> dict:
         "task_done_at": _serialize(task.get("task_done_at")),
         "task_tag_ids": task.get("task_tag_ids") or [],
         "task_priority": task.get("task_priority") or None,
+        "task_deadline": task.get("task_deadline") or None,
     }
 
 
@@ -228,6 +231,7 @@ _TASK_PROJECTION = {
     "task_done_at": 1,
     "task_tag_ids": 1,
     "task_priority": 1,
+    "task_deadline": 1,
 }
 
 
@@ -320,6 +324,7 @@ async def handle_create_task(request: web.Request) -> web.Response:
         "task_done_at": None,
         "task_tag_ids": [],
         "task_priority": None,
+        "task_deadline": None,
     }
     await db.conversations.insert_one(doc)
 
@@ -411,7 +416,7 @@ async def handle_update_task(request: web.Request) -> web.Response:
     """PATCH /api/tasks/{conversation_id} — board moves, edits, add/remove.
 
     Accepts any of: task_status, task_lane, task_rank, prompt, title, model,
-    task_tag_ids, task_priority.
+    task_tag_ids, task_priority, task_deadline.
     task_status: null removes the conversation from the board.
     """
     db = get_db()
@@ -555,6 +560,21 @@ async def handle_update_task(request: web.Request) -> web.Response:
                 {"error": "task_priority must be low, medium, high, urgent or null"},
                 status=400)
         updates["task_priority"] = priority
+
+    if "task_deadline" in body:
+        deadline = body["task_deadline"]
+        if deadline is not None:
+            if not isinstance(deadline, str) or not DEADLINE_RE.match(deadline):
+                return web.json_response(
+                    {"error": "task_deadline must be a YYYY-MM-DD date or null"},
+                    status=400)
+            try:
+                date.fromisoformat(deadline)
+            except ValueError:
+                return web.json_response(
+                    {"error": "task_deadline must be a valid calendar date"},
+                    status=400)
+        updates["task_deadline"] = deadline
 
     if "title" in body:
         title = (body["title"] or "").strip() or None

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -25,6 +25,7 @@
         "next-auth": "^5.0.0-beta.30",
         "radix-ui": "^1.6.0",
         "react": "19.2.3",
+        "react-day-picker": "^9.14.0",
         "react-dom": "19.2.3",
         "react-markdown": "^10.1.0",
         "recharts": "^3.7.0",
@@ -544,6 +545,11 @@
       "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
       "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@date-fns/tz": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.5.0.tgz",
+      "integrity": "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg=="
     },
     "node_modules/@dnd-kit/accessibility": {
       "version": "3.1.1",
@@ -3605,6 +3611,14 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tabby_ai/hijri-converter": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@tabby_ai/hijri-converter/-/hijri-converter-1.0.5.tgz",
+      "integrity": "sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@tailwindcss/node": {
@@ -6679,6 +6693,20 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/date-fns": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-jalali": {
+      "version": "4.1.0-0",
+      "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
+      "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg=="
     },
     "node_modules/dayjs": {
       "version": "1.11.20",
@@ -12847,6 +12875,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-day-picker": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.14.0.tgz",
+      "integrity": "sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==",
+      "dependencies": {
+        "@date-fns/tz": "^1.4.1",
+        "@tabby_ai/hijri-converter": "1.0.5",
+        "date-fns": "^4.1.0",
+        "date-fns-jalali": "4.1.0-0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/gpbl"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/react-dom": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -26,6 +26,7 @@
     "next-auth": "^5.0.0-beta.30",
     "radix-ui": "^1.6.0",
     "react": "19.2.3",
+    "react-day-picker": "^9.14.0",
     "react-dom": "19.2.3",
     "react-markdown": "^10.1.0",
     "recharts": "^3.7.0",

--- a/dashboard/src/components/tasks/MobileTaskBoard.tsx
+++ b/dashboard/src/components/tasks/MobileTaskBoard.tsx
@@ -26,7 +26,7 @@ export function MobileTaskBoard({
   const {
     laneIds, tasksByColumn,
     startTask, markDone, reopen, moveToLane,
-    removeFromBoard, deleteDraft, openTask, setTaskPriority,
+    removeFromBoard, deleteDraft, openTask, setTaskPriority, setTaskDeadline,
   } = useTaskBoardActions({
     board, onBoardChange, onRefresh, onEditDraft, onError,
     openActiveInNewTab: false, selectedTagIds, // window.open is hostile in the standalone PWA
@@ -119,6 +119,7 @@ export function MobileTaskBoard({
             onRemoveFromBoard={removeFromBoard}
             onDeleteDraft={deleteDraft}
             onSetPriority={setTaskPriority}
+            onSetDeadline={setTaskDeadline}
           />
         ))}
         {tasks.length === 0 && (

--- a/dashboard/src/components/tasks/MobileTaskCard.tsx
+++ b/dashboard/src/components/tasks/MobileTaskCard.tsx
@@ -22,8 +22,9 @@ import {
 } from "@/components/ui/dropdown-menu";
 import ClientTimestamp from "@/components/ClientTimestamp";
 import type { BoardLane, Task, TaskPriority } from "@/lib/api";
-import { isDraft as isDraftTask, isStaged as isStagedTask, priorityDisplay, taskDot, taskTimestamp } from "./taskDisplay";
+import { deadlineDisplay, isDraft as isDraftTask, isStaged as isStagedTask, priorityDisplay, taskDot, taskTimestamp } from "./taskDisplay";
 import { PriorityMenuItems, TaskPriorityTag } from "./TaskPriority";
+import { DeadlineMenuItems, TaskDeadlineBadge } from "./TaskDeadline";
 
 interface MobileTaskCardProps {
   task: Task;
@@ -36,13 +37,14 @@ interface MobileTaskCardProps {
   onRemoveFromBoard: (task: Task) => void;
   onDeleteDraft: (task: Task) => void;
   onSetPriority: (task: Task, priority: TaskPriority | null) => void;
+  onSetDeadline: (task: Task, deadline: string | null) => void;
 }
 
 /** Touch-first card for the mobile inbox: no drag, actions always visible,
  * larger tap targets. Menus replace drag for moves. */
 export function MobileTaskCard({
   task, lanes, onOpen, onStart, onMarkDone, onReopen,
-  onMoveToLane, onRemoveFromBoard, onDeleteDraft, onSetPriority,
+  onMoveToLane, onRemoveFromBoard, onDeleteDraft, onSetPriority, onSetDeadline,
 }: MobileTaskCardProps) {
   const isStaged = isStagedTask(task);
   const isDraft = isDraftTask(task);
@@ -73,6 +75,7 @@ export function MobileTaskCard({
           </div>
           <div className="mt-1 flex items-center gap-1 overflow-hidden">
             <TaskPriorityTag task={task} onSetPriority={onSetPriority} />
+            <TaskDeadlineBadge task={task} />
           </div>
         </div>
         <div
@@ -112,6 +115,15 @@ export function MobileTaskCard({
                 </DropdownMenuSubTrigger>
                 <DropdownMenuSubContent className="w-40">
                   <PriorityMenuItems task={task} onSetPriority={onSetPriority} />
+                </DropdownMenuSubContent>
+              </DropdownMenuSub>
+              <DropdownMenuSub>
+                <DropdownMenuSubTrigger>
+                  <span className="flex-1">Deadline</span>
+                  <span className="text-xs text-muted-foreground">{deadlineDisplay(task.task_deadline)?.dateLabel ?? "None"}</span>
+                </DropdownMenuSubTrigger>
+                <DropdownMenuSubContent>
+                  <DeadlineMenuItems task={task} onSetDeadline={onSetDeadline} />
                 </DropdownMenuSubContent>
               </DropdownMenuSub>
               {targetLanes.length > 0 && (

--- a/dashboard/src/components/tasks/TaskBoard.tsx
+++ b/dashboard/src/components/tasks/TaskBoard.tsx
@@ -44,7 +44,7 @@ export function TaskBoard({ board, onBoardChange, onRefresh, onEditDraft, onAddT
   const {
     laneIds, columns, tasksByColumn,
     startTask, markDone, reopen, moveToLane, reorderInColumn,
-    removeFromBoard, deleteDraft, openTask, setTaskModel, setTaskPriority, setTaskTags, createAndAssignTag,
+    removeFromBoard, deleteDraft, openTask, setTaskModel, setTaskPriority, setTaskDeadline, setTaskTags, createAndAssignTag,
   } = useTaskBoardActions({ board, onBoardChange, onRefresh, onEditDraft, onError, selectedTagIds });
 
   const resolveColumn = (overId: string): string | null => {
@@ -139,6 +139,7 @@ export function TaskBoard({ board, onBoardChange, onRefresh, onEditDraft, onAddT
                 onDeleteDraft={deleteDraft}
                 onSetModel={setTaskModel}
                 onSetPriority={setTaskPriority}
+                onSetDeadline={setTaskDeadline}
                 onSetTags={setTaskTags}
                 onCreateTag={createAndAssignTag}
               />

--- a/dashboard/src/components/tasks/TaskCard.tsx
+++ b/dashboard/src/components/tasks/TaskCard.tsx
@@ -15,6 +15,7 @@ import type { AgentModel, BoardLane, Task, TaskPriority, TaskTag } from "@/lib/a
 import { isDraft as isDraftTask, isStaged as isStagedTask, taskDot, taskTimestamp } from "./taskDisplay";
 import { TaskCardMenu } from "./TaskCardMenu";
 import { TaskPriorityTag } from "./TaskPriority";
+import { TaskDeadlineBadge } from "./TaskDeadline";
 
 interface TaskCardProps {
   task: Task;
@@ -30,13 +31,14 @@ interface TaskCardProps {
   onDeleteDraft: (task: Task) => void;
   onSetModel: (task: Task, model: string) => void;
   onSetPriority: (task: Task, priority: TaskPriority | null) => void;
+  onSetDeadline: (task: Task, deadline: string | null) => void;
   onSetTags: (task: Task, tagIds: string[]) => void;
   onCreateTag: (task: Task, name: string) => void;
 }
 
 export function TaskCard({
   task, lanes, tags, models, onOpen, onStart, onMarkDone, onReopen,
-  onMoveToLane, onRemoveFromBoard, onDeleteDraft, onSetModel, onSetPriority, onSetTags, onCreateTag,
+  onMoveToLane, onRemoveFromBoard, onDeleteDraft, onSetModel, onSetPriority, onSetDeadline, onSetTags, onCreateTag,
 }: TaskCardProps) {
   const isStaged = isStagedTask(task);
   const isDraft = isDraftTask(task);
@@ -78,6 +80,7 @@ export function TaskCard({
           </div>
           <div className="mt-1 flex items-center gap-1 overflow-hidden">
             <TaskPriorityTag task={task} onSetPriority={onSetPriority} />
+            <TaskDeadlineBadge task={task} />
             {assignedTags.slice(0, 2).map((tag) => <span key={tag.id} className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">{tag.name}</span>)}
             {assignedTags.length > 2 && <span className="text-[10px] text-muted-foreground">+{assignedTags.length - 2}</span>}
           </div>
@@ -111,7 +114,7 @@ export function TaskCard({
             open={menuOpen} onOpenChange={setMenuOpen}
             onMoveToLane={onMoveToLane} onReopen={onReopen}
             onRemoveFromBoard={onRemoveFromBoard} onDeleteDraft={onDeleteDraft}
-            onSetModel={onSetModel} onSetPriority={onSetPriority} onSetTags={onSetTags} onCreateTag={onCreateTag}>
+            onSetModel={onSetModel} onSetPriority={onSetPriority} onSetDeadline={onSetDeadline} onSetTags={onSetTags} onCreateTag={onCreateTag}>
               <Button variant="ghost" size="icon" className="h-6 w-6">
                 <RiMoreLine className="h-3.5 w-3.5" />
               </Button>

--- a/dashboard/src/components/tasks/TaskCardMenu.tsx
+++ b/dashboard/src/components/tasks/TaskCardMenu.tsx
@@ -14,8 +14,9 @@ import {
   DropdownMenuSub, DropdownMenuSubContent, DropdownMenuSubTrigger, DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import type { AgentModel, BoardLane, Task, TaskPriority, TaskTag } from "@/lib/api";
-import { isDraft as isDraftTask, isStaged as isStagedTask, priorityDisplay } from "./taskDisplay";
+import { deadlineDisplay, isDraft as isDraftTask, isStaged as isStagedTask, priorityDisplay } from "./taskDisplay";
 import { PriorityMenuItems } from "./TaskPriority";
+import { DeadlineMenuItems } from "./TaskDeadline";
 
 export interface TaskCardMenuProps {
   task: Task; lanes: BoardLane[]; tags: TaskTag[]; models: AgentModel[];
@@ -27,6 +28,7 @@ export interface TaskCardMenuProps {
   onDeleteDraft: (task: Task) => void;
   onSetModel: (task: Task, model: string) => void;
   onSetPriority: (task: Task, priority: TaskPriority | null) => void;
+  onSetDeadline: (task: Task, deadline: string | null) => void;
   onSetTags: (task: Task, tagIds: string[]) => void;
   onCreateTag: (task: Task, name: string) => void;
   children: React.ReactNode;
@@ -35,7 +37,7 @@ export interface TaskCardMenuProps {
 /** One task actions menu shared by the overflow button and card right-click. */
 export function TaskCardMenu({ task, lanes, tags, models, open, onOpenChange,
   onMoveToLane, onReopen, onRemoveFromBoard, onDeleteDraft,
-  onSetModel, onSetPriority, onSetTags, onCreateTag, children }: TaskCardMenuProps) {
+  onSetModel, onSetPriority, onSetDeadline, onSetTags, onCreateTag, children }: TaskCardMenuProps) {
   const [query, setQuery] = useState("");
   const isDraft = isDraftTask(task);
   const isStaged = isStagedTask(task);
@@ -84,6 +86,15 @@ export function TaskCardMenu({ task, lanes, tags, models, open, onOpenChange,
           </DropdownMenuSubTrigger>
           <DropdownMenuSubContent className="w-40">
             <PriorityMenuItems task={task} onSetPriority={onSetPriority} />
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            <span className="flex-1">Deadline</span>
+            <span className="text-xs text-muted-foreground">{deadlineDisplay(task.task_deadline)?.dateLabel ?? "None"}</span>
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent>
+            <DeadlineMenuItems task={task} onSetDeadline={onSetDeadline} onPicked={() => onOpenChange(false)} />
           </DropdownMenuSubContent>
         </DropdownMenuSub>
         <DropdownMenuSub>

--- a/dashboard/src/components/tasks/TaskDeadline.tsx
+++ b/dashboard/src/components/tasks/TaskDeadline.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { RiCalendarLine, RiDeleteBack2Line } from "@remixicon/react";
+import { cn } from "@/lib/utils";
+import { Calendar } from "@/components/ui/calendar";
+import { DropdownMenuItem, DropdownMenuSeparator } from "@/components/ui/dropdown-menu";
+import type { Task } from "@/lib/api";
+import { deadlineDisplay, parseDeadline, toDeadlineString } from "./taskDisplay";
+
+/** Calendar picker + remove option for the Deadline submenu of the card
+ * actions menu — shared by the desktop and mobile cards. */
+export function DeadlineMenuItems({ task, onSetDeadline, onPicked }: {
+  task: Task;
+  onSetDeadline: (task: Task, deadline: string | null) => void;
+  /** Called after a date is picked or cleared, to close the menu. */
+  onPicked?: () => void;
+}) {
+  const selected = parseDeadline(task.task_deadline) ?? undefined;
+  return (
+    <>
+      <Calendar
+        mode="single"
+        selected={selected}
+        defaultMonth={selected}
+        onSelect={(date) => {
+          if (!date) return;
+          onSetDeadline(task, toDeadlineString(date));
+          onPicked?.();
+        }}
+      />
+      {task.task_deadline && (
+        <>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onClick={() => { onSetDeadline(task, null); onPicked?.(); }}>
+            <RiDeleteBack2Line className="h-3.5 w-3.5" /> Remove deadline
+          </DropdownMenuItem>
+        </>
+      )}
+    </>
+  );
+}
+
+/** Deadline badge on a task card: date + days remaining, red when the
+ * deadline is less than 2 days away (or already missed). */
+export function TaskDeadlineBadge({ task, className }: { task: Task; className?: string }) {
+  const display = deadlineDisplay(task.task_deadline);
+  if (!display) return null;
+  return (
+    <span
+      title={`Deadline: ${display.fullDate}`}
+      className={cn(
+        "flex shrink-0 items-center gap-1 rounded bg-muted px-1.5 py-0.5 text-[10px] leading-4 text-muted-foreground",
+        display.urgent && "bg-destructive/10 text-destructive",
+        className,
+      )}
+    >
+      <RiCalendarLine className="h-3 w-3 shrink-0" />
+      {display.dateLabel} · {display.remainingLabel}
+    </span>
+  );
+}

--- a/dashboard/src/components/tasks/taskDisplay.ts
+++ b/dashboard/src/components/tasks/taskDisplay.ts
@@ -40,3 +40,41 @@ export function taskTimestamp(task: Task): string | null {
     : task.column === "done" ? task.task_done_at
     : task.task_staged_at;
 }
+
+// ── Deadlines ────────────────────────────────────────────────────────────────
+
+/** Parse a "YYYY-MM-DD" deadline into a local-midnight Date. */
+export function parseDeadline(deadline: string | null | undefined): Date | null {
+  if (!deadline) return null;
+  const [y, m, d] = deadline.split("-").map(Number);
+  if (!y || !m || !d) return null;
+  return new Date(y, m - 1, d);
+}
+
+/** Format a Date as a "YYYY-MM-DD" deadline string (local calendar date). */
+export function toDeadlineString(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+}
+
+/** Card display shape for a task deadline. `urgent` flags deadlines less than
+ * 2 days away (due tomorrow, today, or overdue) — rendered in red. */
+export function deadlineDisplay(deadline: string | null | undefined) {
+  const date = parseDeadline(deadline);
+  if (!date) return null;
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const daysLeft = Math.round((date.getTime() - today.getTime()) / 86_400_000);
+  const remainingLabel =
+    daysLeft < 0 ? `${-daysLeft}d overdue`
+    : daysLeft === 0 ? "due today"
+    : `${daysLeft}d left`;
+  return {
+    date,
+    daysLeft,
+    dateLabel: date.toLocaleDateString(undefined, { month: "short", day: "numeric" }),
+    fullDate: date.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" }),
+    remainingLabel,
+    urgent: daysLeft < 2,
+  };
+}

--- a/dashboard/src/components/tasks/useTaskBoardActions.ts
+++ b/dashboard/src/components/tasks/useTaskBoardActions.ts
@@ -156,6 +156,12 @@ export function useTaskBoardActions({
       () => updateTask(task.conversation_id, { task_priority }),
     );
 
+  const setTaskDeadline = (task: Task, task_deadline: string | null) =>
+    mutate(
+      (tasks) => tasks.map((t) => t.conversation_id === task.conversation_id ? { ...t, task_deadline } : t),
+      () => updateTask(task.conversation_id, { task_deadline }),
+    );
+
   const setTaskTags = (task: Task, task_tag_ids: string[]) =>
     mutate(
       (tasks) => tasks.map((t) => t.conversation_id === task.conversation_id ? { ...t, task_tag_ids } : t),
@@ -211,6 +217,7 @@ export function useTaskBoardActions({
     deleteDraft,
     setTaskModel,
     setTaskPriority,
+    setTaskDeadline,
     setTaskTags,
     createAndAssignTag,
     openTask,

--- a/dashboard/src/components/ui/calendar.tsx
+++ b/dashboard/src/components/ui/calendar.tsx
@@ -1,0 +1,97 @@
+"use client"
+
+import * as React from "react"
+import { RiArrowLeftSLine, RiArrowRightSLine } from "@remixicon/react"
+import { DayButton, DayPicker, getDefaultClassNames } from "react-day-picker"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+function Calendar({
+  className,
+  classNames,
+  showOutsideDays = true,
+  ...props
+}: React.ComponentProps<typeof DayPicker>) {
+  const defaultClassNames = getDefaultClassNames()
+
+  return (
+    <DayPicker
+      data-slot="calendar"
+      showOutsideDays={showOutsideDays}
+      className={cn("group/calendar bg-transparent p-2", className)}
+      classNames={{
+        root: cn("w-fit", defaultClassNames.root),
+        months: cn("relative flex flex-col gap-4", defaultClassNames.months),
+        month: cn("flex w-full flex-col gap-3", defaultClassNames.month),
+        nav: cn(
+          "absolute inset-x-0 top-0 flex w-full items-center justify-between gap-1",
+          defaultClassNames.nav,
+        ),
+        button_previous: cn(
+          buttonVariants({ variant: "ghost", size: "icon-sm" }),
+          "select-none aria-disabled:opacity-50",
+          defaultClassNames.button_previous,
+        ),
+        button_next: cn(
+          buttonVariants({ variant: "ghost", size: "icon-sm" }),
+          "select-none aria-disabled:opacity-50",
+          defaultClassNames.button_next,
+        ),
+        month_caption: cn(
+          "flex h-7 w-full items-center justify-center px-8",
+          defaultClassNames.month_caption,
+        ),
+        caption_label: cn("select-none text-sm font-medium", defaultClassNames.caption_label),
+        month_grid: "w-full border-collapse",
+        weekdays: cn("flex", defaultClassNames.weekdays),
+        weekday: cn(
+          "w-8 select-none text-[0.8rem] font-normal text-muted-foreground",
+          defaultClassNames.weekday,
+        ),
+        week: cn("mt-1 flex w-full", defaultClassNames.week),
+        day: cn("group/day relative select-none p-0 text-center", defaultClassNames.day),
+        today: cn("[&>button]:bg-muted [&>button]:font-medium", defaultClassNames.today),
+        outside: cn("text-muted-foreground/50", defaultClassNames.outside),
+        disabled: cn("text-muted-foreground opacity-50", defaultClassNames.disabled),
+        hidden: cn("invisible", defaultClassNames.hidden),
+        ...classNames,
+      }}
+      components={{
+        Chevron: ({ className: chevronClassName, orientation, ...chevronProps }) =>
+          orientation === "left" ? (
+            <RiArrowLeftSLine className={cn("size-4", chevronClassName)} {...chevronProps} />
+          ) : (
+            <RiArrowRightSLine className={cn("size-4", chevronClassName)} {...chevronProps} />
+          ),
+        DayButton: CalendarDayButton,
+      }}
+      {...props}
+    />
+  )
+}
+
+function CalendarDayButton({
+  className,
+  day,
+  modifiers,
+  ...props
+}: React.ComponentProps<typeof DayButton>) {
+  return (
+    <button
+      type="button"
+      data-day={day.date.toLocaleDateString()}
+      className={cn(
+        buttonVariants({ variant: "ghost" }),
+        "size-8 p-0 text-[13px] font-normal",
+        modifiers.selected &&
+          "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground",
+        modifiers.outside && "text-muted-foreground/50",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Calendar }

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -994,6 +994,8 @@ export interface Task {
   task_done_at: string | null;
   task_tag_ids: string[];
   task_priority: TaskPriority | null;
+  /** Optional deadline as a date-only "YYYY-MM-DD" string. */
+  task_deadline: string | null;
 }
 
 export interface TasksBoardResponse {
@@ -1055,6 +1057,7 @@ export async function updateTask(
     model?: string;
     task_tag_ids?: string[];
     task_priority?: TaskPriority | null;
+    task_deadline?: string | null;
   },
 ): Promise<{ task: Task | null }> {
   const res = await fetch(`${API_BASE}/api/tasks/${conversationId}`, {


### PR DESCRIPTION
## Summary
- Tasks can now have an **optional deadline**, set from the task card's right-click (and `⋯`) menu via a new **Deadline** submenu with a calendar picker
- Cards with a deadline show a badge with the **date + days remaining** (e.g. `Jul 20 · 7d left`); the badge turns **red when the deadline is less than 2 days away** (due tomorrow, due today, or overdue)
- A **Remove deadline** option appears in the submenu when a deadline is set

## Context
Requested by Adarsh via the taskboard: allow adding an optional deadline to a task, settable/removable from the card's right-click options with a calendar picker, with the card showing date + days remaining and turning red under 2 days.

## Changes
- `api/task_routes.py` — new `task_deadline` field (date-only `YYYY-MM-DD` string): default on create, included in card payload/projection, PATCH support with strict validation (regex + real-calendar-date check, `null` clears)
- `dashboard/src/lib/api.ts` — `task_deadline` on the `Task` type and `updateTask()`
- `dashboard/src/components/ui/calendar.tsx` — new shadcn-style `Calendar` component wrapping `react-day-picker` v9 (adapted to this repo's remixicon + `buttonVariants` conventions)
- `dashboard/src/components/tasks/TaskDeadline.tsx` — new `DeadlineMenuItems` (calendar + remove) and `TaskDeadlineBadge` (date + days remaining, red when `< 2` days)
- `dashboard/src/components/tasks/taskDisplay.ts` — `parseDeadline` / `toDeadlineString` / `deadlineDisplay` helpers (local-timezone day math)
- `dashboard/src/components/tasks/TaskCardMenu.tsx` — Deadline submenu in the shared card actions menu (right-click + overflow button)
- `dashboard/src/components/tasks/TaskCard.tsx`, `MobileTaskCard.tsx` — deadline badge on the card; mobile gets the same submenu
- `dashboard/src/components/tasks/useTaskBoardActions.ts` — `setTaskDeadline` optimistic mutation
- `dashboard/src/components/tasks/TaskBoard.tsx`, `MobileTaskBoard.tsx` — prop threading
- `dashboard/package.json` — added `react-day-picker@^9`

## Testing
Verified end-to-end on a local boot of the full stack (backend + dashboard against a throwaway DB, per the run-loma-local flow) with a Playwright browser session — **11/11 checks passed**:

| # | Check | Result |
|---|-------|--------|
| 1 | Right-click menu shows Deadline submenu with calendar picker | ✅ |
| 2 | Badge shows date + days remaining (`Jul 20 · 7d left`) | ✅ |
| 3 | 7-days-out badge is NOT red | ✅ |
| 4 | Due-tomorrow badge shows `Jul 14 · 1d left` | ✅ |
| 5 | Due-tomorrow badge IS red (< 2 days) | ✅ |
| 6 | Deadline persists across page reload | ✅ |
| 7 | PATCH rejects non-date string (400) | ✅ |
| 8 | PATCH rejects impossible date `2026-02-30` (400) | ✅ |
| 9 | PATCH accepts valid date (200) | ✅ |
| 10 | PATCH accepts `null` to clear (200) | ✅ |
| 11 | "Remove deadline" clears the badge | ✅ |

Also ran `tsc --noEmit` (clean) and `eslint` on all touched files (no new warnings).

### Screenshots
**1. Right-click → Deadline submenu with calendar picker**
![calendar picker open](https://cdn.plotline.so/loma-images/loma-task-deadline/1-calendar-picker-open.png)

**2. Badges on cards — red `Jul 14 · 1d left` (< 2 days) vs normal `Jul 20 · 7d left`**
![board badges](https://cdn.plotline.so/loma-images/loma-task-deadline/2-board-badges.png)

**3. Deadline already set — selected date highlighted + "Remove deadline" option**
![remove deadline option](https://cdn.plotline.so/loma-images/loma-task-deadline/3-remove-deadline-option.png)

**4. After removal — badges cleared**
![after remove](https://cdn.plotline.so/loma-images/loma-task-deadline/4-after-remove.png)

## Notes
- Deadlines are stored as date-only `YYYY-MM-DD` strings (timezone-agnostic); days remaining is computed against the viewer's local calendar day
- This PR was generated by the Plotline agent based on the request above — please review carefully before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)
