### PR TITLE
fix(ui): keep dialog footer reachable on large paste (desktop scroll)

### DIFF
--- a/dashboard/src/components/ui/dialog.tsx
+++ b/dashboard/src/components/ui/dialog.tsx
@@ -66,6 +66,10 @@ function DialogContent({
           // keyboard never hides fields or footer buttons (--app-h tracks the
           // visual viewport in the installed PWA).
           "max-md:top-[max(0.75rem,env(safe-area-inset-top))] max-md:translate-y-0 max-md:max-h-[calc(var(--app-h,100dvh)-max(0.75rem,env(safe-area-inset-top))-0.75rem)] max-md:overflow-y-auto max-md:overflow-x-hidden max-md:[&>*]:min-w-0",
+          // Desktop: cap height and scroll internally so tall content (e.g. a
+          // large pasted block in a textarea) can never push the dialog past
+          // the viewport and hide the footer buttons.
+          "md:max-h-[calc(100dvh-4rem)] md:overflow-y-auto md:overflow-x-hidden",
           className
         )}
         {...props}


### PR DESCRIPTION
## Summary
- Fixes the task modal getting stuck off-screen when a large block of text is pasted into the Details field on desktop.

## Context
Reported issue: pasting a large block of text into the New Task modal expands it past the viewport; the content and footer buttons get stuck off-screen with nothing to scroll (desktop-only).

## Root cause
- `ui/textarea.tsx` uses `field-sizing-content` with `min-h-16` and **no `max-h`**, so the textarea grows unbounded to fit pasted content.
- `ui/dialog.tsx` scoped its height cap and internal scroll to the `max-md:` (mobile) branch only. On desktop there was no max-height and no internal scroll, so the grown textarea pushed the dialog past the viewport and the footer off-screen.

## Changes
- `dashboard/src/components/ui/dialog.tsx` — add a desktop `md:max-h-[calc(100dvh-4rem)]` cap with `md:overflow-y-auto md:overflow-x-hidden`, mirroring the existing mobile (`max-md:`) pattern. Tall content now scrolls internally and the footer stays reachable. Single shared primitive, so this fixes the symptom for every dialog without changing textarea behavior (the base `Textarea` is also used by the chat composer).

## Testing
- Verified `git diff` is a single, minimal change to the shared `DialogContent`.
- Draft PR carries the `preview` label — reviewers can validate the behavior live in the preview deployment (open the New Task modal, paste a large block, confirm the dialog scrolls internally and the Add / Add & start buttons stay visible).

## Notes
- This is the **standalone** scroll fix, split out per the request for individual PRs per issue. The priority-in-modal change is in #95. This supersedes the scroll half of the combined #96.
- Generated by the Plotline IE Bot — please review before marking ready.
