### PR TITLE
feat: add Priority selector to the New Task modal

### DIFF
--- a/api/task_routes.py
+++ b/api/task_routes.py
@@ -257,6 +257,12 @@ async def handle_create_task(request: web.Request) -> web.Response:
 
     model = (body.get("model") or "").strip()
 
+    priority = body.get("task_priority")
+    if priority is not None and priority not in TASK_PRIORITIES:
+        return web.json_response(
+            {"error": "task_priority must be low, medium, high, urgent or null"},
+            status=400)
+
     files = body.get("files") or []
     if files:
         if not isinstance(files, list) or len(files) > MAX_DRAFT_FILES:
@@ -323,7 +329,7 @@ async def handle_create_task(request: web.Request) -> web.Response:
         "task_started_at": now if start else None,
         "task_done_at": None,
         "task_tag_ids": [],
-        "task_priority": None,
+        "task_priority": priority,
         "task_deadline": None,
     }
     await db.conversations.insert_one(doc)

--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -18,6 +18,7 @@ import {
   fetchTasksBoard,
   updateTask,
   type Task,
+  type TaskPriority,
   type TasksBoardResponse,
 } from "@/lib/api";
 import { Button } from "@/components/ui/button";
@@ -100,7 +101,7 @@ export default function TasksPage() {
   }, [sessionStatus, refresh]);
 
   const handleTaskSubmit = async (
-    values: { title: string; prompt: string; lane: string; model: string },
+    values: { title: string; prompt: string; lane: string; model: string; priority: TaskPriority | null },
     start: boolean,
   ) => {
     busyRef.current = true;
@@ -112,6 +113,7 @@ export default function TasksPage() {
           prompt: values.prompt,
           task_lane: values.lane,
           model: values.model,
+          task_priority: values.priority,
         });
         conversationId = editingTask.conversation_id;
       } else {
@@ -120,6 +122,7 @@ export default function TasksPage() {
           title: values.title || undefined,
           lane: values.lane,
           model: values.model || undefined,
+          task_priority: values.priority,
         });
         conversationId = task.conversation_id;
       }

