### PR TITLE
feat: add Claude Opus 5 model support

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -136,6 +136,7 @@ logger = logging.getLogger(__name__)
 # Claude Agent SDK models surfaced in the dashboard picker, newest first.
 # The first entry is treated as the headline/default Claude model.
 SUPPORTED_CLAUDE_MODEL_IDS = (
+    "claude-opus-5",
     "claude-opus-4-8",
     "claude-fable-5",
     "claude-opus-4-7",
@@ -144,6 +145,7 @@ SUPPORTED_CLAUDE_MODEL_IDS = (
 
 FAVORITE_MODEL_IDS = (
     "opencode-go/deepseek-v4-flash",
+    "anthropic/claude-opus-5",
     "anthropic/claude-opus-4-8",
     "anthropic/claude-fable-5",
     "anthropic/claude-opus-4-7",

--- a/dashboard/src/app/flows/[id]/page.tsx
+++ b/dashboard/src/app/flows/[id]/page.tsx
@@ -59,6 +59,7 @@ const LABEL_COLORS = [
 ];
 
 const FAVORITE_MODEL_IDS = [
+  "anthropic/claude-opus-5",
   "anthropic/claude-opus-4-8",
   "anthropic/claude-fable-5",
   "anthropic/claude-opus-4-7",

--- a/dashboard/src/hooks/useAgentModels.ts
+++ b/dashboard/src/hooks/useAgentModels.ts
@@ -7,6 +7,7 @@ const MODEL_STORAGE_KEY = "dashboard-chat-selected-model";
 
 export const FAVORITE_MODEL_IDS = [
   "opencode-go/deepseek-v4-flash",
+  "anthropic/claude-opus-5",
   "anthropic/claude-opus-4-8",
   "anthropic/claude-fable-5",
   "anthropic/claude-opus-4-7",


### PR DESCRIPTION
## Summary
- Adds `claude-opus-5` to the Claude Agent SDK model catalog.
- Promotes `anthropic/claude-opus-5` in Chat, Tasks, and Flow model pickers.
- Keeps existing deployment defaults unchanged.

## Changes
- `api/routes.py` adds Opus 5 to supported and favorite model IDs.
- `dashboard/src/hooks/useAgentModels.ts` adds Opus 5 to shared dashboard favorites.
- `dashboard/src/app/flows/[id]/page.tsx` adds Opus 5 to flow favorites.

## Testing
- `python3 -m compileall -q api` passed.
- `npm run build` in `dashboard/` passed, including TypeScript validation.
- Python unit tests were not run because `pytest` is not installed in the environment.

## Notes
- This is a model-catalog change only. It does not change `CLAUDE_MODEL` or `AGENT_DEFAULT_MODEL`.
- Please review carefully before merging.
