### PR TITLE
feat: set task priority from the New Task dialog

### DIFF
--- a/api/task_routes.py
+++ b/api/task_routes.py
@@ -283,6 +283,14 @@ async def handle_create_task(request: web.Request) -> web.Response:
     if start and not prompt:
         return web.json_response({"error": "Details are required to start"}, status=400)
 
+    # Priority is optional at creation; validate against the same set the PATCH
+    # route enforces so the New Task dialog and the board tag stay in sync.
+    priority = body.get("task_priority")
+    if priority is not None and priority not in TASK_PRIORITIES:
+        return web.json_response(
+            {"error": "task_priority must be low, medium, high, urgent or null"},
+            status=400)
+
     now = datetime.now(timezone.utc)
     # Draft doc mirrors observer.start()'s shape, but the run hasn't begun:
     # status/started_at stay None and messages stays [] — observer.resume()
@@ -323,7 +331,7 @@ async def handle_create_task(request: web.Request) -> web.Response:
         "task_started_at": now if start else None,
         "task_done_at": None,
         "task_tag_ids": [],
-        "task_priority": None,
+        "task_priority": priority,
         "task_deadline": None,
     }
     await db.conversations.insert_one(doc)

--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -18,6 +18,7 @@ import {
   fetchTasksBoard,
   updateTask,
   type Task,
+  type TaskPriority,
   type TasksBoardResponse,
 } from "@/lib/api";
 import { Button } from "@/components/ui/button";
@@ -100,7 +101,7 @@ export default function TasksPage() {
   }, [sessionStatus, refresh]);
 
   const handleTaskSubmit = async (
-    values: { title: string; prompt: string; lane: string; model: string },
+    values: { title: string; prompt: string; lane: string; model: string; priority: TaskPriority | null },
     start: boolean,
   ) => {
     busyRef.current = true;
@@ -112,6 +113,7 @@ export default function TasksPage() {
           prompt: values.prompt,
           task_lane: values.lane,
           model: values.model,
+          task_priority: values.priority,
         });
         conversationId = editingTask.conversation_id;
       } else {
@@ -120,6 +122,7 @@ export default function TasksPage() {
           title: values.title || undefined,
           lane: values.lane,
           model: values.model || undefined,
+          task_priority: values.priority,
         });
         conversationId = task.conversation_id;
       }

