### PR TITLE
feat: Option + Space dictation shortcut + Deepgram Nova-3 transcription

### DIFF
--- a/api/transcribe_routes.py
+++ b/api/transcribe_routes.py
@@ -6,11 +6,11 @@ transcription API and return plain text. Server-side so the API key stays
 private and quality beats on-device engines (Web Speech API is also broken
 in installed iOS PWAs, which is the primary dictation surface).
 
-Provider selection: Groq's Whisper Large v3 Turbo when GROQ_API_KEY is set
-(preferred - ~10x cheaper and faster), otherwise OpenAI's whisper-1. Both are
-pure speech-to-text Whisper models: unlike the previous gpt-4o-transcribe
-(a chat LLM), they cannot "answer" a spoken question instead of
-transcribing it.
+Provider selection: Deepgram's Nova-3 when DEEPGRAM_API_KEY is set
+(preferred - purpose-built STT, sub-second latency, ~40% cheaper than
+gpt-4o-transcribe), otherwise OpenAI's whisper-1. Both are pure
+speech-to-text models: unlike the previous gpt-4o-transcribe (a chat LLM),
+they cannot "answer" a spoken question instead of transcribing it.
 """
 import logging
 import os
@@ -24,16 +24,20 @@ from api.prompt_setting_defaults import get_default_prompt_setting
 
 logger = logging.getLogger(__name__)
 
-GROQ_TRANSCRIBE_URL = "https://api.groq.com/openai/v1/audio/transcriptions"
-GROQ_TRANSCRIBE_MODEL = "whisper-large-v3-turbo"
+DEEPGRAM_TRANSCRIBE_URL = "https://api.deepgram.com/v1/listen"
+DEEPGRAM_TRANSCRIBE_MODEL = "nova-3"
 OPENAI_TRANSCRIBE_URL = "https://api.openai.com/v1/audio/transcriptions"
 OPENAI_TRANSCRIBE_MODEL = "whisper-1"
 
-# Both providers reject >25MB; the client caps recordings at ~3 minutes anyway.
+# OpenAI rejects >25MB and Deepgram accepts far more; the client caps
+# recordings at ~3 minutes anyway.
 MAX_AUDIO_BYTES = 20 * 1024 * 1024
 # A tap-and-immediate-stop produces a few hundred bytes of container header —
 # not worth an API call.
 MIN_AUDIO_BYTES = 1024
+
+# Deepgram caps keyterm prompting at 100 terms per request.
+MAX_KEYTERMS = 100
 
 
 def _vocab_prompt() -> str:
@@ -46,22 +50,84 @@ def _vocab_prompt() -> str:
     )
 
 
+def _vocab_keyterms(vocab: str) -> list[str]:
+    """Split the vocabulary hint into individual terms for Deepgram's
+    keyterm prompting (Nova-3's equivalent of Whisper's `prompt` field)."""
+    terms = [t.strip() for t in vocab.replace("\n", ",").split(",")]
+    return [t for t in terms if t][:MAX_KEYTERMS]
+
+
+async def _transcribe_deepgram(api_key: str, audio: bytes, content_type: str) -> tuple[str | None, str | None]:
+    """Send raw audio to Deepgram Nova-3. Returns (text, error)."""
+    params = [("model", DEEPGRAM_TRANSCRIBE_MODEL), ("smart_format", "true")]
+    vocab = _vocab_prompt()
+    if vocab:
+        params.extend(("keyterm", term) for term in _vocab_keyterms(vocab))
+
+    timeout = aiohttp.ClientTimeout(total=60)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        async with session.post(
+            DEEPGRAM_TRANSCRIBE_URL,
+            params=params,
+            data=audio,
+            headers={
+                "Authorization": f"Token {api_key}",
+                "Content-Type": content_type,
+            },
+        ) as resp:
+            payload = await resp.json(content_type=None)
+            if resp.status != 200:
+                message = (
+                    payload.get("err_msg")
+                    or payload.get("error")
+                    or "Transcription failed"
+                )
+                logger.error("[TRANSCRIBE] Deepgram %s: %s", resp.status, message)
+                return None, str(message)
+    try:
+        text = payload["results"]["channels"][0]["alternatives"][0]["transcript"]
+    except (KeyError, IndexError, TypeError):
+        logger.error("[TRANSCRIBE] Deepgram: unexpected response shape")
+        return None, "Transcription failed"
+    return (text or "").strip(), None
+
+
+async def _transcribe_openai(
+    api_key: str, audio: bytes, filename: str, content_type: str
+) -> tuple[str | None, str | None]:
+    """Send audio to OpenAI whisper-1 (multipart). Returns (text, error)."""
+    form = aiohttp.FormData()
+    form.add_field("file", audio, filename=filename, content_type=content_type)
+    form.add_field("model", OPENAI_TRANSCRIBE_MODEL)
+    vocab = _vocab_prompt()
+    if vocab:
+        form.add_field("prompt", vocab)
+
+    timeout = aiohttp.ClientTimeout(total=60)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        async with session.post(
+            OPENAI_TRANSCRIBE_URL,
+            data=form,
+            headers={"Authorization": f"Bearer {api_key}"},
+        ) as resp:
+            payload = await resp.json(content_type=None)
+            if resp.status != 200:
+                message = (payload.get("error") or {}).get("message") or "Transcription failed"
+                logger.error("[TRANSCRIBE] OpenAI %s: %s", resp.status, message)
+                return None, str(message)
+    return (payload.get("text") or "").strip(), None
+
+
 async def handle_transcribe(request: web.Request) -> web.Response:
     """POST /api/transcribe — multipart audio in, {"text": ...} out."""
     if not get_user_email(request):
         return web.json_response({"error": "Not authenticated"}, status=401)
 
-    groq_key = os.environ.get("GROQ_API_KEY", "").strip()
+    deepgram_key = os.environ.get("DEEPGRAM_API_KEY", "").strip()
     openai_key = os.environ.get("OPENAI_API_KEY", "").strip()
-    if groq_key:
-        api_key, url, model, provider = (
-            groq_key, GROQ_TRANSCRIBE_URL, GROQ_TRANSCRIBE_MODEL, "Groq")
-    elif openai_key:
-        api_key, url, model, provider = (
-            openai_key, OPENAI_TRANSCRIBE_URL, OPENAI_TRANSCRIBE_MODEL, "OpenAI")
-    else:
+    if not deepgram_key and not openai_key:
         return web.json_response(
-            {"error": "Transcription is not configured (set GROQ_API_KEY or OPENAI_API_KEY)"},
+            {"error": "Transcription is not configured (set DEEPGRAM_API_KEY or OPENAI_API_KEY)"},
             status=503,
         )
 
@@ -84,31 +150,18 @@ async def handle_transcribe(request: web.Request) -> web.Response:
     if len(audio) > MAX_AUDIO_BYTES:
         return web.json_response({"error": "Recording too large"}, status=413)
 
-    form = aiohttp.FormData()
-    form.add_field("file", audio, filename=filename, content_type=content_type)
-    form.add_field("model", model)
-    vocab = _vocab_prompt()
-    if vocab:
-        form.add_field("prompt", vocab)
-
     try:
-        timeout = aiohttp.ClientTimeout(total=60)
-        async with aiohttp.ClientSession(timeout=timeout) as session:
-            async with session.post(
-                url,
-                data=form,
-                headers={"Authorization": f"Bearer {api_key}"},
-            ) as resp:
-                payload = await resp.json(content_type=None)
-                if resp.status != 200:
-                    message = (payload.get("error") or {}).get("message") or "Transcription failed"
-                    logger.error("[TRANSCRIBE] %s %s: %s", provider, resp.status, message)
-                    return web.json_response({"error": message}, status=502)
+        if deepgram_key:
+            text, error = await _transcribe_deepgram(deepgram_key, audio, content_type)
+        else:
+            text, error = await _transcribe_openai(openai_key, audio, filename, content_type)
     except Exception:
         logger.exception("[TRANSCRIBE] request failed")
         return web.json_response({"error": "Transcription failed"}, status=502)
 
-    return web.json_response({"text": (payload.get("text") or "").strip()})
+    if error is not None:
+        return web.json_response({"error": error}, status=502)
+    return web.json_response({"text": text})
 
 
 def setup_transcribe_routes(app: web.Application):

--- a/api/transcribe_routes.py
+++ b/api/transcribe_routes.py
@@ -1,10 +1,16 @@
 """Speech-to-text route for composer dictation.
 
 The dashboard records audio with MediaRecorder (audio/mp4 on iOS Safari,
-audio/webm on Chrome) and posts the blob here; we forward it to OpenAI's
+audio/webm on Chrome) and posts the blob here; we forward it to a hosted
 transcription API and return plain text. Server-side so the API key stays
 private and quality beats on-device engines (Web Speech API is also broken
 in installed iOS PWAs, which is the primary dictation surface).
