### PR TITLE
feat: create new tasks in the side drawer

### DIFF
--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -148,6 +148,29 @@ export default function TasksPage() {
     }
   };
 
+  const openNewTaskDrawer = async () => {
+    if (!board || busyRef.current) return;
+    busyRef.current = true;
+    setError(null);
+    try {
+      const todoLane = board.lanes.find(
+        (lane) => lane.id === "todo" || lane.name.trim().toLowerCase() === "todo",
+      ) || board.lanes[0];
+      const { task } = await createTask({
+        title: "New task",
+        prompt: "",
+        lane: todoLane?.id || "todo",
+      });
+      setBoard({ ...board, tasks: [task, ...board.tasks] });
+      setChatTask(task);
+      setChatDrawerOpen(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not create task");
+    } finally {
+      busyRef.current = false;
+    }
+  };
+
   const laneCounts: Record<string, number> = {};
   if (board) {
     for (const lane of board.lanes) laneCounts[lane.id] = board.counts[lane.id] ?? 0;
@@ -201,7 +224,7 @@ export default function TasksPage() {
               </DropdownMenuContent>
             </DropdownMenu>
           )}
-          <Button size="sm" onClick={() => { setEditingTask(null); setNewTaskLane(undefined); setTaskDialogOpen(true); }}>
+          <Button size="sm" onClick={() => void openNewTaskDrawer()}>
             <RiAddLine className="h-4 w-4" />
             New task
           </Button>
@@ -298,8 +321,8 @@ export default function TasksPage() {
               board={board}
               onBoardChange={setBoard}
               onRefresh={refresh}
-              onEditDraft={(task) => { setEditingTask(task); setTaskDialogOpen(true); }}
-              onAddTask={(laneId) => { setEditingTask(null); setNewTaskLane(laneId); setTaskDialogOpen(true); }}
+              onEditDraft={(task) => { setChatTask(task); setChatDrawerOpen(true); }}
+              onAddTask={() => void openNewTaskDrawer()}
               onOpenChat={(task) => { setChatTask(task); setChatDrawerOpen(true); }}
               onError={setError}
               includedTagIds={includedTagIds}
@@ -348,6 +371,15 @@ export default function TasksPage() {
         onOpenChange={(open) => {
           setChatDrawerOpen(open);
           if (!open) refresh();
+        }}
+        onTaskChange={(updatedTask) => {
+          setChatTask(updatedTask);
+          setBoard((current) => current ? {
+            ...current,
+            tasks: current.tasks.map((task) =>
+              task.conversation_id === updatedTask.conversation_id ? updatedTask : task,
+            ),
+          } : current);
         }}
       />
     </div>

--- a/dashboard/src/components/ChatPanel.tsx
+++ b/dashboard/src/components/ChatPanel.tsx
@@ -692,6 +692,19 @@ export default function ChatPanel({
     }
   }, [input, draftStorageKey]);
 
+  // Write through during typing as well as in the effect above. This keeps a
+  // draft safe even when the drawer is closed immediately after the last key.
+  const updateComposerInput = (value: string) => {
+    setInput(value);
+    if (!draftStorageKey) return;
+    try {
+      if (value.trim()) window.localStorage.setItem(draftStorageKey, value);
+      else window.localStorage.removeItem(draftStorageKey);
+    } catch {
+      // Ignore quota/private-mode failures.
+    }
+  };
+
   useEffect(() => {
     if (!isStreaming) {
       setItems((prev) => removeTransientStatusItems(prev));
@@ -1344,7 +1357,7 @@ export default function ChatPanel({
                 <Textarea
                   ref={inputRef}
                   value={input}
-                  onChange={(e) => setInput(e.target.value)}
+                  onChange={(e) => updateComposerInput(e.target.value)}
                   onKeyDown={handleKeyDown}
                   onPaste={handlePaste}
                   onFocus={() => {
@@ -1659,7 +1672,7 @@ export default function ChatPanel({
                 <Textarea
                   ref={inputRef}
                   value={input}
-                  onChange={(e) => setInput(e.target.value)}
+                  onChange={(e) => updateComposerInput(e.target.value)}
                   onKeyDown={handleKeyDown}
                   onPaste={handlePaste}
                   onFocus={() => {

--- a/dashboard/src/components/tasks/TaskBoard.tsx
+++ b/dashboard/src/components/tasks/TaskBoard.tsx
@@ -26,7 +26,7 @@ interface TaskBoardProps {
   onBoardChange: (board: TasksBoardResponse) => void;
   onRefresh: () => void;
   onEditDraft: (task: Task) => void;
-  /** Open the new-task dialog with a lane preselected. */
+  /** Create a new task and open it in the side drawer. */
   onAddTask: (laneId: string) => void;
   /** Open a non-draft task's chat in the side drawer instead of a new tab. */
   onOpenChat?: (task: Task) => void;

--- a/dashboard/src/components/tasks/TaskChatDrawer.tsx
+++ b/dashboard/src/components/tasks/TaskChatDrawer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { RiExternalLinkLine, RiLoader4Line } from "@remixicon/react";
+import { RiExternalLinkLine, RiLoader4Line, RiPencilLine } from "@remixicon/react";
 import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -9,7 +9,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import ChatWithArtifacts from "@/components/ChatWithArtifacts";
 import { rebuildItemsFromConversation, type ChatItem } from "@/components/ChatPanel";
 import type { Artifact } from "@/components/ArtifactViewer";
-import { basePath, fetchConversation, type ChatFile, type Task } from "@/lib/api";
+import { basePath, fetchConversation, updateTask, type ChatFile, type Task } from "@/lib/api";
 
 /** Loads and renders one conversation inside the drawer. Keyed by
  * conversation_id from the parent so switching tasks resets all state. */
@@ -105,10 +105,12 @@ export function TaskChatDrawer({
   task,
   open,
   onOpenChange,
+  onTaskChange,
 }: {
   task: Task | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  onTaskChange?: (task: Task) => void;
 }) {
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
@@ -117,9 +119,13 @@ export function TaskChatDrawer({
         className="gap-0 p-0 data-[side=right]:w-full data-[side=right]:sm:max-w-[min(1100px,92vw)]"
       >
         <div className="flex flex-shrink-0 items-center gap-1 border-b border-border py-2.5 pl-4 pr-12">
-          <SheetTitle className="min-w-0 flex-1 truncate font-heading text-base font-semibold">
-            {task ? task.title || task.prompt : "Task"}
-          </SheetTitle>
+          {task && (
+            <EditableTaskTitle
+              key={`${task.conversation_id}:${task.title || task.prompt}`}
+              task={task}
+              onTaskChange={onTaskChange}
+            />
+          )}
           {task && (
             <Tooltip>
               <TooltipTrigger asChild>
@@ -146,5 +152,62 @@ export function TaskChatDrawer({
         )}
       </SheetContent>
     </Sheet>
+  );
+}
+
+function EditableTaskTitle({ task, onTaskChange }: { task: Task; onTaskChange?: (task: Task) => void }) {
+  const [editingTitle, setEditingTitle] = useState(false);
+  const [title, setTitle] = useState(task.title || task.prompt || "New task");
+
+  const saveTitle = async () => {
+    if (!task) return;
+    const nextTitle = title.trim() || "New task";
+    setTitle(nextTitle);
+    setEditingTitle(false);
+    if (nextTitle === task.title) return;
+    try {
+      const { task: updatedTask } = await updateTask(task.conversation_id, { title: nextTitle });
+      onTaskChange?.(updatedTask || { ...task, title: nextTitle });
+    } catch {
+      setTitle(task.title || task.prompt || "New task");
+    }
+  };
+
+  return (
+    <div className="min-w-0 flex-1">
+            {editingTitle ? (
+              <input
+                value={title}
+                onChange={(event) => setTitle(event.target.value)}
+                onBlur={() => void saveTitle()}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") void saveTitle();
+                  if (event.key === "Escape") {
+                    setTitle(task?.title || task?.prompt || "New task");
+                    setEditingTitle(false);
+                  }
+                }}
+                aria-label="Task title"
+                maxLength={200}
+                autoFocus
+                className="h-8 w-full max-w-md rounded-md border border-input bg-background px-2 font-heading text-base font-semibold outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              />
+            ) : (
+              <div className="flex min-w-0 items-center gap-1">
+                <SheetTitle
+                  className="min-w-0 truncate font-heading text-base font-semibold"
+                  onClick={() => setEditingTitle(true)}
+                  title="Click to rename"
+                >
+                  {task ? task.title || task.prompt || "New task" : "Task"}
+                </SheetTitle>
+                {task && (
+                  <Button variant="ghost" size="icon-xs" className="shrink-0 text-muted-foreground" onClick={() => setEditingTitle(true)} aria-label="Rename task">
+                    <RiPencilLine size={14} />
+                  </Button>
+                )}
+              </div>
+            )}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- open both desktop new-task entry points directly in the right-side drawer
- create new tasks with the default title `New task` in the To Do lane
- allow inline task-title editing in the drawer
- persist composer text immediately so closing right after typing still keeps the draft

## Testing
- `tsc --noEmit` passed
- targeted ESLint passed with no errors (8 pre-existing warnings in `ChatPanel.tsx`)
- local end-to-end browser test passed: create task, verify To Do placement, rename title, type details, close, reopen, and verify draft restoration

## Screenshots

### New task opens in the drawer
![New task drawer](https://cdn.plotline.so/loma-images/loma-pr-new-task-drawer/open.png)

### Title edited inline
![Edited title](https://cdn.plotline.so/loma-images/loma-pr-new-task-drawer/title-edited.png)

### Draft restored after closing and reopening
![Restored draft](https://cdn.plotline.so/loma-images/loma-pr-new-task-drawer/draft-restored.png)

## Context
Follow-up to #116. PR #116 was already merged, so this change is based on the latest `main`.
