### PR TITLE
fix: make topic classification reliable and retryable

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -327,10 +327,11 @@ async def _generate_title_llm(prompt: str, response_snippet: str = "") -> str:
         return "Untitled conversation"
 
 
-async def _classify_topic_llm(prompt: str, response_snippet: str = "") -> str:
+async def _classify_topic_llm(prompt: str, response_snippet: str = "") -> str | None:
     """Classify a conversation into a topic category using Claude Haiku.
 
-    Returns one of the _VALID_TOPICS values, or 'other' on failure.
+    Returns one of the _VALID_TOPICS values. Failures return None so callers
+    leave the topic unset and a later enrichment pass can retry it.
     """
     context = prompt[:500]
     if response_snippet:
@@ -344,34 +345,45 @@ async def _classify_topic_llm(prompt: str, response_snippet: str = "") -> str:
         f"Conversation:\n{context}"
     )
 
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            "claude", "-p", message,
-            "--model", "claude-haiku-4-5-20251001",
-            "--max-turns", "1",
-            "--output-format", "json",
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=15)
-
-        if proc.returncode != 0:
-            logger.warning("Topic classification CLI failed (rc=%d): %s", proc.returncode, stderr.decode()[:500])
-            return "other"
-
-        output = stdout.decode().strip()
+    for attempt in range(1, 4):
         try:
-            envelope = json.loads(output)
-            raw = envelope.get("result", output)
-        except json.JSONDecodeError:
-            raw = output
+            proc = await asyncio.create_subprocess_exec(
+                "claude", "-p", message,
+                "--model", "claude-haiku-4-5-20251001",
+                "--max-turns", "1",
+                "--output-format", "json",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=15)
 
-        topic = raw.strip().lower().strip('"').strip("'").strip()
-        return topic if topic in _VALID_TOPICS else "other"
+            if proc.returncode != 0:
+                logger.warning(
+                    "Topic classification CLI failed (attempt=%d, rc=%d): %s",
+                    attempt, proc.returncode, stderr.decode()[:500],
+                )
+                continue
 
-    except Exception as e:
-        logger.warning("Topic classification failed: %s", e)
-        return "other"
+            output = stdout.decode().strip()
+            try:
+                envelope = json.loads(output)
+                raw = envelope.get("result", output)
+            except json.JSONDecodeError:
+                raw = output
+
+            topic = raw.strip().lower().strip('"').strip("'").strip()
+            if topic in _VALID_TOPICS:
+                return topic
+            logger.warning("Invalid topic classification (attempt=%d): %r", attempt, topic)
+        except asyncio.TimeoutError:
+            logger.warning("Topic classification timed out (attempt=%d)", attempt)
+        except Exception as e:
+            logger.warning("Topic classification failed (attempt=%d): %s", attempt, e)
+
+        if attempt < 3:
+            await asyncio.sleep(0.25 * attempt)
+
+    return None
 
 
 async def _enrich_conversation(db, conversation: dict) -> dict:
@@ -390,8 +402,9 @@ async def _enrich_conversation(db, conversation: dict) -> dict:
 
     if not conversation.get("topic"):
         topic = await _classify_topic_llm(prompt, response_snippet)
-        conversation["topic"] = topic
-        needs_update["topic"] = topic
+        if topic:
+            conversation["topic"] = topic
+            needs_update["topic"] = topic
 
     if needs_update:
         try:

--- a/observability/observer.py
+++ b/observability/observer.py
@@ -439,13 +439,16 @@ class ConversationObserver:
             # set title_edited) — only enrich the topic in that case.
             existing = await self.db.conversations.find_one(
                 {"conversation_id": self.conversation_id}, {"title_edited": 1})
-            update_fields = {"topic": topic}
+            update_fields = {}
+            if topic:
+                update_fields["topic"] = topic
             if not (existing or {}).get("title_edited"):
                 update_fields["title"] = title
-            await self.db.conversations.update_one(
-                {"conversation_id": self.conversation_id},
-                {"$set": update_fields},
-            )
+            if update_fields:
+                await self.db.conversations.update_one(
+                    {"conversation_id": self.conversation_id},
+                    {"$set": update_fields},
+                )
             logger.info("Observability: enrichment complete for %s: title=%r topic=%s",
                          self.conversation_id, title, topic)
         except Exception as e:

