### PR TITLE
feat: open board tasks in a side drawer with per-task draft persistence

### DIFF
--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -38,6 +38,7 @@ import { MobileTaskBoard } from "@/components/tasks/MobileTaskBoard";
 import { QuickAddTask } from "@/components/tasks/QuickAddTask";
 import { TaskDialog } from "@/components/tasks/TaskDialog";
 import { AddChatDialog } from "@/components/tasks/AddChatDialog";
+import { TaskChatDrawer } from "@/components/tasks/TaskChatDrawer";
 import { BoardSettingsDialog } from "@/components/tasks/BoardSettingsDialog";
 import { InstallHint } from "@/components/tasks/InstallHint";
 import { useIsMobile } from "@/hooks/useIsMobile";
@@ -55,6 +56,10 @@ export default function TasksPage() {
   const [newTaskLane, setNewTaskLane] = useState<string | undefined>(undefined);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [addChatOpen, setAddChatOpen] = useState(false);
+  // Desktop: clicking a non-draft card opens its chat in a side drawer so the
+  // board keeps its tab. Task is kept on close for the exit animation.
+  const [chatTask, setChatTask] = useState<Task | null>(null);
+  const [chatDrawerOpen, setChatDrawerOpen] = useState(false);
   const [includedTagIds, setIncludedTagIds] = useState<string[]>([]);
   const [excludedTagIds, setExcludedTagIds] = useState<string[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
@@ -295,6 +300,7 @@ export default function TasksPage() {
               onRefresh={refresh}
               onEditDraft={(task) => { setEditingTask(task); setTaskDialogOpen(true); }}
               onAddTask={(laneId) => { setEditingTask(null); setNewTaskLane(laneId); setTaskDialogOpen(true); }}
+              onOpenChat={(task) => { setChatTask(task); setChatDrawerOpen(true); }}
               onError={setError}
               includedTagIds={includedTagIds}
               excludedTagIds={excludedTagIds}
@@ -335,6 +341,14 @@ export default function TasksPage() {
         onOpenChange={setSettingsOpen}
         laneCounts={laneCounts}
         onSaved={refresh}
+      />
+      <TaskChatDrawer
+        task={chatTask}
+        open={chatDrawerOpen}
+        onOpenChange={(open) => {
+          setChatDrawerOpen(open);
+          if (!open) refresh();
+        }}
       />
     </div>
   );

--- a/dashboard/src/components/ChatPanel.tsx
+++ b/dashboard/src/components/ChatPanel.tsx
@@ -544,6 +544,7 @@ export default function ChatPanel({
   autoSend,
   systemContext,
   initialStatus,
+  draftStorageKey,
   activeArtifactId,
   onArtifactOpen,
   onArtifactClose,
@@ -562,6 +563,9 @@ export default function ChatPanel({
   autoSend?: boolean;
   systemContext?: string;
   initialStatus?: string;
+  /** When set, unsent composer text is persisted to localStorage under this
+   * key and restored on mount — an accidental close never loses a draft. */
+  draftStorageKey?: string;
   /** Currently active artifact ID (for highlighting the active card) */
   activeArtifactId?: string | null;
   /** Callback when user clicks an artifact card */
@@ -663,6 +667,30 @@ export default function ChatPanel({
   useEffect(() => {
     inputRef.current?.focus();
   }, []);
+
+  // Restore an unsent draft (e.g. the task drawer was closed by mistake).
+  // Server-provided prompts (staged board drafts) win over the local draft.
+  useEffect(() => {
+    if (!draftStorageKey || initialPrompt) return;
+    try {
+      const saved = window.localStorage.getItem(draftStorageKey);
+      if (saved) setInput((prev) => prev || saved);
+    } catch {
+      // localStorage unavailable (private mode) — drafts just don't persist.
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [draftStorageKey]);
+
+  // Persist unsent composer text; sending (or clearing) removes the draft.
+  useEffect(() => {
+    if (!draftStorageKey) return;
+    try {
+      if (input.trim()) window.localStorage.setItem(draftStorageKey, input);
+      else window.localStorage.removeItem(draftStorageKey);
+    } catch {
+      // Ignore quota/private-mode failures.
+    }
+  }, [input, draftStorageKey]);
 
   useEffect(() => {
     if (!isStreaming) {

--- a/dashboard/src/components/ChatWithArtifacts.tsx
+++ b/dashboard/src/components/ChatWithArtifacts.tsx
@@ -82,6 +82,7 @@ export default function ChatWithArtifacts({
   systemContext,
   initialStatus,
   onConversationCreated,
+  draftStorageKey,
 }: {
   initialItems?: ChatItem[];
   initialArtifacts?: Artifact[];
@@ -93,6 +94,8 @@ export default function ChatWithArtifacts({
   systemContext?: string;
   initialStatus?: string;
   onConversationCreated?: (conversationId: string) => void;
+  /** localStorage key for persisting unsent composer text (see ChatPanel) */
+  draftStorageKey?: string;
 }) {
   // ── Artifact state ──────────────────────────────────────────────────────
   const [artifacts, setArtifacts] = useState<Artifact[]>(initialArtifacts || []);
@@ -160,6 +163,7 @@ export default function ChatWithArtifacts({
           autoSend={autoSend}
           systemContext={systemContext}
           initialStatus={initialStatus}
+          draftStorageKey={draftStorageKey}
           activeArtifactId={activeArtifactId}
           onArtifactOpen={handleArtifactOpen}
           onArtifactClose={handleArtifactClose}

--- a/dashboard/src/components/tasks/TaskBoard.tsx
+++ b/dashboard/src/components/tasks/TaskBoard.tsx
@@ -28,12 +28,14 @@ interface TaskBoardProps {
   onEditDraft: (task: Task) => void;
   /** Open the new-task dialog with a lane preselected. */
   onAddTask: (laneId: string) => void;
+  /** Open a non-draft task's chat in the side drawer instead of a new tab. */
+  onOpenChat?: (task: Task) => void;
   onError: (message: string | null) => void;
   includedTagIds: string[];
   excludedTagIds: string[];
 }
 
-export function TaskBoard({ board, onBoardChange, onRefresh, onEditDraft, onAddTask, onError, includedTagIds, excludedTagIds }: TaskBoardProps) {
+export function TaskBoard({ board, onBoardChange, onRefresh, onEditDraft, onAddTask, onOpenChat, onError, includedTagIds, excludedTagIds }: TaskBoardProps) {
   const [activeTask, setActiveTask] = useState<Task | null>(null);
   const { models } = useAgentModels();
 
@@ -46,7 +48,7 @@ export function TaskBoard({ board, onBoardChange, onRefresh, onEditDraft, onAddT
     laneIds, columns, tasksByColumn,
     startTask, markDone, reopen, moveToLane, reorderInColumn,
     removeFromBoard, deleteDraft, forkTask, openTask, setTaskModel, setTaskPriority, setTaskDeadline, setTaskTags, createAndAssignTag,
-  } = useTaskBoardActions({ board, onBoardChange, onRefresh, onEditDraft, onError, includedTagIds, excludedTagIds });
+  } = useTaskBoardActions({ board, onBoardChange, onRefresh, onEditDraft, onError, onOpenChat, includedTagIds, excludedTagIds });
 
   const resolveColumn = (overId: string): string | null => {
     if (tasksByColumn[overId] !== undefined) return overId;

--- a/dashboard/src/components/tasks/TaskChatDrawer.tsx
+++ b/dashboard/src/components/tasks/TaskChatDrawer.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { RiExternalLinkLine, RiLoader4Line } from "@remixicon/react";
+import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import ChatWithArtifacts from "@/components/ChatWithArtifacts";
+import { rebuildItemsFromConversation, type ChatItem } from "@/components/ChatPanel";
+import type { Artifact } from "@/components/ArtifactViewer";
+import { basePath, fetchConversation, type ChatFile, type Task } from "@/lib/api";
+
+/** Loads and renders one conversation inside the drawer. Keyed by
+ * conversation_id from the parent so switching tasks resets all state. */
+function DrawerConversation({ conversationId }: { conversationId: string }) {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [initialItems, setInitialItems] = useState<ChatItem[] | undefined>();
+  const [initialArtifacts, setInitialArtifacts] = useState<Artifact[] | undefined>();
+  const [initialStatus, setInitialStatus] = useState<string | undefined>();
+  const [draftPrompt, setDraftPrompt] = useState<string | null>(null);
+  const [draftFiles, setDraftFiles] = useState<ChatFile[] | null>(null);
+  const [model, setModel] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await fetchConversation(conversationId);
+        if (cancelled) return;
+        setModel(data.conversation.model || null);
+        if (data.conversation.task_status === "todo" && !data.conversation.status) {
+          // Unstarted board draft: nothing has been sent yet — put the staged
+          // prompt in the composer instead of rendering it as a sent message
+          // (mirrors /chat's handling).
+          setInitialItems([]);
+          setDraftPrompt(data.conversation.prompt);
+          setDraftFiles(data.conversation.draft_files || null);
+        } else {
+          const { items, artifacts } = rebuildItemsFromConversation(
+            data.conversation.messages,
+            data.conversation.prompt,
+            data.conversation.final_response,
+            data.turns,
+            data.artifacts,
+          );
+          setInitialItems(items);
+          setInitialArtifacts(artifacts);
+          setInitialStatus(data.conversation.status);
+        }
+      } catch (e) {
+        console.error("Failed to load conversation in task drawer:", e);
+        if (!cancelled) setError("Failed to load conversation");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [conversationId]);
+
+  if (loading) {
+    return (
+      <div className="flex flex-1 items-center justify-center bg-muted/30">
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <RiLoader4Line size={16} className="animate-spin text-brand-600" />
+          Loading conversation...
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-4">
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <ChatWithArtifacts
+        initialItems={initialItems}
+        initialArtifacts={initialArtifacts}
+        conversationId={conversationId}
+        initialPrompt={draftPrompt || undefined}
+        initialFiles={draftFiles || undefined}
+        initialModel={model || undefined}
+        initialStatus={initialStatus}
+        draftStorageKey={`loma-task-draft-${conversationId}`}
+      />
+    </div>
+  );
+}
+
+/** Right-side drawer that opens a board task's conversation in place, so the
+ * board never loses its tab. Unsent composer text is drafted to localStorage
+ * (per conversation) and restored if the drawer is reopened. */
+export function TaskChatDrawer({
+  task,
+  open,
+  onOpenChange,
+}: {
+  task: Task | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className="gap-0 p-0 data-[side=right]:w-full data-[side=right]:sm:max-w-[min(1100px,92vw)]"
+      >
+        <div className="flex flex-shrink-0 items-center gap-1 border-b border-border py-2.5 pl-4 pr-12">
+          <SheetTitle className="min-w-0 flex-1 truncate font-heading text-base font-semibold">
+            {task ? task.title || task.prompt : "Task"}
+          </SheetTitle>
+          {task && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="ghost" size="icon-sm" className="text-muted-foreground" asChild>
+                  <a
+                    href={`${basePath}/chat?continue=${task.conversation_id}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label="Open in full tab"
+                  >
+                    <RiExternalLinkLine size={16} />
+                  </a>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Open in full tab</TooltipContent>
+            </Tooltip>
+          )}
+        </div>
+        {task && (
+          <DrawerConversation
+            key={task.conversation_id}
+            conversationId={task.conversation_id}
+          />
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/dashboard/src/components/tasks/useTaskBoardActions.ts
+++ b/dashboard/src/components/tasks/useTaskBoardActions.ts
@@ -33,6 +33,9 @@ export interface TaskBoardActionsOptions {
   /** Desktop opens active cards in a new tab; the mobile/standalone PWA
    * navigates in place (window.open opens an in-app browser there). */
   openActiveInNewTab?: boolean;
+  /** When provided, non-draft tasks open through this callback (e.g. the
+   * desktop side drawer) instead of navigating away from the board. */
+  onOpenChat?: (task: Task) => void;
   includedTagIds?: string[];
   excludedTagIds?: string[];
 }
@@ -41,7 +44,7 @@ export interface TaskBoardActionsOptions {
  * desktop kanban (TaskBoard) and the mobile inbox (MobileTaskBoard). */
 export function useTaskBoardActions({
   board, onBoardChange, onRefresh, onEditDraft, onError,
-  openActiveInNewTab = true, includedTagIds = [], excludedTagIds = [],
+  openActiveInNewTab = true, onOpenChat, includedTagIds = [], excludedTagIds = [],
 }: TaskBoardActionsOptions) {
   const router = useRouter();
 
@@ -205,6 +208,11 @@ export function useTaskBoardActions({
     // (including chats parked in a lane) opens the conversation.
     if (task.task_status === "todo" && !task.status) {
       onEditDraft(task);
+      return;
+    }
+    // Side drawer keeps the board in place — no new tabs, no navigation.
+    if (onOpenChat) {
+      onOpenChat(task);
       return;
     }
     const url = `${basePath}/chat?continue=${task.conversation_id}`;


### PR DESCRIPTION
## Summary
- Clicking a non-draft task card on the desktop board now opens its chat in a **right-side drawer** on the same tab, instead of `window.open`-ing a new browser tab.
- The board stays put behind the drawer — close it and click another card to keep navigating without piling up tabs.
- Anything typed in the drawer's composer is **persisted as a draft** (localStorage, per conversation) and restored if the drawer is closed by mistake and reopened. Sending or clearing the text removes the draft. Drafts are per-task and don't leak between conversations.
- A header button still lets you pop the chat out into a full tab when needed.
- Mobile/PWA navigation is unchanged. Unstarted drafts still open the task editor dialog.

## Changes
- `dashboard/src/components/tasks/TaskChatDrawer.tsx` — new right-side `Sheet` drawer that loads a conversation (same rebuild path as `/chat`) and renders `ChatWithArtifacts`; header has the task title + "Open in full tab".
- `dashboard/src/components/tasks/useTaskBoardActions.ts` — new optional `onOpenChat` callback; when provided, non-draft tasks open through it instead of new-tab/in-place navigation.
- `dashboard/src/components/tasks/TaskBoard.tsx` — threads `onOpenChat` through to the hook.
- `dashboard/src/app/tasks/page.tsx` — holds drawer state, passes `onOpenChat` (desktop board only), renders `TaskChatDrawer`, refreshes the board on drawer close.
- `dashboard/src/components/ChatWithArtifacts.tsx` / `ChatPanel.tsx` — new optional `draftStorageKey` prop: composer text is saved to localStorage on change and restored on mount (server-staged prompts win over local drafts).

## Testing (local stack, Playwright)
Booted the full stack locally (isolated throwaway DB), logged in, seeded two needs-input tasks, and drove the flow end-to-end. All assertions passed:
- drawer opens in the same tab (verified only 1 page open in the browser context)
- typing a draft, closing, opening a *different* task → no draft leakage between tasks
- reopening the first task → draft restored exactly

**1. Board**
![board](https://cdn.plotline.so/loma-images/loma-pr/task-drawer/1-board.png)

**2. Click a task → chat opens in the side drawer (same tab)**
![drawer open](https://cdn.plotline.so/loma-images/loma-pr/task-drawer/2-open.png)

**3. Draft typed in the drawer composer**
![draft typed](https://cdn.plotline.so/loma-images/loma-pr/task-drawer/3-typed.png)

**4. Close → open another task (navigation stays in the drawer)**
![second task](https://cdn.plotline.so/loma-images/loma-pr/task-drawer/4-second-task.png)

**5. Reopen the first task → unsent draft restored**
![draft restored](https://cdn.plotline.so/loma-images/loma-pr/task-drawer/5-draft-restored.png)

Also verified: `tsc --noEmit` clean; `npm run lint` identical to main's baseline (no new issues).

## Notes
- This PR was generated by the Plotline IE Bot based on the request above
- Please review carefully before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)