### PR TITLE
fix: use proper redirect URI in OAuth client registration

### DIFF
--- a/api/integration_routes.py
+++ b/api/integration_routes.py
@@ -296,14 +296,19 @@ async def _add_custom_connector(request: web.Request) -> web.Response:
 
         if not client_id and oauth_config.get("registration_endpoint"):
             from api.oauth_routes import _oauth_redirect_uri
-            redirect_uri = f"{os.environ.get('APP_BASE_URL', '').rstrip('/')}/api/oauth/custom-mcp/{slug}/callback"
+            redirect_uri = _oauth_redirect_uri(request, f"custom-mcp/{slug}")
             reg_result = await register_oauth_client(
                 registration_endpoint=oauth_config["registration_endpoint"],
                 redirect_uri=redirect_uri,
             )
             if reg_result is None:
                 return web.json_response(
-                    {"error": "OAuth dynamic client registration failed. Provide client_id manually."},
+                    {"error": "OAuth dynamic client registration failed (network error). Provide client_id manually."},
+                    status=400,
+                )
+            if "error" in reg_result:
+                return web.json_response(
+                    {"error": f"OAuth dynamic client registration failed: {reg_result['error']}. Provide client_id manually."},
                     status=400,
                 )
             client_id = reg_result["client_id"]

--- a/api/oauth_helpers.py
+++ b/api/oauth_helpers.py
@@ -505,7 +505,9 @@ async def register_oauth_client(
 ) -> dict | None:
     """Dynamically register as an OAuth client (RFC 7591).
 
-    Returns {"client_id": ..., "client_secret": ...} or None on failure.
+    Returns {"client_id": ..., "client_secret": ..., "error": None} on
+    success, or {"error": "..."} on failure for surfacing to the user.
+    Returns None only on network-level failures.
     """
     body = {
         "client_name": client_name,
@@ -524,11 +526,16 @@ async def register_oauth_client(
                 if resp.status not in (200, 201):
                     text = await resp.text()
                     logger.error("OAuth client registration failed (%d): %s", resp.status, text[:300])
-                    return None
+                    detail = ""
+                    try:
+                        detail = json.loads(text).get("error_description") or json.loads(text).get("error", "")
+                    except Exception:
+                        detail = text[:200]
+                    return {"error": f"Registration rejected ({resp.status}): {detail}".strip(": ")}
                 data = await resp.json()
                 if not data.get("client_id"):
                     logger.error("OAuth registration returned no client_id")
-                    return None
+                    return {"error": "Registration succeeded but returned no client_id"}
                 return {
                     "client_id": data["client_id"],
                     "client_secret": data.get("client_secret", ""),


### PR DESCRIPTION
## Summary
- Fixed redirect URI construction during dynamic client registration — was manually built from `APP_BASE_URL` (producing an invalid path-only URI when unset), now uses `_oauth_redirect_uri()` which has proper fallback logic
- Surfaces the actual error from the OAuth registration endpoint instead of a generic "failed" message

## Test plan
- [ ] Remove existing Customer.io connector if any, re-add via `https://mcp.customer.io/mcp` — dynamic registration should succeed and OAuth popup should open
- [ ] Verify the error message is informative if registration fails (e.g. with an invalid registration endpoint)


🤖 Generated with [Claude Code](https://claude.com/claude-code)