### PR TITLE
fix: keep task dialog scrollable with large pasted text

### DIFF
--- a/dashboard/src/components/tasks/TaskDialog.tsx
+++ b/dashboard/src/components/tasks/TaskDialog.tsx
@@ -122,7 +122,10 @@ export function TaskDialog({ open, onOpenChange, lanes, task, defaultLane, onSub
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-lg" onKeyDown={handleKeyDown}>
+      <DialogContent
+        className="max-h-[calc(100dvh-2rem)] overflow-y-auto overflow-x-hidden sm:max-w-lg"
+        onKeyDown={handleKeyDown}
+      >
         <DialogHeader>
           <DialogTitle>{task ? "Task details" : "New task"}</DialogTitle>
         </DialogHeader>
@@ -150,6 +153,7 @@ export function TaskDialog({ open, onOpenChange, lanes, task, defaultLane, onSub
               onChange={(e) => setPrompt(e.target.value)}
               placeholder="What should the agent do?"
               rows={6}
+              className="max-h-64 overflow-y-auto"
             />
           </div>
           {/* Stacked on phones — side by side the long model label forces a


### PR DESCRIPTION
## Summary
- Caps the task details textarea height and enables internal scrolling
- Caps the task dialog to the viewport and enables dialog-level scrolling
- Keeps footer actions reachable after pasting large text

## Testing
- `npx eslint src/components/tasks/TaskDialog.tsx`
- `npm run build`
- Playwright visual validation with 45 pasted lines at a 1440x700 viewport

## Screenshot
![Large pasted text remains scrollable inside the task dialog](https://cdn.plotline.so/loma-images/loma-prs/task-dialog-large-text-scroll.png)

## Notes
- The fix is scoped to the Task dialog and does not change textarea or dialog behavior globally.
- This PR was generated by Loma based on the approved request.
