### PR TITLE
feat: task priority in New Task modal + fix large-paste dialog scroll

### DIFF
--- a/api/task_routes.py
+++ b/api/task_routes.py
@@ -257,6 +257,12 @@ async def handle_create_task(request: web.Request) -> web.Response:
 
     model = (body.get("model") or "").strip()
 
+    priority = body.get("task_priority")
+    if priority is not None and priority not in TASK_PRIORITIES:
+        return web.json_response(
+            {"error": "task_priority must be low, medium, high, urgent or null"},
+            status=400)
+
     files = body.get("files") or []
     if files:
         if not isinstance(files, list) or len(files) > MAX_DRAFT_FILES:
@@ -323,7 +329,7 @@ async def handle_create_task(request: web.Request) -> web.Response:
         "task_started_at": now if start else None,
         "task_done_at": None,
         "task_tag_ids": [],
-        "task_priority": None,
+        "task_priority": priority,
         "task_deadline": None,
     }
     await db.conversations.insert_one(doc)

--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -18,6 +18,7 @@ import {
   fetchTasksBoard,
   updateTask,
   type Task,
+  type TaskPriority,
   type TasksBoardResponse,
 } from "@/lib/api";
 import { Button } from "@/components/ui/button";
@@ -100,7 +101,7 @@ export default function TasksPage() {
   }, [sessionStatus, refresh]);
 
   const handleTaskSubmit = async (
-    values: { title: string; prompt: string; lane: string; model: string },
+    values: { title: string; prompt: string; lane: string; model: string; priority: TaskPriority | null },
     start: boolean,
   ) => {
     busyRef.current = true;
@@ -112,6 +113,7 @@ export default function TasksPage() {
           prompt: values.prompt,
           task_lane: values.lane,
           model: values.model,
+          task_priority: values.priority,
         });
         conversationId = editingTask.conversation_id;
       } else {
@@ -120,6 +122,7 @@ export default function TasksPage() {
           title: values.title || undefined,
           lane: values.lane,
           model: values.model || undefined,
+          task_priority: values.priority,
         });
         conversationId = task.conversation_id;
       }

