### PR TITLE
fix: keep the task dialog scrollable on large paste

### DIFF
--- a/dashboard/src/components/tasks/TaskDialog.tsx
+++ b/dashboard/src/components/tasks/TaskDialog.tsx
@@ -122,7 +122,7 @@ export function TaskDialog({ open, onOpenChange, lanes, task, defaultLane, onSub
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-lg" onKeyDown={handleKeyDown}>
+      <DialogContent className="sm:max-w-lg md:max-h-[calc(100dvh-2rem)] md:overflow-y-auto" onKeyDown={handleKeyDown}>
         <DialogHeader>
           <DialogTitle>{task ? "Task details" : "New task"}</DialogTitle>
         </DialogHeader>
@@ -150,6 +150,7 @@ export function TaskDialog({ open, onOpenChange, lanes, task, defaultLane, onSub
               onChange={(e) => setPrompt(e.target.value)}
               placeholder="What should the agent do?"
               rows={6}
+              className="max-h-[40vh] overflow-y-auto"
             />
           </div>
           {/* Stacked on phones — side by side the long model label forces a


### PR DESCRIPTION
## Summary
- Fixes the task dialog getting stuck off-screen when a large block of text is pasted into **Details**.
- Caps the details textarea so a large paste scrolls *inside* it instead of growing unbounded.
- Caps the dialog height with internal scroll on desktop, mirroring the existing mobile (`max-md:`) pattern.

## Context
Reported internally: pasting large text into the New Task modal expands it past the viewport; the content and footer buttons end up off-screen with nothing to scroll. **Desktop-only** — the shared dialog already caps height + scrolls on mobile via `max-md:` rules, but desktop had no cap, and `ui/textarea.tsx` uses `field-sizing-content` with no `max-h`, so the textarea grows without bound.

## Changes
- `dashboard/src/components/tasks/TaskDialog.tsx`
  - Details textarea: `max-h-[40vh] overflow-y-auto` so large pastes scroll internally.
  - Dialog: `md:max-h-[calc(100dvh-2rem)] md:overflow-y-auto` — a desktop height cap with internal scroll (`md:` is the exact complement of the shared component's `max-md:` mobile rules, so mobile behavior is untouched).

## Scope note
Deliberately **scoped to the task dialog** rather than editing shared `ui/dialog.tsx` / `ui/textarea.tsx`, to avoid changing the chat composer and every other dialog/textarea in the app. Targets exactly the reported surface with zero blast radius elsewhere.

## Testing
- Dashboard `tsc --noEmit` — 0 errors. `eslint` on the changed file — clean.

## Notes
- Generated by the Plotline Agent based on an internal bug report. Please review before merging.