--- a/tests/test_topic_classification.py
+++ b/tests/test_topic_classification.py
@@ -1,0 +1,118 @@
+import asyncio
+
+from api.routes import _classify_topic_llm, _enrich_conversation
+
+
+class FakeProcess:
+    def __init__(self, stdout=b"", stderr=b"", returncode=0):
+        self._stdout = stdout
+        self._stderr = stderr
+        self.returncode = returncode
+
+    async def communicate(self):
+        return self._stdout, self._stderr
+
+
+def test_topic_classification_returns_valid_topic(monkeypatch):
+    async def create_process(*args, **kwargs):
+        return FakeProcess(b'{"result":"integration"}')
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", create_process)
+
+    assert asyncio.run(_classify_topic_llm("Help integrate the SDK")) == "integration"
+
+
+def test_topic_classification_accepts_genuine_other(monkeypatch):
+    async def create_process(*args, **kwargs):
+        return FakeProcess(b'{"result":"other"}')
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", create_process)
+
+    assert asyncio.run(_classify_topic_llm("Say hello")) == "other"
+
+
+def test_topic_classification_retries_cli_failure(monkeypatch):
+    processes = [
+        FakeProcess(stderr=b"temporary failure", returncode=1),
+        FakeProcess(b'{"result":"sdk"}'),
+    ]
+
+    async def create_process(*args, **kwargs):
+        return processes.pop(0)
+
+    async def no_sleep(_delay):
+        pass
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", create_process)
+    monkeypatch.setattr(asyncio, "sleep", no_sleep)
+
+    assert asyncio.run(_classify_topic_llm("Android SDK crash")) == "sdk"
+    assert not processes
+
+
+def test_topic_classification_does_not_convert_invalid_output_to_other(monkeypatch):
+    calls = 0
+
+    async def create_process(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return FakeProcess(b'{"result":"not-a-valid-topic"}')
+
+    async def no_sleep(_delay):
+        pass
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", create_process)
+    monkeypatch.setattr(asyncio, "sleep", no_sleep)
+
+    assert asyncio.run(_classify_topic_llm("Unclear request")) is None
+    assert calls == 3
+
+
+def test_topic_classification_retries_timeouts(monkeypatch):
+    calls = 0
+
+    async def create_process(*args, **kwargs):
+        return FakeProcess()
+
+    async def timeout(coro, *args, **kwargs):
+        nonlocal calls
+        calls += 1
+        coro.close()
+        raise asyncio.TimeoutError
+
+    async def no_sleep(_delay):
+        pass
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", create_process)
+    monkeypatch.setattr(asyncio, "wait_for", timeout)
+    monkeypatch.setattr(asyncio, "sleep", no_sleep)
+
+    assert asyncio.run(_classify_topic_llm("Unclear request")) is None
+    assert calls == 3
+
+
+def test_enrichment_leaves_failed_topic_unset_for_later_retry(monkeypatch):
+    class Conversations:
+        def __init__(self):
+            self.update = None
+
+        async def update_one(self, query, update):
+            self.update = update
+
+    class DB:
+        conversations = Conversations()
+
+    async def failed_classification(*args):
+        return None
+
+    monkeypatch.setattr("api.routes._classify_topic_llm", failed_classification)
+    conversation = {
+        "conversation_id": "conversation-1",
+        "prompt": "Unclear request",
+        "title": "Existing title",
+    }
+
+    result = asyncio.run(_enrich_conversation(DB(), conversation))
+
+    assert "topic" not in result
+    assert DB.conversations.update is None


### PR DESCRIPTION
## Summary
- retry transient topic classification failures up to three times
- distinguish classification failures from a genuine `other` result
- leave failed topics unset so later enrichment/backfill can retry them
- persist only validated topic categories

## Context
Loma currently stores `other` when the Claude CLI fails, times out, or returns malformed output. That makes operational failures indistinguishable from real classifications and prevents retrying them.

## Changes
- `api/routes.py`: return `None` after bounded retries instead of converting failures to `other`
- `observability/observer.py`: skip topic persistence when classification fails
- `tests/test_topic_classification.py`: cover valid classifications, genuine `other`, CLI retries, invalid output, timeout retries, and retry-safe persistence

## Testing
- `python3 -m pytest tests/test_topic_classification.py -q` (`6 passed`)
- Full suite: `284 passed`, with one unrelated existing failure in `tests/test_opencode_runtime.py::test_stream_agent_uses_opencode_runtime_by_default` because the client pool is not initialized

## Notes
- Existing records already stored as `other` are not rewritten by this PR because genuine `other` values cannot be distinguished safely from historical fallback values.
- This is a draft PR and should be reviewed before merging.
