### PR TITLE
feat: expose Integrations to all roles

### DIFF
--- a/dashboard/src/app/integrations/manage/page.tsx
+++ b/dashboard/src/app/integrations/manage/page.tsx
@@ -317,8 +317,7 @@ export default function IntegrationsPage() {
   const [disconnectingOrg, setDisconnectingOrg] = useState<string | null>(null);
   const [webhookUrls, setWebhookUrls] = useState<Record<string, string>>({});
 
-  const { hasRole, isAdmin } = useUser();
-  const canManageOrgIntegrations = hasRole("maintainer");
+  const { isAdmin } = useUser();
 
   const [showCustomModal, setShowCustomModal] = useState(false);
   const [customForm, setCustomForm] = useState({
@@ -963,7 +962,7 @@ export default function IntegrationsPage() {
 
           {/* Org Integrations */}
           <TabsContent value="org">
-            {canManageOrgIntegrations && userManagedIntegrations.length > 0 ? (
+            {userManagedIntegrations.length > 0 ? (
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-2">
               {userManagedIntegrations.map((integ) => {
                 const isOrgConnected = integ.status === "connected";
@@ -1097,7 +1096,7 @@ export default function IntegrationsPage() {
 
           {/* System-Managed Integrations */}
           <TabsContent value="system">
-            {canManageOrgIntegrations && systemManagedIntegrations.length > 0 ? (
+            {systemManagedIntegrations.length > 0 ? (
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-2">
               {systemManagedIntegrations.map((integ) => {
                 const Logo = PROVIDER_LOGOS[integ.provider];

--- a/dashboard/src/components/Sidebar.tsx
+++ b/dashboard/src/components/Sidebar.tsx
@@ -74,6 +74,11 @@ const navigation: NavItem[] = [
     icon: <RiMoneyDollarCircleLine size={16} />,
   },
   {
+    name: "Integrations",
+    href: "/integrations/manage",
+    icon: <RiSettings3Line size={16} />,
+  },
+  {
     name: "Flows",
     href: "/flows",
     minRole: "analyst",
@@ -99,12 +104,6 @@ const userMenuNav: NavItem[] = [
     href: "/analytics",
     minRole: "analyst",
     icon: <RiBarChartBoxLine size={16} />,
-  },
-  {
-    name: "Integrations",
-    href: "/integrations/manage",
-    minRole: "maintainer",
-    icon: <RiSettings3Line size={16} />,
   },
   {
     name: "Admin",


### PR DESCRIPTION
## Summary
- Moves **Integrations** from the role-filtered settings menu into the primary side navigation.
- Makes the navigation entry and org/system integration cards available to every system role.
- Keeps existing admin-only controls for creating and removing custom MCP connectors unchanged.

### Testing artefacts
Validated with the isolated `run-loma-local` stack after changing the signed-in test user to the lowest `chatter` role.

**Integrations in the primary side nav for a `chatter` user**

![Integrations side nav for chatter](https://cdn.plotline.so/loma-images/loma-pr/integrations-sidebar-chatter.png)

**Integrations page and org cards accessible to a `chatter` user**

![Integrations page for chatter](https://cdn.plotline.so/loma-images/loma-pr/integrations-page-chatter.png)

## Changes
- `dashboard/src/components/Sidebar.tsx`: moves Integrations into the main navigation and removes its minimum-role requirement.
- `dashboard/src/app/integrations/manage/page.tsx`: removes maintainer-only rendering for org and system integrations.

## Tests
- `npm run build` ✅
- Local Playwright smoke test as `chatter`: primary nav link visible, route navigation succeeds, page heading and Org tab render ✅
- `npm run lint` ⚠️ blocked by 19 pre-existing errors elsewhere in the dashboard; no new lint error was introduced by this change.

## Notes
- Draft PR generated by Loma. Please review before merging.
