### PR TITLE
feat: set priority when creating a task

### DIFF
--- a/api/task_routes.py
+++ b/api/task_routes.py
@@ -256,6 +256,11 @@ async def handle_create_task(request: web.Request) -> web.Response:
         return web.json_response({"error": "A title or details are required"}, status=400)
 
     model = (body.get("model") or "").strip()
+    priority = body.get("task_priority")
+    if priority is not None and priority not in TASK_PRIORITIES:
+        return web.json_response(
+            {"error": "task_priority must be low, medium, high, urgent or null"},
+            status=400)
 
     files = body.get("files") or []
     if files:
@@ -323,7 +328,7 @@ async def handle_create_task(request: web.Request) -> web.Response:
         "task_started_at": now if start else None,
         "task_done_at": None,
         "task_tag_ids": [],
-        "task_priority": None,
+        "task_priority": priority,
         "task_deadline": None,
     }
     await db.conversations.insert_one(doc)

--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -18,6 +18,7 @@ import {
   fetchTasksBoard,
   updateTask,
   type Task,
+  type TaskPriority,
   type TasksBoardResponse,
 } from "@/lib/api";
 import { Button } from "@/components/ui/button";
@@ -100,7 +101,7 @@ export default function TasksPage() {
   }, [sessionStatus, refresh]);
 
   const handleTaskSubmit = async (
-    values: { title: string; prompt: string; lane: string; model: string },
+    values: { title: string; prompt: string; lane: string; model: string; priority: TaskPriority | null },
     start: boolean,
   ) => {
     busyRef.current = true;
@@ -112,6 +113,7 @@ export default function TasksPage() {
           prompt: values.prompt,
           task_lane: values.lane,
           model: values.model,
+          task_priority: values.priority,
         });
         conversationId = editingTask.conversation_id;
       } else {
@@ -120,6 +122,7 @@ export default function TasksPage() {
           title: values.title || undefined,
           lane: values.lane,
           model: values.model || undefined,
+          task_priority: values.priority,
         });
         conversationId = task.conversation_id;
       }