--- a/dashboard/src/components/tasks/TaskDialog.tsx
+++ b/dashboard/src/components/tasks/TaskDialog.tsx
@@ -20,7 +20,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { DictationButton, appendDictation } from "@/components/composer/DictationButton";
-import { fetchAgentModels, type AgentModel, type BoardLane, type Task } from "@/lib/api";
+import { fetchAgentModels, type AgentModel, type BoardLane, type Task, type TaskPriority } from "@/lib/api";
+import { TASK_PRIORITIES } from "./taskDisplay";
 
 interface TaskDialogProps {
   open: boolean;
@@ -30,7 +31,7 @@ interface TaskDialogProps {
   task?: Task | null;
   defaultLane?: string;
   onSubmit: (
-    values: { title: string; prompt: string; lane: string; model: string },
+    values: { title: string; prompt: string; lane: string; model: string; priority: TaskPriority | null },
     start: boolean,
   ) => Promise<void>;
 }
@@ -51,6 +52,7 @@ export function TaskDialog({ open, onOpenChange, lanes, task, defaultLane, onSub
   const [prompt, setPrompt] = useState("");
   const [lane, setLane] = useState(lanes[0]?.id ?? "todo");
   const [model, setModel] = useState("");
+  const [priority, setPriority] = useState<TaskPriority | null>(null);
   const [models, setModels] = useState<AgentModel[]>([]);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -61,6 +63,7 @@ export function TaskDialog({ open, onOpenChange, lanes, task, defaultLane, onSub
       setPrompt(task?.prompt ?? "");
       setLane(task?.task_lane ?? defaultLane ?? lanes[0]?.id ?? "todo");
       setModel(task?.model ?? "");
+      setPriority(task?.task_priority ?? null);
       setError(null);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -96,7 +99,7 @@ export function TaskDialog({ open, onOpenChange, lanes, task, defaultLane, onSub
     setBusy(true);
     setError(null);
     try {
-      await onSubmit({ title: title.trim(), prompt: prompt.trim(), lane, model }, start);
+      await onSubmit({ title: title.trim(), prompt: prompt.trim(), lane, model, priority }, start);
       onOpenChange(false);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Something went wrong");
@@ -150,6 +153,7 @@ export function TaskDialog({ open, onOpenChange, lanes, task, defaultLane, onSub
               onChange={(e) => setPrompt(e.target.value)}
               placeholder="What should the agent do?"
               rows={6}
+              className="max-h-[45vh] overflow-y-auto"
             />
           </div>
           {/* Stacked on phones — side by side the long model label forces a
@@ -185,6 +189,23 @@ export function TaskDialog({ open, onOpenChange, lanes, task, defaultLane, onSub
                 </Select>
               </div>
             )}
+            <div className="flex-1 min-w-0 space-y-1.5">
+              <Label>Priority</Label>
+              <Select
+                value={priority ?? "none"}
+                onValueChange={(v) => setPriority(v === "none" ? null : (v as TaskPriority))}
+              >
+                <SelectTrigger className="w-full max-w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">No priority</SelectItem>
+                  {TASK_PRIORITIES.map((p) => (
+                    <SelectItem key={p.id} value={p.id}>{p.symbol} {p.label}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
           </div>
           {error && <p className="text-xs text-destructive">{error}</p>}
         </div>

--- a/dashboard/src/components/ui/dialog.tsx
+++ b/dashboard/src/components/ui/dialog.tsx
@@ -66,6 +66,10 @@ function DialogContent({
           // keyboard never hides fields or footer buttons (--app-h tracks the
           // visual viewport in the installed PWA).
           "max-md:top-[max(0.75rem,env(safe-area-inset-top))] max-md:translate-y-0 max-md:max-h-[calc(var(--app-h,100dvh)-max(0.75rem,env(safe-area-inset-top))-0.75rem)] max-md:overflow-y-auto max-md:overflow-x-hidden max-md:[&>*]:min-w-0",
+          // Desktop: cap height and scroll internally so tall content (e.g. a
+          // large pasted block in a textarea) can never push the dialog past
+          // the viewport and hide the footer buttons.
+          "md:max-h-[calc(100dvh-4rem)] md:overflow-y-auto md:overflow-x-hidden",
           className
         )}
         {...props}

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -1045,6 +1045,7 @@ export async function createTask(params: {
   title?: string;
   lane?: string;
   model?: string;
+  task_priority?: TaskPriority | null;
   /** Attachments staged with the draft; sent with the first message on start */
   files?: ChatFile[];
   /** Fire immediately: the agent starts running in the background */

--- a/tests/test_task_routes.py
+++ b/tests/test_task_routes.py
@@ -1,0 +1,67 @@
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from api.task_routes import handle_create_task
+
+
+class FakeRequest(dict):
+    def __init__(self, *, user_email="owner@example.com", body=None):
+        super().__init__(user_email=user_email, system_role="chatter")
+        self._body = body if body is not None else {}
+
+    async def json(self):
+        return self._body
+
+
+def response_json(response):
+    return json.loads(response.body)
+
+
+def _mock_db():
+    db = MagicMock()
+    db.conversations.insert_one = AsyncMock()
+    return db
+
+
+BOARD = {"lanes": [{"id": "todo", "name": "To do"}], "tags": []}
+
+
+async def _create(body):
+    db = _mock_db()
+    with patch("api.task_routes.get_db", return_value=db), patch(
+        "api.task_routes._get_board_config_for", AsyncMock(return_value=BOARD)
+    ):
+        response = await handle_create_task(FakeRequest(body=body))
+    return db, response
+
+
+@pytest.mark.asyncio
+async def test_create_task_persists_valid_priority():
+    db, response = await _create(
+        {"title": "Ship it", "prompt": "do the thing", "task_priority": "urgent"}
+    )
+    assert response.status == 201
+    assert response_json(response)["task"]["task_priority"] == "urgent"
+    inserted = db.conversations.insert_one.await_args.args[0]
+    assert inserted["task_priority"] == "urgent"
+
+
+@pytest.mark.asyncio
+async def test_create_task_rejects_invalid_priority():
+    db, response = await _create(
+        {"title": "Ship it", "prompt": "do the thing", "task_priority": "sky-high"}
+    )
+    assert response.status == 400
+    assert "task_priority" in response_json(response)["error"]
+    db.conversations.insert_one.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_task_defaults_priority_to_none_when_omitted():
+    db, response = await _create({"title": "Ship it", "prompt": "do the thing"})
+    assert response.status == 201
+    assert response_json(response)["task"]["task_priority"] is None
+    inserted = db.conversations.insert_one.await_args.args[0]
+    assert inserted["task_priority"] is None


### PR DESCRIPTION
## Summary
- Add a **Priority** selector to the New Task / Task details modal so priority can be set at creation time (previously only settable on the board after the task existed).
- Fix a **desktop-only** bug where pasting a large block of text into the modal grew the textarea unbounded, pushing the dialog footer (Cancel / Add / Add & start) off-screen with no way to scroll.

## Context
Reported internally: (1) priority is settable from the Tasks panel but not from the New Task modal, and (2) pasting large text into the modal makes it un-scrollable and stuck off-screen. Also clarified: the priority field is **display metadata only** — it does not affect model selection, execution order, prompt content, or how the agent builds a PR.

## Root cause
**Priority gap (three layers):**
- `TaskDialog.tsx` rendered Title / Details / Lane / Model — no Priority field; submit shape was `{ title, prompt, lane, model }`.
- `api.ts` `createTask()` had no `task_priority` param (only `updateTask()` did — which is why the board tag worked but the modal didn't).
- `api/task_routes.py` `handle_create_task` hardcoded `"task_priority": None`; only the PATCH route validated priority.

**Scroll bug:**
- `ui/textarea.tsx` uses `field-sizing-content` with `min-h-16` and no `max-h`, so it grows without bound.
- `ui/dialog.tsx` scoped its height cap + `overflow-y-auto` to `max-md:` only, so on desktop there was no max-height and no internal scroll.

## Changes
- `dashboard/src/components/tasks/TaskDialog.tsx` — add a Priority `Select` (No priority + urgent/high/medium/low from the shared `TASK_PRIORITIES`), track it in state, seed from the task on open, include `priority` in the submit payload. Cap the details textarea (`max-h-[45vh] overflow-y-auto`) so large pastes scroll internally.
- `dashboard/src/lib/api.ts` — add optional `task_priority` to `createTask()` params.
- `dashboard/src/app/tasks/page.tsx` — thread `task_priority` through both the create and edit paths.
- `api/task_routes.py` — validate `task_priority` against `TASK_PRIORITIES` (400 on invalid) and persist it in `handle_create_task`, mirroring the existing PATCH validation.
- `dashboard/src/components/ui/dialog.tsx` — add a desktop `md:max-h-[calc(100dvh-4rem)]` + internal scroll (mirrors the existing mobile pattern).
- `tests/test_task_routes.py` — new tests: valid priority persists, invalid → 400, omitted → `None`.

## Testing
- Backend unit tests (new `tests/test_task_routes.py`) — all pass:
  ```
  tests/test_task_routes.py::test_create_task_persists_valid_priority PASSED
  tests/test_task_routes.py::test_create_task_rejects_invalid_priority PASSED
  tests/test_task_routes.py::test_create_task_defaults_priority_to_none_when_omitted PASSED
  3 passed
  ```
- UI changes reuse existing `Select` / `Textarea` / `Dialog` primitives and the shared `TASK_PRIORITIES` list — no new styling invented. Before/after screenshots of the modal to follow as a comment.

## Notes
- Generated by the Plotline IE Bot based on an internal request.
- Draft — please review before merging.