--- a/dashboard/src/components/tasks/TaskDialog.tsx
+++ b/dashboard/src/components/tasks/TaskDialog.tsx
@@ -20,7 +20,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { DictationButton, appendDictation } from "@/components/composer/DictationButton";
-import { fetchAgentModels, type AgentModel, type BoardLane, type Task } from "@/lib/api";
+import { fetchAgentModels, type AgentModel, type BoardLane, type Task, type TaskPriority } from "@/lib/api";
+import { TASK_PRIORITIES } from "./taskDisplay";
 
 interface TaskDialogProps {
   open: boolean;
@@ -30,7 +31,7 @@ interface TaskDialogProps {
   task?: Task | null;
   defaultLane?: string;
   onSubmit: (
-    values: { title: string; prompt: string; lane: string; model: string },
+    values: { title: string; prompt: string; lane: string; model: string; priority: TaskPriority | null },
     start: boolean,
   ) => Promise<void>;
 }
@@ -51,6 +52,7 @@ export function TaskDialog({ open, onOpenChange, lanes, task, defaultLane, onSub
   const [prompt, setPrompt] = useState("");
   const [lane, setLane] = useState(lanes[0]?.id ?? "todo");
   const [model, setModel] = useState("");
+  const [priority, setPriority] = useState<TaskPriority | null>(null);
   const [models, setModels] = useState<AgentModel[]>([]);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -61,6 +63,7 @@ export function TaskDialog({ open, onOpenChange, lanes, task, defaultLane, onSub
       setPrompt(task?.prompt ?? "");
       setLane(task?.task_lane ?? defaultLane ?? lanes[0]?.id ?? "todo");
       setModel(task?.model ?? "");
+      setPriority(task?.task_priority ?? null);
       setError(null);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -96,7 +99,7 @@ export function TaskDialog({ open, onOpenChange, lanes, task, defaultLane, onSub
     setBusy(true);
     setError(null);
     try {
-      await onSubmit({ title: title.trim(), prompt: prompt.trim(), lane, model }, start);
+      await onSubmit({ title: title.trim(), prompt: prompt.trim(), lane, model, priority }, start);
       onOpenChange(false);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Something went wrong");
@@ -185,6 +188,23 @@ export function TaskDialog({ open, onOpenChange, lanes, task, defaultLane, onSub
                 </Select>
               </div>
             )}
+            <div className="flex-1 min-w-0 space-y-1.5">
+              <Label>Priority</Label>
+              <Select
+                value={priority ?? "none"}
+                onValueChange={(value) => setPriority(value === "none" ? null : (value as TaskPriority))}
+              >
+                <SelectTrigger className="w-full max-w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">No priority</SelectItem>
+                  {TASK_PRIORITIES.map((p) => (
+                    <SelectItem key={p.id} value={p.id}>{p.symbol} {p.label}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
           </div>
           {error && <p className="text-xs text-destructive">{error}</p>}
         </div>

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -1045,6 +1045,7 @@ export async function createTask(params: {
   title?: string;
   lane?: string;
   model?: string;
+  task_priority?: TaskPriority | null;
   /** Attachments staged with the draft; sent with the first message on start */
   files?: ChatFile[];
   /** Fire immediately: the agent starts running in the background */

--- a/tests/test_task_routes.py
+++ b/tests/test_task_routes.py
@@ -1,0 +1,72 @@
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from api.task_routes import handle_create_task
+
+
+class FakeRequest(dict):
+    """Minimal aiohttp-request stand-in: dict-based auth + a JSON body."""
+
+    def __init__(self, *, user_email="owner@example.com", body=None):
+        super().__init__(user_email=user_email, system_role="chatter")
+        self._body = body if body is not None else {}
+
+    async def json(self):
+        return self._body
+
+
+def response_json(response):
+    return json.loads(response.body)
+
+
+def _db():
+    """A DB whose user has the default board (single 'todo' lane)."""
+    db = MagicMock()
+    db.users.find_one = AsyncMock(return_value=None)  # -> DEFAULT_BOARD
+    db.conversations.insert_one = AsyncMock()
+    return db
+
+
+@pytest.mark.asyncio
+async def test_create_task_persists_valid_priority():
+    db = _db()
+    with patch("api.task_routes.get_db", return_value=db):
+        res = await handle_create_task(FakeRequest(
+            body={"title": "Ship it", "prompt": "do the thing", "task_priority": "high"},
+        ))
+
+    assert res.status == 201
+    # Stored on the draft doc...
+    stored = db.conversations.insert_one.await_args.args[0]
+    assert stored["task_priority"] == "high"
+    # ...and reflected in the returned card view.
+    assert response_json(res)["task"]["task_priority"] == "high"
+
+
+@pytest.mark.asyncio
+async def test_create_task_rejects_invalid_priority():
+    db = _db()
+    with patch("api.task_routes.get_db", return_value=db):
+        res = await handle_create_task(FakeRequest(
+            body={"title": "Bad", "prompt": "x", "task_priority": "sometime"},
+        ))
+
+    assert res.status == 400
+    assert "task_priority" in response_json(res)["error"]
+    db.conversations.insert_one.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_task_defaults_priority_to_none():
+    db = _db()
+    with patch("api.task_routes.get_db", return_value=db):
+        res = await handle_create_task(FakeRequest(
+            body={"title": "No priority", "prompt": "x"},
+        ))
+
+    assert res.status == 201
+    stored = db.conversations.insert_one.await_args.args[0]
+    assert stored["task_priority"] is None
+    assert response_json(res)["task"]["task_priority"] is None


### PR DESCRIPTION
## Summary
- Adds a **Priority** selector to the New Task / Task details dialog so priority can be set at creation time (previously it was only settable on an existing card via the board tag).
- Threads the selected priority through `createTask` and `updateTask`.
- Validates and persists `task_priority` in the create handler, reusing the same allow-list the PATCH route already enforces.

## Context
Reported internally: priority could be set from the Tasks panel on an existing task, but not from the modal where a new task is created. Root cause was a three-layer gap — the dialog had no field, `createTask()` had no `task_priority` param, and `handle_create_task` hardcoded `task_priority: None`.

## Changes
- `dashboard/src/components/tasks/TaskDialog.tsx` — new Priority `Select` (reuses `TASK_PRIORITIES`), state + reset wiring, included in the submit payload.
- `dashboard/src/app/tasks/page.tsx` — passes `task_priority` to `createTask`/`updateTask`.
- `dashboard/src/lib/api.ts` — `createTask()` now accepts `task_priority`.
- `api/task_routes.py` — `handle_create_task` validates and stores the priority instead of hardcoding `None`.
- `tests/test_task_routes.py` — new tests: valid priority persists, invalid → 400, omitted → `None`.

## Testing
- `pytest tests/test_task_routes.py` — 3 passed. Full backend suite: 281 passed (1 pre-existing unrelated `test_opencode_runtime` failure, also fails on clean `main`).
- Dashboard `tsc --noEmit` — 0 errors. `eslint` on changed files — clean.

## Notes
- Generated by the Plotline Agent based on an internal bug report. Please review before merging.