--- a/dashboard/src/components/tasks/TaskDialog.tsx
+++ b/dashboard/src/components/tasks/TaskDialog.tsx
@@ -20,7 +20,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { DictationButton, appendDictation } from "@/components/composer/DictationButton";
-import { fetchAgentModels, type AgentModel, type BoardLane, type Task } from "@/lib/api";
+import { fetchAgentModels, type AgentModel, type BoardLane, type Task, type TaskPriority } from "@/lib/api";
+import { TASK_PRIORITIES } from "./taskDisplay";
 
 interface TaskDialogProps {
   open: boolean;
@@ -30,7 +31,7 @@ interface TaskDialogProps {
   task?: Task | null;
   defaultLane?: string;
   onSubmit: (
-    values: { title: string; prompt: string; lane: string; model: string },
+    values: { title: string; prompt: string; lane: string; model: string; priority: TaskPriority | null },
     start: boolean,
   ) => Promise<void>;
 }
@@ -51,6 +52,7 @@ export function TaskDialog({ open, onOpenChange, lanes, task, defaultLane, onSub
   const [prompt, setPrompt] = useState("");
   const [lane, setLane] = useState(lanes[0]?.id ?? "todo");
   const [model, setModel] = useState("");
+  const [priority, setPriority] = useState<TaskPriority | "none">("none");
   const [models, setModels] = useState<AgentModel[]>([]);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -61,6 +63,7 @@ export function TaskDialog({ open, onOpenChange, lanes, task, defaultLane, onSub
       setPrompt(task?.prompt ?? "");
       setLane(task?.task_lane ?? defaultLane ?? lanes[0]?.id ?? "todo");
       setModel(task?.model ?? "");
+      setPriority(task?.task_priority ?? "none");
       setError(null);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -96,7 +99,7 @@ export function TaskDialog({ open, onOpenChange, lanes, task, defaultLane, onSub
     setBusy(true);
     setError(null);
     try {
-      await onSubmit({ title: title.trim(), prompt: prompt.trim(), lane, model }, start);
+      await onSubmit({ title: title.trim(), prompt: prompt.trim(), lane, model, priority: priority === "none" ? null : priority }, start);
       onOpenChange(false);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Something went wrong");
@@ -185,6 +188,22 @@ export function TaskDialog({ open, onOpenChange, lanes, task, defaultLane, onSub
                 </Select>
               </div>
             )}
+          </div>
+          <div className="space-y-1.5">
+            <Label>Priority</Label>
+            <Select value={priority} onValueChange={(value) => setPriority(value as TaskPriority | "none")}>
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="none">No priority</SelectItem>
+                {TASK_PRIORITIES.map((item) => (
+                  <SelectItem key={item.id} value={item.id}>
+                    {item.symbol} {item.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
           {error && <p className="text-xs text-destructive">{error}</p>}
         </div>

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -1045,6 +1045,7 @@ export async function createTask(params: {
   title?: string;
   lane?: string;
   model?: string;
+  task_priority?: TaskPriority | null;
   /** Attachments staged with the draft; sent with the first message on start */
   files?: ChatFile[];
   /** Fire immediately: the agent starts running in the background */

--- a/tests/test_task_routes.py
+++ b/tests/test_task_routes.py
@@ -1,0 +1,60 @@
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+from api.task_routes import handle_create_task
+
+
+class FakeRequest(dict):
+    def __init__(self, body):
+        super().__init__(user_email="owner@example.com")
+        self._body = body
+
+    async def json(self):
+        return self._body
+
+
+def response_json(response):
+    return json.loads(response.body)
+
+
+def fake_db():
+    db = MagicMock()
+    db.users.find_one = AsyncMock(return_value=None)
+    db.conversations.insert_one = AsyncMock()
+    return db
+
+
+def test_create_task_stores_valid_priority():
+    db = fake_db()
+    with patch("api.task_routes.get_db", return_value=db):
+        response = asyncio.run(handle_create_task(FakeRequest({
+            "title": "Important task", "task_priority": "high",
+        })))
+
+    assert response.status == 201
+    assert db.conversations.insert_one.await_args.args[0]["task_priority"] == "high"
+
+
+def test_create_task_rejects_invalid_priority():
+    db = fake_db()
+    with patch("api.task_routes.get_db", return_value=db):
+        response = asyncio.run(handle_create_task(FakeRequest({
+            "title": "Important task", "task_priority": "critical",
+        })))
+
+    assert response.status == 400
+    assert response_json(response)["error"] == (
+        "task_priority must be low, medium, high, urgent or null"
+    )
+    db.conversations.insert_one.assert_not_awaited()
+
+
+def test_create_task_defaults_priority_to_none():
+    db = fake_db()
+    with patch("api.task_routes.get_db", return_value=db):
+        response = asyncio.run(handle_create_task(FakeRequest({"title": "Normal task"})))
+
+    assert response.status == 201
+    assert db.conversations.insert_one.await_args.args[0]["task_priority"] is None


### PR DESCRIPTION
## Summary
- Adds a Priority selector to the New Task and Task Details dialog
- Sends priority through the create and update APIs
- Validates and stores priority during task creation
- Adds backend coverage for valid, invalid, and omitted priorities

## Testing
- `pytest -q tests/test_task_routes.py` (3 passed)
- `npx eslint src/components/tasks/TaskDialog.tsx src/app/tasks/page.tsx src/lib/api.ts`
- `npm run build`
- Local UI validation

## Screenshot
![Priority selector in New Task dialog](https://cdn.plotline.so/loma-images/loma-prs/task-create-priority.png)

## Notes
- Priority remains organizational metadata only. It does not affect model selection, task execution order, prompts, or PR generation.
- This PR was generated by Loma based on the approved request.
