### PR TITLE
fix(google_drive): support Shared Drive files (supportsAllDrives)

### DIFF
--- a/tools/google_docs_personal.py
+++ b/tools/google_docs_personal.py
@@ -216,6 +216,7 @@ async def copy_doc(user_email: str, document_id: str, title: str = "") -> dict:
         fileId=document_id,
         body=metadata,
         fields="id,name,webViewLink",
+        supportsAllDrives=True,
     ).execute()
 
     return {

--- a/tools/google_drive.py
+++ b/tools/google_drive.py
@@ -126,6 +126,9 @@ async def list_files(user_email: str, query: str = "", limit: int = 10) -> dict:
         pageSize=limit,
         fields=fields,
         orderBy="modifiedTime desc",
+        corpora="allDrives",
+        supportsAllDrives=True,
+        includeItemsFromAllDrives=True,
     ).execute()
 
     files = [_format_file(f) for f in result.get("files", [])]
@@ -149,6 +152,7 @@ async def read_file(user_email: str, file_id: str) -> dict:
     meta = service.files().get(
         fileId=file_id,
         fields="id,name,mimeType,size,modifiedTime,owners,webViewLink",
+        supportsAllDrives=True,
     ).execute()
 
     mime_type = meta.get("mimeType", "")
@@ -177,7 +181,7 @@ async def read_file(user_email: str, file_id: str) -> dict:
         try:
             from googleapiclient.http import MediaIoBaseDownload
 
-            request = service.files().get_media(fileId=file_id)
+            request = service.files().get_media(fileId=file_id, supportsAllDrives=True)
             fh = io.BytesIO()
             downloader = MediaIoBaseDownload(fh, request)
             done = False
@@ -192,7 +196,7 @@ async def read_file(user_email: str, file_id: str) -> dict:
         try:
             from googleapiclient.http import MediaIoBaseDownload
 
-            request = service.files().get_media(fileId=file_id)
+            request = service.files().get_media(fileId=file_id, supportsAllDrives=True)
             fh = io.BytesIO()
             downloader = MediaIoBaseDownload(fh, request)
             done = False
@@ -270,6 +274,7 @@ async def upload_file(
         body=file_metadata,
         media_body=media,
         fields="id,name,mimeType,webViewLink,size",
+        supportsAllDrives=True,
     ).execute()
 
     return {
@@ -298,6 +303,7 @@ async def create_folder(
     result = service.files().create(
         body=metadata,
         fields="id,name,webViewLink",
+        supportsAllDrives=True,
     ).execute()
 
     return {
@@ -324,6 +330,7 @@ async def copy_file(
         fileId=file_id,
         body=metadata,
         fields="id,name,mimeType,webViewLink,size",
+        supportsAllDrives=True,
     ).execute()
 
     return {

--- a/tools/google_sheets.py
+++ b/tools/google_sheets.py
@@ -130,6 +130,7 @@ async def copy_spreadsheet(user_email: str, spreadsheet_id: str, title: str = ""
         fileId=spreadsheet_id,
         body=metadata,
         fields="id,name,webViewLink",
+        supportsAllDrives=True,
     ).execute()
 
     return {


### PR DESCRIPTION
## Symptom

Reading **any** Google Drive file that lives on a **Shared Drive** failed with:

```
Google Drive API error: <HttpError 404 when requesting
https://www.googleapis.com/drive/v3/files/1yKj...L72?fields=... returned
"File not found: 1yKjqVCI8kI33vWNdoUrrMjX8R8JBdL72."
```

Because the tool surfaced a raw `404 File not found`, Loma misdiagnosed this to the user as a
permissions problem — telling them *"I couldn't open the doc, it's not shared with your account"* —
when in fact the user had full access to the file. Shared Drive files were also silently missing
from `list-files` / `search` results.

## Root cause

`tools/google_drive.py` called the Drive v3 API without the Shared Drive flags. By default the
Drive v3 API scopes every request to **My Drive only**; items on a Shared Drive are simply not
visible and the API reports them as `404 notFound` rather than `403`. The caller must opt in:

- `supportsAllDrives=True` — required on any call that addresses a file by ID
- `includeItemsFromAllDrives=True` (+ `corpora`) — required for `files.list` to enumerate them

None of the calls set these, so the entire Shared Drive surface was invisible to the tool.

## Fix

Added the flags to every Drive API call that accepts them:

**`tools/google_drive.py`**
- `files().list(...)` — `supportsAllDrives`, `includeItemsFromAllDrives`, `corpora="allDrives"` (powers both `list-files` and `search`)
- `files().get(...)` — `supportsAllDrives`
- `files().get_media(...)` — `supportsAllDrives` (both call sites: text download and PDF/DOCX extraction)
- `files().create(...)` — `supportsAllDrives` (`upload-file` and `create-folder`)
- `files().copy(...)` — `supportsAllDrives` (`copy-file`)

**`tools/google_docs_personal.py`** — `drive.files().copy(...)` in `copy_doc` (same latent bug)
**`tools/google_sheets.py`** — `drive.files().copy(...)` in `copy_spreadsheet` (same latent bug)

`files().export(...)` is intentionally left unchanged — the Drive v3 `export` method does not accept
`supportsAllDrives`.

No other behaviour changed; the diff is additive keyword arguments only.

### Note on `corpora="allDrives"`

`corpora` is only valid when `driveId` is not set, which is the case here (the tool never scopes to a
single drive). It was verified empirically rather than assumed — see below.

## Verification

Repro from the bug report, run against live credentials.

**Before** (on `main`):

```
{"error": "Google Drive API error: <HttpError 404 ... returned \"File not found: 1yKjqVCI8kI33vWNdoUrrMjX8R8JBdL72.\" ...>"}
```

**After** (this branch) — returns metadata *and* successfully extracts the `.docx` body, exercising
both the patched `files().get` and `files().get_media` paths:

```json
{
  "id": "1yKjqVCI8kI33vWNdoUrrMjX8R8JBdL72",
  "name": "Plotline Web RFP Response — IndiGo",
  "mimeType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
  "modifiedTime": "2026-07-30T13:35:08.384Z",
  "webViewLink": "https://docs.google.com/document/d/1yKjqVCI8kI33vWNdoUrrMjX8R8JBdL72/edit",
  "content": "Plotline\n\nRFP Response - Personalization & Experimentation Platform\n\nPrepared for InterGlobe Aviation Limited (IndiGo)\n..."
}
```

**Regression check on `list-files`** — confirming `corpora="allDrives"` does not break the existing
My Drive listing. Same command, `--limit 5`, before vs. after:

| | Before | After |
|---|---|---|
| Agencies/Freelancer Shortlist | ✅ | ✅ |
| Plotline Web RFP Response — IndiGo | ❌ missing | ✅ **now visible** |
| DPA_Krom bank.docx | ✅ | ✅ |
| Plotline Collections | ✅ | ✅ |
| DPA_Krom Bank — Plotline.docx | ✅ | ✅ |

Every previously-returned file is still returned, `orderBy="modifiedTime desc"` is preserved, and the
Shared Drive file now appears in its correct chronological position. `search` (`name contains 'RFP'`)
was also re-run and returns Shared Drive hits alongside My Drive hits.

`python -m compileall` passes on all three modified files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)