--- a/dashboard/src/components/tasks/TaskDialog.tsx
+++ b/dashboard/src/components/tasks/TaskDialog.tsx
@@ -20,7 +20,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { DictationButton, appendDictation } from "@/components/composer/DictationButton";
-import { fetchAgentModels, type AgentModel, type BoardLane, type Task } from "@/lib/api";
+import { fetchAgentModels, type AgentModel, type BoardLane, type Task, type TaskPriority } from "@/lib/api";
+import { TASK_PRIORITIES } from "@/components/tasks/taskDisplay";
 
 interface TaskDialogProps {
   open: boolean;
@@ -30,7 +31,7 @@ interface TaskDialogProps {
   task?: Task | null;
   defaultLane?: string;
   onSubmit: (
-    values: { title: string; prompt: string; lane: string; model: string },
+    values: { title: string; prompt: string; lane: string; model: string; priority: TaskPriority | null },
     start: boolean,
   ) => Promise<void>;
 }
@@ -51,6 +52,7 @@ export function TaskDialog({ open, onOpenChange, lanes, task, defaultLane, onSub
   const [prompt, setPrompt] = useState("");
   const [lane, setLane] = useState(lanes[0]?.id ?? "todo");
   const [model, setModel] = useState("");
+  const [priority, setPriority] = useState<TaskPriority | null>(null);
   const [models, setModels] = useState<AgentModel[]>([]);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -61,6 +63,7 @@ export function TaskDialog({ open, onOpenChange, lanes, task, defaultLane, onSub
       setPrompt(task?.prompt ?? "");
       setLane(task?.task_lane ?? defaultLane ?? lanes[0]?.id ?? "todo");
       setModel(task?.model ?? "");
+      setPriority(task?.task_priority ?? null);
       setError(null);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -96,7 +99,7 @@ export function TaskDialog({ open, onOpenChange, lanes, task, defaultLane, onSub
     setBusy(true);
     setError(null);
     try {
-      await onSubmit({ title: title.trim(), prompt: prompt.trim(), lane, model }, start);
+      await onSubmit({ title: title.trim(), prompt: prompt.trim(), lane, model, priority }, start);
       onOpenChange(false);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Something went wrong");
@@ -185,6 +188,23 @@ export function TaskDialog({ open, onOpenChange, lanes, task, defaultLane, onSub
                 </Select>
               </div>
             )}
+            <div className="flex-1 min-w-0 space-y-1.5">
+              <Label>Priority</Label>
+              <Select
+                value={priority ?? "none"}
+                onValueChange={(v) => setPriority(v === "none" ? null : (v as TaskPriority))}
+              >
+                <SelectTrigger className="w-full max-w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="none">None</SelectItem>
+                  {TASK_PRIORITIES.map((p) => (
+                    <SelectItem key={p.id} value={p.id}>{p.symbol} {p.label}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
           </div>
           {error && <p className="text-xs text-destructive">{error}</p>}
         </div>

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -1045,6 +1045,7 @@ export async function createTask(params: {
   title?: string;
   lane?: string;
   model?: string;
+  task_priority?: TaskPriority | null;
   /** Attachments staged with the draft; sent with the first message on start */
   files?: ChatFile[];
   /** Fire immediately: the agent starts running in the background */

--- a/tests/test_task_routes.py
+++ b/tests/test_task_routes.py
@@ -1,0 +1,65 @@
+import contextlib
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from api.task_routes import handle_create_task
+
+
+BOARD = {"lanes": [{"id": "todo", "name": "To do"}], "tags": []}
+
+
+class FakeRequest:
+    """Minimal aiohttp request stand-in exposing an async json() body."""
+
+    def __init__(self, body):
+        self._body = body
+
+    async def json(self):
+        return self._body
+
+
+def response_json(response):
+    return json.loads(response.body)
+
+
+@contextlib.contextmanager
+def _env():
+    db = MagicMock()
+    db.conversations.insert_one = AsyncMock()
+    with patch("api.task_routes.get_db", return_value=db), \
+         patch("api.task_routes.get_user_email", return_value="owner@example.com"), \
+         patch("api.task_routes._get_board_config_for", AsyncMock(return_value=BOARD)):
+        yield db
+
+
+@pytest.mark.asyncio
+async def test_create_task_persists_valid_priority():
+    with _env() as db:
+        resp = await handle_create_task(
+            FakeRequest({"title": "T", "prompt": "do it", "task_priority": "high"}))
+    assert resp.status == 201
+    assert response_json(resp)["task"]["task_priority"] == "high"
+    doc = db.conversations.insert_one.await_args.args[0]
+    assert doc["task_priority"] == "high"
+
+
+@pytest.mark.asyncio
+async def test_create_task_rejects_invalid_priority():
+    with _env() as db:
+        resp = await handle_create_task(
+            FakeRequest({"title": "T", "prompt": "do it", "task_priority": "sky-high"}))
+    assert resp.status == 400
+    assert "task_priority" in response_json(resp)["error"]
+    db.conversations.insert_one.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_task_defaults_priority_to_none_when_omitted():
+    with _env() as db:
+        resp = await handle_create_task(
+            FakeRequest({"title": "T", "prompt": "do it"}))
+    assert resp.status == 201
+    doc = db.conversations.insert_one.await_args.args[0]
+    assert doc["task_priority"] is None


### PR DESCRIPTION
## Summary
Priority could be set on an existing task from the board (the PATCH route validates `task_priority`) but **not from the New Task modal** where a task is created. Three-layer gap: the dialog had no priority field, `createTask()` had no `task_priority` param, and `handle_create_task` hardcoded `task_priority=None`.

## Context
Direct request (no Linear ticket): "I can set Priority from the tasks panel for a particular request but I'm not able to set it directly from the modal where I create the New Task."

Note: Priority is display-only metadata (board organization). It does **not** affect model selection, execution order, prompt content, or how the agent builds a PR — this PR does not change that behavior, it only lets you set the value at creation time.

## Changes
- `dashboard/src/components/tasks/TaskDialog.tsx` — add a Priority `<Select>` (None / Urgent / High / Medium / Low) next to Lane and Model; seed from `task.task_priority` when editing; include `priority` in the submit payload.
- `dashboard/src/app/tasks/page.tsx` — thread `priority` through `handleTaskSubmit` into `createTask()` (create) and `updateTask()` (edit).
- `dashboard/src/lib/api.ts` — add `task_priority?: TaskPriority | null` to `createTask()`.
- `api/task_routes.py` — validate `task_priority` in `handle_create_task` (mirrors the PATCH route) and persist it instead of hardcoding `None`.
- `tests/test_task_routes.py` — new tests: valid priority persisted, invalid priority → 400, omitted → `None`.

## Testing
Backend unit tests (CI-style `pytest -q`):
```
tests/test_task_routes.py ...                                            [100%]
3 passed
```
UI rendered with the real component markup + Tailwind v4 classes + the dashboard theme tokens:

**Priority selector now present in the New Task modal:**

![priority field](https://cdn.plotline.so/loma-images/loma-task-dialog/priority_after.png)

**Options selectable at creation:**

![priority options](https://cdn.plotline.so/loma-images/loma-task-dialog/priority_open.png)

## Notes
- This PR was generated by the Plotline Agent based on the request above. Please review carefully before merging.
- A live preview is available via the `preview` label.