+
+Provider selection: Groq's Whisper Large v3 Turbo when GROQ_API_KEY is set
+(preferred - ~10x cheaper and faster), otherwise OpenAI's whisper-1. Both are
+pure speech-to-text Whisper models: unlike the previous gpt-4o-transcribe
+(a chat LLM), they cannot "answer" a spoken question instead of
+transcribing it.
 """
 import logging
 import os
@@ -18,10 +24,12 @@ from api.prompt_setting_defaults import get_default_prompt_setting
 
 logger = logging.getLogger(__name__)
 
+GROQ_TRANSCRIBE_URL = "https://api.groq.com/openai/v1/audio/transcriptions"
+GROQ_TRANSCRIBE_MODEL = "whisper-large-v3-turbo"
 OPENAI_TRANSCRIBE_URL = "https://api.openai.com/v1/audio/transcriptions"
-TRANSCRIBE_MODEL = "gpt-4o-transcribe"
+OPENAI_TRANSCRIBE_MODEL = "whisper-1"
 
-# OpenAI rejects >25MB; the client caps recordings at ~3 minutes anyway.
+# Both providers reject >25MB; the client caps recordings at ~3 minutes anyway.
 MAX_AUDIO_BYTES = 20 * 1024 * 1024
 # A tap-and-immediate-stop produces a few hundred bytes of container header —
 # not worth an API call.
@@ -43,10 +51,17 @@ async def handle_transcribe(request: web.Request) -> web.Response:
     if not get_user_email(request):
         return web.json_response({"error": "Not authenticated"}, status=401)
 
-    api_key = os.environ.get("OPENAI_API_KEY", "").strip()
-    if not api_key:
+    groq_key = os.environ.get("GROQ_API_KEY", "").strip()
+    openai_key = os.environ.get("OPENAI_API_KEY", "").strip()
+    if groq_key:
+        api_key, url, model, provider = (
+            groq_key, GROQ_TRANSCRIBE_URL, GROQ_TRANSCRIBE_MODEL, "Groq")
+    elif openai_key:
+        api_key, url, model, provider = (
+            openai_key, OPENAI_TRANSCRIBE_URL, OPENAI_TRANSCRIBE_MODEL, "OpenAI")
+    else:
         return web.json_response(
-            {"error": "Transcription is not configured (missing OPENAI_API_KEY)"},
+            {"error": "Transcription is not configured (set GROQ_API_KEY or OPENAI_API_KEY)"},
             status=503,
         )
 
@@ -71,7 +86,7 @@ async def handle_transcribe(request: web.Request) -> web.Response:
 
     form = aiohttp.FormData()
     form.add_field("file", audio, filename=filename, content_type=content_type)
-    form.add_field("model", TRANSCRIBE_MODEL)
+    form.add_field("model", model)
     vocab = _vocab_prompt()
     if vocab:
         form.add_field("prompt", vocab)
@@ -80,14 +95,14 @@ async def handle_transcribe(request: web.Request) -> web.Response:
         timeout = aiohttp.ClientTimeout(total=60)
         async with aiohttp.ClientSession(timeout=timeout) as session:
             async with session.post(
-                OPENAI_TRANSCRIBE_URL,
+                url,
                 data=form,
                 headers={"Authorization": f"Bearer {api_key}"},
             ) as resp:
                 payload = await resp.json(content_type=None)
                 if resp.status != 200:
                     message = (payload.get("error") or {}).get("message") or "Transcription failed"
-                    logger.error("[TRANSCRIBE] OpenAI %s: %s", resp.status, message)
+                    logger.error("[TRANSCRIBE] %s %s: %s", provider, resp.status, message)
                     return web.json_response({"error": message}, status=502)
     except Exception:
         logger.exception("[TRANSCRIBE] request failed")

--- a/dashboard/src/components/composer/DictationButton.tsx
+++ b/dashboard/src/components/composer/DictationButton.tsx
@@ -19,7 +19,7 @@ interface DictationButtonProps {
 }
 
 /** Mic toggle for composers: tap to record, tap again to stop + transcribe
- * (server-side, gpt-4o-transcribe). Hidden where MediaRecorder/getUserMedia
+ * (server-side, Deepgram Nova-3). Hidden where MediaRecorder/getUserMedia
  * are unavailable (e.g. plain HTTP). */
 export function DictationButton({ onText, disabled, className }: DictationButtonProps) {
   const { state, seconds, error, supported, toggle } = useDictation(onText);

--- a/dashboard/src/components/composer/DictationButton.tsx
+++ b/dashboard/src/components/composer/DictationButton.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useRef } from "react";
 import { RiLoader4Line, RiMicLine, RiStopFill } from "@remixicon/react";
 import { Button } from "@/components/ui/button";
 import { useDictation } from "@/hooks/useDictation";
@@ -22,17 +23,44 @@ interface DictationButtonProps {
  * are unavailable (e.g. plain HTTP). */
 export function DictationButton({ onText, disabled, className }: DictationButtonProps) {
   const { state, seconds, error, supported, toggle } = useDictation(onText);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    const handleShortcut = (event: KeyboardEvent) => {
+      if (
+        event.code !== "Space" ||
+        !event.altKey ||
+        event.ctrlKey ||
+        event.metaKey ||
+        event.shiftKey ||
+        disabled ||
+        state === "transcribing"
+      ) return;
+
+      const button = buttonRef.current;
+      const scope = button?.closest("form, [role=dialog]") ?? button?.parentElement?.parentElement?.parentElement;
+      if (!button || !scope?.contains(document.activeElement)) return;
+
+      event.preventDefault();
+      toggle();
+    };
+
+    window.addEventListener("keydown", handleShortcut);
+    return () => window.removeEventListener("keydown", handleShortcut);
+  }, [disabled, state, toggle]);
 
   if (!supported) return null;
 
   if (state === "recording") {
     return (
       <Button
+        ref={buttonRef}
         type="button"
         variant="ghost"
         size="sm"
         onClick={toggle}
-        title="Stop and transcribe"
+        title="Stop and transcribe (Option + Space)"
+        aria-keyshortcuts="Alt+Space"
         className={cn(
           "h-7 gap-1.5 rounded-lg px-2 text-red-600 hover:text-red-600 hover:bg-red-500/10",
           className,
@@ -52,12 +80,14 @@ export function DictationButton({ onText, disabled, className }: DictationButton
 
   return (
     <Button
+      ref={buttonRef}
       type="button"
       variant="ghost"
       size="icon-sm"
       onClick={toggle}
       disabled={disabled || state === "transcribing"}
-      title={error ?? "Dictate"}
+      title={error ?? "Dictate (Option + Space)"}
+      aria-keyshortcuts="Alt+Space"
       className={cn(
         error ? "text-destructive" : "text-muted-foreground hover:text-foreground",
         className,


### PR DESCRIPTION
## Summary
- Adds `Option + Space` as a focused-composer shortcut for dictation
- Uses the same shortcut to start recording and stop for transcription
- Ignores the shortcut while transcribing, when disabled, or outside the active composer
- Exposes `Alt+Space` through `aria-keyshortcuts` and updates button tooltips
- Switches server-side transcription from OpenAI `gpt-4o-transcribe` to **Deepgram Nova-3**, with OpenAI `whisper-1` as fallback when `DEEPGRAM_API_KEY` is not set

## Transcription provider change
- `api/transcribe_routes.py` now prefers `DEEPGRAM_API_KEY` (Deepgram `/v1/listen`, raw audio body) and falls back to `OPENAI_API_KEY` with `whisper-1` (multipart)
- Why Deepgram: purpose-built STT with sub-second latency, ~40% cheaper than `gpt-4o-transcribe` (~$0.0036/min vs $0.006/min), $200 starter credit. Groq was dropped because Developer tier upgrades are paused and free-tier rate limits are too tight for production
- Both providers are pure speech-to-text models — this also fixes the bug where `gpt-4o-transcribe` sometimes *answered* a spoken question instead of transcribing it
- The dictation vocabulary prompt setting keeps working with both providers: it maps to Deepgram `keyterm` prompting (Nova-3's equivalent of Whisper's `prompt` field, capped at 100 terms) and to the `prompt` field for whisper-1
- Deploy note: add `DEEPGRAM_API_KEY` via the admin env editor to enable Deepgram; existing deployments without it keep working via the OpenAI fallback

## Testing
- `npm run lint -- src/components/composer/DictationButton.tsx src/hooks/useDictation.ts`
- `npx tsc --noEmit`
- `npm run build`
- `python3 -m py_compile api/transcribe_routes.py` syntax + import check
- **Live Deepgram API test** with a real key and a spoken-question audio clip ("What is the capital of France?"):
  - Direct API call: transcript returned verbatim (`"What is the capital of France?"`, confidence 0.999, model `general-nova-3 2025-07-31.0`) — transcribed the question rather than answering it, confirming the hallucination bug fix
  - End-to-end through `_transcribe_deepgram()` with vocabulary keyterms (`Loma, Plotline, MCP, PR`): PASS
  - Error path with an invalid key: Deepgram 401 surfaced cleanly as `"Invalid credentials."` with a 502 to the client
- Local Playwright validation using the `run-loma-local` isolated stack:
  - focused composer receives `Option + Space`
  - recording state appears
  - rendered button exposes `aria-keyshortcuts="Alt+Space"`

### Idle state
![Idle dictation button](https://cdn.plotline.so/loma-images/loma-prs/option-space-dictation-idle.png)

### Recording after shortcut
![Recording state after Option + Space](https://cdn.plotline.so/loma-images/loma-prs/option-space-dictation-recording.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)