### PR TITLE
fix: unblock conversation sharing public-content scan

### DIFF
--- a/tests/test_conversation_sharing.py
+++ b/tests/test_conversation_sharing.py
@@ -9,7 +9,7 @@ from api.routes import (
 )
 
 
-def conversation(owner="owner@plotline.so", visibility="private"):
+def conversation(owner="owner@example.com", visibility="private"):
     return {
         "conversation_id": "conv-1",
         "source": "dashboard",
@@ -39,10 +39,10 @@ async def test_owner_can_share_and_unshare_conversation():
 
     with patch("api.routes.get_db", return_value=db):
         shared = await handle_share_conversation(FakeRequest(
-            user_email="owner@plotline.so", body={"shared": True},
+            user_email="owner@example.com", body={"shared": True},
         ))
         private = await handle_share_conversation(FakeRequest(
-            user_email="owner@plotline.so", body={"shared": False},
+            user_email="owner@example.com", body={"shared": False},
         ))
 
     assert shared.status == 200
@@ -65,7 +65,7 @@ async def test_non_owner_cannot_change_sharing_even_if_admin():
 
     with patch("api.routes.get_db", return_value=db):
         response = await handle_share_conversation(FakeRequest(
-            user_email="admin@plotline.so", role="admin", body={"shared": True},
+            user_email="admin@example.com", role="admin", body={"shared": True},
         ))
 
     assert response.status == 403
@@ -75,17 +75,17 @@ async def test_non_owner_cannot_change_sharing_even_if_admin():
 @pytest.mark.parametrize("role", ["chatter", "analyst", "operator", "maintainer", "admin"])
 def test_shared_conversation_is_accessible_to_every_authenticated_role(role):
     assert _check_conversation_access(
-        conversation(visibility="shared"), "teammate@plotline.so", role
+        conversation(visibility="shared"), "teammate@example.com", role
     )
 
 
 @pytest.mark.parametrize("role", ["chatter", "analyst", "operator", "maintainer"])
 def test_private_dashboard_conversation_remains_owner_only(role):
     assert not _check_conversation_access(
-        conversation(visibility="private"), "teammate@plotline.so", role
+        conversation(visibility="private"), "teammate@example.com", role
     )
     assert _check_conversation_access(
-        conversation(visibility="private"), "owner@plotline.so", role
+        conversation(visibility="private"), "owner@example.com", role
     )
 
 


### PR DESCRIPTION
## Summary
- Replace internal company-domain test identities with RFC example identities
- Unblock the `public-content-scan` failure introduced by PR #93 without changing sharing behavior

## Root cause
PR #93 added `@plotline.so` fixtures to `tests/test_conversation_sharing.py`. The public repository CI intentionally rejects private/internal markers, so the `Block private/internal markers` step failed.

## Testing
- `python scripts/check_public_content.py` ✅
- `python scripts/check_secrets.py` ✅
- `pytest -q tests/test_conversation_sharing.py` ✅ (12 passed)
- `python -m compileall -q .` ✅

A full local suite also exposed an unrelated existing failure in `tests/test_opencode_runtime.py::test_stream_agent_uses_opencode_runtime_by_default` because the client pool is not initialized. PR #93's GitHub Actions backend job passed, and this PR does not touch that runtime or test.
