### PR TITLE
feat: share conversations with teammates

### DIFF
--- a/api/project_routes.py
+++ b/api/project_routes.py
@@ -269,8 +269,8 @@ async def handle_assign_conversation_to_project(request: web.Request) -> web.Res
         return web.json_response({"error": "Conversation not found"}, status=404)
 
     # Access check: reuse same logic as pin
-    from api.routes import _check_conversation_access
-    if not _check_conversation_access(conversation, user_email, system_role):
+    from api.routes import _check_conversation_manage_access
+    if not _check_conversation_manage_access(conversation, user_email, system_role):
         return web.json_response({"error": "Conversation not found"}, status=404)
 
     try:
@@ -318,8 +318,8 @@ async def handle_remove_conversation_from_project(request: web.Request) -> web.R
     if not conversation:
         return web.json_response({"error": "Conversation not found"}, status=404)
 
-    from api.routes import _check_conversation_access
-    if not _check_conversation_access(conversation, user_email, system_role):
+    from api.routes import _check_conversation_manage_access
+    if not _check_conversation_manage_access(conversation, user_email, system_role):
         return web.json_response({"error": "Conversation not found"}, status=404)
 
     await db.conversations.update_one(

--- a/api/routes.py
+++ b/api/routes.py
@@ -447,6 +447,7 @@ async def handle_list_conversations(request: web.Request) -> web.Response:
         isolation_condition = {
             "$or": [
                 {"metadata.user_name": user_email},
+                {"metadata.visibility": "shared"},
                 {"source": "task_step"},
                 {
                     "source": {"$in": ["flow", "webhook"]},
@@ -461,6 +462,7 @@ async def handle_list_conversations(request: web.Request) -> web.Response:
         isolation_condition = {
             "$or": [
                 {"metadata.user_name": user_email},
+                {"metadata.visibility": "shared"},
                 {"source": "task_step"},
                 {
                     "source": {"$in": ["flow", "webhook"]},
@@ -469,8 +471,13 @@ async def handle_list_conversations(request: web.Request) -> web.Response:
             ]
         }
     else:
-        # operator / chatter — own conversations only
-        query["metadata.user_name"] = user_email
+        # operator / chatter can also open conversations explicitly shared by an owner
+        isolation_condition = {
+            "$or": [
+                {"metadata.user_name": user_email},
+                {"metadata.visibility": "shared"},
+            ]
+        }
 
     if source:
         query["source"] = source
@@ -535,22 +542,10 @@ async def handle_get_conversation(request: web.Request) -> web.Response:
     if not conversation:
         return web.json_response({"error": "Not found"}, status=404)
 
-    # ── Chat isolation ──
     user_email = get_user_email(request)
     system_role = get_system_role(request)
-    owner = (conversation.get("metadata") or {}).get("user_name", "")
-    conv_source = conversation.get("source", "")
-
-    if system_role == "admin":
-        pass  # admin sees everything
-    elif system_role in ("maintainer", "analyst"):
-        # maintainer/analyst can see own conversations + flow/task-spawned
-        if owner != user_email and conv_source not in ("flow", "task_step"):
-            return web.json_response({"error": "Not found"}, status=404)
-    else:
-        # operator / chatter — own conversations only
-        if owner != user_email:
-            return web.json_response({"error": "Not found"}, status=404)
+    if not user_email or not _check_conversation_access(conversation, user_email, system_role):
+        return web.json_response({"error": "Not found"}, status=404)
 
     turns = await db.turns.find({"conversation_id": cid}) \
         .sort("turn_number", 1) \
@@ -838,8 +833,12 @@ async def handle_chat(request: web.Request) -> web.Response:
             # Check if conversation already exists (resume) or is client-generated (start)
             existing = await db.conversations.find_one(
                 {"conversation_id": existing_conversation_id},
-                {"_id": 1, "task_status": 1, "started_at": 1, "metadata.user_name": 1},
+                {"_id": 1, "task_status": 1, "started_at": 1, "metadata": 1, "source": 1},
             )
+            if existing and not _check_conversation_access(
+                existing, user_email, get_system_role(request)
+            ):
+                return web.json_response({"error": "Not found"}, status=404)
             observer = ConversationObserver(
                 db, metadata=metadata,
                 conversation_id=existing_conversation_id,
@@ -1533,6 +1532,9 @@ def _check_conversation_access(conversation: dict, user_email: str, system_role:
     """Return True if the user has access to this conversation."""
     owner = (conversation.get("metadata") or {}).get("user_name", "")
     conv_source = conversation.get("source", "")
+    visibility = (conversation.get("metadata") or {}).get("visibility")
+    if user_email and visibility == "shared":
+        return True
     if system_role == "admin":
         return True
     if system_role in ("maintainer", "analyst"):
@@ -1543,6 +1545,49 @@ def _check_conversation_access(conversation: dict, user_email: str, system_role:
             return visibility != "private"
         return conv_source == "task_step"
     return owner == user_email
+
+
+def _check_conversation_manage_access(conversation: dict, user_email: str, system_role: str) -> bool:
+    """Return True for users allowed to mutate a conversation."""
+    owner = (conversation.get("metadata") or {}).get("user_name", "")
+    return owner == user_email or system_role == "admin"
+
+
+async def handle_share_conversation(request: web.Request) -> web.Response:
+    """PUT /api/conversations/{conversation_id}/share -- owner toggles link sharing."""
+    db = get_db()
+    if db is None:
+        return web.json_response({"error": "Observability not configured"}, status=503)
+
+    user_email = get_user_email(request)
+    if not user_email:
+        return web.json_response({"error": "Authentication required"}, status=401)
+
+    cid = request.match_info["conversation_id"]
+    conversation = await db.conversations.find_one({
+        "conversation_id": cid,
+        "deleted": {"$ne": True},
+    })
+    if not conversation:
+        return web.json_response({"error": "Not found"}, status=404)
+
+    owner = (conversation.get("metadata") or {}).get("user_name", "")
+    if owner != user_email:
+        return web.json_response({"error": "Only the conversation owner can change sharing"}, status=403)
+
+    try:
+        body = await request.json()
+    except Exception:
+        return web.json_response({"error": "Invalid JSON"}, status=400)
+    if not isinstance(body.get("shared"), bool):
+        return web.json_response({"error": "shared must be a boolean"}, status=400)
+
+    visibility = "shared" if body["shared"] else "private"
+    await db.conversations.update_one(
+        {"conversation_id": cid},
+        {"$set": {"metadata.visibility": visibility}},
+    )
+    return web.json_response({"shared": body["shared"], "conversation_id": cid})
 
 
 async def handle_pin_conversation(request: web.Request) -> web.Response:
@@ -1625,7 +1670,7 @@ async def handle_update_conversation(request: web.Request) -> web.Response:
         return web.json_response({"error": "Not found"}, status=404)
 
     system_role = get_system_role(request)
-    if not _check_conversation_access(conversation, user_email, system_role):
+    if not _check_conversation_manage_access(conversation, user_email, system_role):
         return web.json_response({"error": "Not found"}, status=404)
 
     try:
@@ -1674,7 +1719,7 @@ async def handle_delete_conversation(request: web.Request) -> web.Response:
         return web.json_response({"error": "Not found"}, status=404)
 
     system_role = get_system_role(request)
-    if not _check_conversation_access(conversation, user_email, system_role):
+    if not _check_conversation_manage_access(conversation, user_email, system_role):
         return web.json_response({"error": "Not found"}, status=404)
 
     now = datetime.now(timezone.utc)
@@ -1753,6 +1798,7 @@ def setup_api_routes(app: web.Application):
     app.router.add_delete("/api/conversations/{conversation_id}", handle_delete_conversation)
     app.router.add_post("/api/conversations/{conversation_id}/pin", handle_pin_conversation)
     app.router.add_delete("/api/conversations/{conversation_id}/pin", handle_unpin_conversation)
+    app.router.add_put("/api/conversations/{conversation_id}/share", handle_share_conversation)
     app.router.add_get("/api/stats", handle_get_stats)
     app.router.add_get("/api/cost-stats", handle_cost_stats)
     app.router.add_get("/api/token-usage", handle_token_usage)

--- a/dashboard/src/app/chat/page.tsx
+++ b/dashboard/src/app/chat/page.tsx
@@ -29,7 +29,7 @@ import { useUser } from "../../lib/UserContext";
 function ChatPageContent() {
   const searchParams = useSearchParams();
   const router = useRouter();
-  const { isPinned, togglePin, projects, renameConversation, removeConversation, assignToProject, unassignFromProject, addProject } = useUser();
+  const { user, isPinned, togglePin, projects, renameConversation, removeConversation, assignToProject, unassignFromProject, addProject } = useUser();
   const continueId = searchParams.get("continue");
   const flowId = searchParams.get("flow");
   const taskId = null; // Tasks system removed
@@ -54,6 +54,8 @@ function ChatPageContent() {
   const [taskDraftFiles, setTaskDraftFiles] = useState<ChatFile[] | null>(null);
   const [taskModel, setTaskModel] = useState<string | null>(null);
   const [taskStatus, setTaskStatus] = useState<"todo" | "active" | "done" | null>(null);
+  const [conversationOwner, setConversationOwner] = useState<string | null>(null);
+  const [conversationShared, setConversationShared] = useState(false);
 
   // Track the active conversation ID — starts from URL param but also updates
   // when a fresh chat creates a new conversation (via onConversationCreated callback)
@@ -67,7 +69,8 @@ function ChatPageContent() {
   // Callback for ChatPanel to notify us when a new conversation is created
   const handleConversationCreated = useCallback((newId: string) => {
     setActiveConversationId(newId);
-  }, []);
+    setConversationOwner(user?.email || null);
+  }, [user?.email]);
 
   useEffect(() => {
     if (flowId) {
@@ -105,6 +108,8 @@ function ChatPageContent() {
     async function loadConversation() {
       try {
         const data = await fetchConversation(continueId!);
+        setConversationOwner(data.conversation.metadata?.user_name || null);
+        setConversationShared(data.conversation.metadata?.visibility === "shared");
         setTaskStatus(data.conversation.task_status || null);
         if (data.conversation.task_status === "todo" && !data.conversation.status) {
           // Unstarted board draft: nothing has been sent yet. Don't rebuild
@@ -184,7 +189,7 @@ function ChatPageContent() {
       {/* Mobile: no header bar — chat actions live in a floating menu on the
           right (mirrors the floating hamburger on the left). ChatContextMenu
           carries pin/rename/board/project/delete. */}
-      {activeConversationId && (
+      {activeConversationId && user?.email === conversationOwner && (
         <div className="md:hidden fixed right-3 top-[max(0.5rem,env(safe-area-inset-top))] z-30 flex items-center gap-2">
           <CostChip conversationId={activeConversationId} />
           <ChatContextMenu
@@ -212,6 +217,9 @@ function ChatPageContent() {
               setProjectId(null);
             }}
             onCreateProject={async (name) => { await addProject(name); }}
+            canShare={!!user?.email && user.email === conversationOwner}
+            isShared={conversationShared}
+            onSharingChange={setConversationShared}
             triggerClassName="h-9 w-9 flex items-center justify-center rounded-full border border-border bg-background/80 backdrop-blur text-muted-foreground press-scale"
           />
         </div>
@@ -251,19 +259,19 @@ function ChatPageContent() {
                 <h1
                   className={cn(
                     "text-base font-heading font-semibold text-foreground truncate",
-                    activeConversationId && "cursor-pointer hover:text-brand-600 transition-colors"
+                    activeConversationId && user?.email === conversationOwner && "cursor-pointer hover:text-brand-600 transition-colors"
                   )}
                   onClick={() => {
-                    if (activeConversationId) {
+                    if (activeConversationId && user?.email === conversationOwner) {
                       setTitleValue(conversationTitle || promptPreview || "");
                       setEditingTitle(true);
                     }
                   }}
-                  title={activeConversationId ? "Click to rename" : undefined}
+                  title={activeConversationId && user?.email === conversationOwner ? "Click to rename" : undefined}
                 >
                   {headerTitle}
                 </h1>
-                {activeConversationId && (
+                {activeConversationId && user?.email === conversationOwner && (
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <Button
@@ -314,7 +322,7 @@ function ChatPageContent() {
               </Tooltip>
 
               {/* More actions (project, etc.) */}
-              <ChatContextMenu
+              {user?.email === conversationOwner && <ChatContextMenu
                 conversationId={activeConversationId}
                 conversationTitle={conversationTitle || promptPreview || "Untitled"}
                 isPinned={isPinned(activeConversationId)}
@@ -339,11 +347,14 @@ function ChatPageContent() {
                   setProjectId(null);
                 }}
                 onCreateProject={async (name) => { await addProject(name); }}
+                canShare={!!user?.email && user.email === conversationOwner}
+                isShared={conversationShared}
+                onSharingChange={setConversationShared}
                 triggerClassName="p-2 rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
-              />
+              />}
 
               {/* Delete */}
-              <div className="relative">
+              {user?.email === conversationOwner && <div className="relative">
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button
@@ -384,7 +395,7 @@ function ChatPageContent() {
                     </div>
                   </div>
                 )}
-              </div>
+              </div>}
             </div>
           )}
         </div>

--- a/dashboard/src/components/ChatContextMenu.tsx
+++ b/dashboard/src/components/ChatContextMenu.tsx
@@ -33,8 +33,10 @@ import {
   RiAddLine,
   RiDeleteBinLine,
   RiLoader4Line,
+  RiShareLine,
+  RiFileCopyLine,
 } from "@remixicon/react";
-import { updateTask } from "@/lib/api";
+import { basePath, setConversationShared, updateTask } from "@/lib/api";
 
 interface ChatContextMenuProps {
   conversationId: string;
@@ -50,6 +52,9 @@ interface ChatContextMenuProps {
   onAssignProject: (conversationId: string, projectId: string) => Promise<void>;
   onRemoveProject: (conversationId: string) => Promise<void>;
   onCreateProject: (name: string) => Promise<void>;
+  canShare?: boolean;
+  isShared?: boolean;
+  onSharingChange?: (shared: boolean) => void;
   triggerClassName?: string;
 }
 
@@ -66,11 +71,17 @@ export default function ChatContextMenu({
   onAssignProject,
   onRemoveProject,
   onCreateProject,
+  canShare = false,
+  isShared = false,
+  onSharingChange,
   triggerClassName,
 }: ChatContextMenuProps) {
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const [renameDialogOpen, setRenameDialogOpen] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [shareDialogOpen, setShareDialogOpen] = useState(false);
+  const [shared, setShared] = useState(isShared);
+  const [copied, setCopied] = useState(false);
   const [showNewProject, setShowNewProject] = useState(false);
   const [renameValue, setRenameValue] = useState(conversationTitle);
   const [newProjectName, setNewProjectName] = useState("");
@@ -81,6 +92,46 @@ export default function ChatContextMenu({
   useEffect(() => {
     setOnBoard(!!taskStatus);
   }, [taskStatus]);
+
+  useEffect(() => setShared(isShared), [isShared]);
+
+  const shareUrl = typeof window === "undefined"
+    ? ""
+    : `${window.location.origin}${basePath}/chat?continue=${conversationId}`;
+
+  async function handleShare() {
+    setLoading(true);
+    try {
+      await setConversationShared(conversationId, true);
+      setShared(true);
+      onSharingChange?.(true);
+      setShareDialogOpen(true);
+    } catch (e) {
+      console.error("Failed to share conversation:", e);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleStopSharing() {
+    setLoading(true);
+    try {
+      await setConversationShared(conversationId, false);
+      setShared(false);
+      onSharingChange?.(false);
+      setShareDialogOpen(false);
+    } catch (e) {
+      console.error("Failed to stop sharing:", e);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function copyShareLink() {
+    await navigator.clipboard.writeText(shareUrl);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
 
   async function handleToggleBoard() {
     const next = !onBoard;
@@ -205,6 +256,20 @@ export default function ChatContextMenu({
               </>
             )}
           </DropdownMenuItem>
+
+          {canShare && (
+            <DropdownMenuItem
+              onClick={(e) => {
+                e.stopPropagation();
+                setDropdownOpen(false);
+                if (shared) setShareDialogOpen(true);
+                else handleShare();
+              }}
+            >
+              <RiShareLine size={16} className="text-muted-foreground" />
+              {shared ? "Manage sharing" : "Share conversation"}
+            </DropdownMenuItem>
+          )}
 
           {/* Rename */}
           <DropdownMenuItem
@@ -373,6 +438,30 @@ export default function ChatContextMenu({
                 "Save"
               )}
             </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={shareDialogOpen} onOpenChange={setShareDialogOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Share conversation</DialogTitle>
+            <DialogDescription>
+              Anyone on your team with access to Loma can open this conversation and continue the chat.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex gap-2">
+            <Input value={shareUrl} readOnly aria-label="Conversation share link" />
+            <Button onClick={copyShareLink} disabled={!shareUrl}>
+              {copied ? <RiCheckLine size={16} /> : <RiFileCopyLine size={16} />}
+              {copied ? "Copied" : "Copy"}
+            </Button>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={handleStopSharing} disabled={loading}>
+              Stop sharing
+            </Button>
+            <Button onClick={() => setShareDialogOpen(false)}>Done</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -621,6 +621,22 @@ export async function updateConversation(
   return res.json();
 }
 
+export async function setConversationShared(
+  id: string,
+  shared: boolean,
+): Promise<{ shared: boolean; conversation_id: string }> {
+  const res = await fetch(`${API_BASE}/api/conversations/${id}/share`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ shared }),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.error || `Failed to update sharing: ${res.status}`);
+  }
+  return res.json();
+}
+
 export async function deleteConversation(id: string): Promise<{ deleted: boolean }> {
   const res = await fetch(`${API_BASE}/api/conversations/${id}`, {
     method: "DELETE",

--- a/tests/test_conversation_sharing.py
+++ b/tests/test_conversation_sharing.py
@@ -1,0 +1,99 @@
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from api.routes import (
+    _check_conversation_access,
+    handle_share_conversation,
+)
+
+
+def conversation(owner="owner@plotline.so", visibility="private"):
+    return {
+        "conversation_id": "conv-1",
+        "source": "dashboard",
+        "metadata": {"user_name": owner, "visibility": visibility},
+    }
+
+
+class FakeRequest(dict):
+    def __init__(self, *, user_email, role="chatter", body=None):
+        super().__init__(user_email=user_email, system_role=role)
+        self.match_info = {"conversation_id": "conv-1"}
+        self._body = body
+
+    async def json(self):
+        return self._body
+
+
+def response_json(response):
+    return json.loads(response.body)
+
+
+@pytest.mark.asyncio
+async def test_owner_can_share_and_unshare_conversation():
+    db = MagicMock()
+    db.conversations.find_one = AsyncMock(return_value=conversation())
+    db.conversations.update_one = AsyncMock()
+
+    with patch("api.routes.get_db", return_value=db):
+        shared = await handle_share_conversation(FakeRequest(
+            user_email="owner@plotline.so", body={"shared": True},
+        ))
+        private = await handle_share_conversation(FakeRequest(
+            user_email="owner@plotline.so", body={"shared": False},
+        ))
+
+    assert shared.status == 200
+    assert response_json(shared)["shared"] is True
+    assert private.status == 200
+    assert response_json(private)["shared"] is False
+    assert db.conversations.update_one.await_args_list[0].args[1] == {
+        "$set": {"metadata.visibility": "shared"}
+    }
+    assert db.conversations.update_one.await_args_list[1].args[1] == {
+        "$set": {"metadata.visibility": "private"}
+    }
+
+
+@pytest.mark.asyncio
+async def test_non_owner_cannot_change_sharing_even_if_admin():
+    db = MagicMock()
+    db.conversations.find_one = AsyncMock(return_value=conversation())
+    db.conversations.update_one = AsyncMock()
+
+    with patch("api.routes.get_db", return_value=db):
+        response = await handle_share_conversation(FakeRequest(
+            user_email="admin@plotline.so", role="admin", body={"shared": True},
+        ))
+
+    assert response.status == 403
+    db.conversations.update_one.assert_not_awaited()
+
+
+@pytest.mark.parametrize("role", ["chatter", "analyst", "operator", "maintainer", "admin"])
+def test_shared_conversation_is_accessible_to_every_authenticated_role(role):
+    assert _check_conversation_access(
+        conversation(visibility="shared"), "teammate@plotline.so", role
+    )
+
+
+@pytest.mark.parametrize("role", ["chatter", "analyst", "operator", "maintainer"])
+def test_private_dashboard_conversation_remains_owner_only(role):
+    assert not _check_conversation_access(
+        conversation(visibility="private"), "teammate@plotline.so", role
+    )
+    assert _check_conversation_access(
+        conversation(visibility="private"), "owner@plotline.so", role
+    )
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_user_cannot_change_sharing():
+    db = MagicMock()
+    with patch("api.routes.get_db", return_value=db):
+        response = await handle_share_conversation(FakeRequest(
+            user_email="", body={"shared": True},
+        ))
+    assert response.status == 401


### PR DESCRIPTION
## Summary
- adds owner-controlled conversation sharing with a copyable chat link
- allows every authenticated role, including chatter, to open and continue explicitly shared conversations
- keeps private conversations isolated and restricts sharing changes to the owner

## Changes
- added `PUT /api/conversations/{conversation_id}/share` and centralized read/manage access checks
- included shared conversations in authenticated users' conversation lists
- added the Share conversation dialog with copy and stop-sharing actions
- added backend coverage for owner, non-owner, unauthenticated, private, and all-role shared access

## Testing
- `python -m pytest tests/test_conversation_sharing.py` (12 passed)
- `npx eslint src/components/ChatContextMenu.tsx src/app/chat/page.tsx src/lib/api.ts` (passed)
- `npm run build` (passed)
- isolated local Loma run with a throwaway MongoDB database:
  - owner shared a conversation and received the direct chat link
  - chatter-role API access to the shared conversation returned 200
  - throwaway database was dropped after verification
- full Python suite: 277 passed, 2 unrelated pre-existing environment failures (`ZipFile.mkdir` unavailable under Python 3.10 and an uninitialized pool in `test_opencode_runtime`)
- full dashboard lint remains blocked by pre-existing errors in unrelated files; targeted lint for changed files passed

## Testing screenshot
![Share conversation dialog](https://cdn.plotline.so/loma-images/loma-prs/share-conversations-dialog.png)

## Notes
- This PR was generated by Loma based on the approved implementation plan.
- Please review carefully before merging.
