### PR TITLE
feat: Ashby ATS integration (read-only) with compensation-leak guardrails

### DIFF
--- a/seed/skills/ashby/SKILL.md
+++ b/seed/skills/ashby/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: ashby
+description: Ashby ATS — jobs, candidates, applications, interview stages, and application form data (read-only) — use when asked about hiring pipelines, open roles, candidates, reviewing/shortlisting applications for a job, resumes, or interview feedback in Ashby.
+user-invocable: false
+---
+
+# Ashby — Jobs, Candidates & Applications (Read-Only)
+
+Query the Ashby ATS for jobs, candidates, applications, interview stages, form
+submissions, feedback, and resume download URLs. Use for hiring-pipeline
+questions and for exporting applications for AI-assisted review.
+
+## Available Commands
+
+This is a **CLI tool** — invoke via Bash. Do NOT look for MCP tools.
+Requires the `ASHBY_API_KEY` environment variable (read-only Ashby key).
+
+### `check-auth` — Verify the key and endpoint access
+
+```bash
+python3 tools/ashby.py check-auth
+```
+
+### `list-jobs` — All jobs
+
+```bash
+python3 tools/ashby.py list-jobs
+python3 tools/ashby.py list-jobs --status Open
+```
+
+Returns id, title, status, department/location IDs. Note: multiple jobs can
+share a title (e.g. re-opened roles) — disambiguate by `status` and `createdAt`.
+
+### `get-job` — Job details
+
+```bash
+python3 tools/ashby.py get-job 463d3765-d0db-4657-b312-92ae87e88128
+```
+
+### `list-stages` — Interview stages for a job
+
+```bash
+python3 tools/ashby.py list-stages --job-id JOB_ID
+```
+
+### `list-candidates` / `get-candidate`
+
+```bash
+python3 tools/ashby.py list-candidates --limit 100
+python3 tools/ashby.py get-candidate CANDIDATE_ID
+```
+
+`get-candidate` includes a short-lived `resumeUrl` for downloading the resume.
+
+### `list-applications` — All applications for a job (auto-paginates)
+
+```bash
+python3 tools/ashby.py list-applications --job-id JOB_ID
+python3 tools/ashby.py list-applications --job-id JOB_ID --status Active
+python3 tools/ashby.py list-applications --job-id JOB_ID --status Archived
+```
+
+Returns a `by_stage` breakdown plus one row per application (candidate, stage,
+source, archive reason).
+
+### `get-application` / `export-application`
+
+```bash
+python3 tools/ashby.py get-application APPLICATION_ID
+python3 tools/ashby.py export-application APPLICATION_ID
+```
+
+`export-application` aggregates application + candidate profile + resume URL +
+interview feedback into one JSON blob — the right input for AI review.
+
+### `export-job-applications` — Bulk export for AI review
+
+```bash
+python3 tools/ashby.py export-job-applications --job-id JOB_ID --status Active --limit 50
+```
+
+Exports up to `--limit` (default 200) full application records for a job. For
+large jobs, prefer reviewing in batches of 25-50 to keep context manageable.
+
+## AI Review Workflow (shortlisting)
+
+1. `list-jobs --status Open` → find the job ID.
+2. `list-applications --job-id ID --status Active` → see pipeline counts.
+3. `export-job-applications --job-id ID --status Active --limit 50` → full data.
+4. Review resumes/answers against the role criteria, produce a shortlist with
+   evidence per candidate.
+5. Present the shortlist to the user for approval. **Loma never moves, rejects,
+   or contacts candidates** — this integration is read-only; the human acts in
+   the Ashby dashboard.
+
+## Security Guardrails (do not work around these)
+
+- **Read-only**: no write endpoints exist in the tool. Do not attempt stage
+  moves, archiving, notes, or offers via this tool or raw curl.
+- **Compensation is always redacted**: job compensation, salary/CTC/equity
+  fields, and comp-related form answers come back as
+  `[REDACTED:compensation-data-blocked-by-loma]`. Never attempt to bypass this
+  via raw curl with the same key, and never echo redacted markers' surrounding
+  context as if it were comp data.
+- **Offer endpoints are blocked** locally by an allowlist AND the API key
+  should not have `offersRead`/`offersWrite`. If a user needs offer data, tell
+  them it requires a separate restricted HR key and explicit setup.
+- Candidate PII (emails, phones, resumes) is sensitive: share only what the
+  requesting user needs, and never post it to public channels.

--- a/tests/test_ashby_tool.py
+++ b/tests/test_ashby_tool.py
@@ -1,0 +1,152 @@
+"""Tests for tools/ashby.py — focused on the compensation-leak guardrails.
+
+These tests run fully offline (no Ashby API calls).
+"""
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tools.ashby import (  # noqa: E402
+    ENDPOINT_ALLOWLIST,
+    EXPAND_ALLOWLIST,
+    REDACTED,
+    AshbyToolError,
+    _post,
+    _sanitize_expand,
+    redact_sensitive,
+)
+
+
+# ---------------------------------------------------------------------------
+# Endpoint allowlist — offer/write endpoints must be locally blocked
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "offer.list",
+        "offer.info",
+        "offer.create",
+        "offer.start",
+        "apiKey.info",
+        "application.changeStage",
+        "application.update",
+        "candidate.update",
+        "candidate.create",
+        "job.create",
+        "job.update",
+        "job.setStatus",
+    ],
+)
+def test_blocked_endpoints_raise_locally(endpoint):
+    """Blocked endpoints raise before any network request is made."""
+    with pytest.raises(AshbyToolError, match="not allowed"):
+        asyncio.run(_post(endpoint, {}))
+
+
+def test_no_offer_or_write_endpoints_in_allowlist():
+    for endpoint in ENDPOINT_ALLOWLIST:
+        assert not endpoint.startswith("offer."), f"offer endpoint in allowlist: {endpoint}"
+        for verb in ("create", "update", "delete", "change", "set", "add", "upload", "move"):
+            assert verb not in endpoint.lower(), f"write endpoint in allowlist: {endpoint}"
+
+
+# ---------------------------------------------------------------------------
+# Expand sanitization — the compensation expansion can never be requested
+# ---------------------------------------------------------------------------
+
+def test_compensation_expand_is_stripped():
+    assert _sanitize_expand(["compensation"]) == []
+    assert _sanitize_expand(["compensation", "openings"]) == ["openings"]
+    assert "compensation" not in EXPAND_ALLOWLIST
+
+
+# ---------------------------------------------------------------------------
+# Response redaction — comp keys are scrubbed recursively
+# ---------------------------------------------------------------------------
+
+def test_redacts_compensation_key_at_any_depth():
+    payload = {
+        "results": {
+            "id": "job-1",
+            "title": "Technical Support Engineer",
+            "compensation": {
+                "compensationTiers": [{"title": "Tier A", "components": [{"summary": "INR 2,000,000"}]}],
+            },
+            "nested": [{"salaryRange": {"min": 100, "max": 200}}],
+        }
+    }
+    redacted = redact_sensitive(payload)
+    assert redacted["results"]["compensation"] == REDACTED
+    assert redacted["results"]["nested"][0]["salaryRange"] == REDACTED
+    # Non-sensitive fields survive untouched
+    assert redacted["results"]["title"] == "Technical Support Engineer"
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "compensation",
+        "compensationTierId",
+        "salary",
+        "expectedSalary",
+        "equityGrant",
+        "bonusAmount",
+        "payRate",
+        "pay_rate",
+        "remuneration",
+    ],
+)
+def test_sensitive_key_variants_are_redacted(key):
+    assert redact_sensitive({key: "secret"})[key] == REDACTED
+
+
+def test_redacts_form_answers_with_compensation_titles():
+    """Application form / survey answers about salary get their values scrubbed."""
+    payload = {
+        "results": [
+            {"title": "Expected CTC", "path": "expected_ctc", "value": "35 LPA"},
+            {"title": "What is your current salary?", "value": "28 LPA"},
+            {"title": "Years of experience", "value": "5"},
+        ]
+    }
+    redacted = redact_sensitive(payload)
+    assert redacted["results"][0]["value"] == REDACTED
+    assert redacted["results"][1]["value"] == REDACTED
+    assert redacted["results"][2]["value"] == "5"
+
+
+def test_no_comp_values_survive_serialization():
+    """End-to-end style check: known comp numbers never appear in redacted output."""
+    payload = {
+        "results": {
+            "compensation": {"compensationTiers": [{"summary": "$180,000 - $220,000"}]},
+            "customFields": [{"title": "Salary expectation", "value": "45 LPA"}],
+            "candidate": {"name": "Jane Doe"},
+        }
+    }
+    out = json.dumps(redact_sensitive(payload))
+    assert "180,000" not in out
+    assert "45 LPA" not in out
+    assert "Jane Doe" in out
+
+
+def test_redaction_preserves_non_dict_types():
+    assert redact_sensitive([1, "a", None]) == [1, "a", None]
+    assert redact_sensitive("plain") == "plain"
+
+
+# ---------------------------------------------------------------------------
+# Missing API key
+# ---------------------------------------------------------------------------
+
+def test_missing_api_key_raises(monkeypatch):
+    monkeypatch.delenv("ASHBY_API_KEY", raising=False)
+    with pytest.raises(AshbyToolError, match="ASHBY_API_KEY"):
+        asyncio.run(_post("job.list", {}))

--- a/tools/ashby.py
+++ b/tools/ashby.py
@@ -1,0 +1,508 @@
+"""Ashby ATS — jobs, candidates, applications, and form data (READ-ONLY).
+
+Provides CLI commands for the Loma agent:
+  1. ashby.py check-auth                        — Verify API key and endpoint access
+  2. ashby.py list-jobs [--status Open]         — List jobs (id, title, status)
+  3. ashby.py get-job JOB_ID                    — Job details (compensation always redacted)
+  4. ashby.py list-stages --job-id JOB_ID       — Interview stages for a job's interview plan
+  5. ashby.py list-candidates [--limit N]       — List candidates
+  6. ashby.py get-candidate CANDIDATE_ID        — Candidate profile + resume download URL
+  7. ashby.py list-applications --job-id ID [--status Active|Archived]
+                                                — All applications for a job (auto-paginates)
+  8. ashby.py get-application APPLICATION_ID    — Full application detail
+  9. ashby.py export-application APPLICATION_ID — Aggregated export (application + candidate
+                                                  + resume URL + feedback) for AI review
+ 10. ashby.py export-job-applications --job-id ID [--status Active] [--limit N]
+                                                — Bulk export of a job's applications
+
+Requires ASHBY_API_KEY environment variable.
+API docs: https://developers.ashbyhq.com
+Auth: HTTP Basic — API key as username, blank password.
+
+SECURITY — compensation / offer data must never leak through this tool:
+  * READ-ONLY: no write/update/delete endpoints are implemented.
+  * Endpoint allowlist: only the endpoints listed in ENDPOINT_ALLOWLIST can be
+    called. offer.*, apiKey.*, and every other endpoint are rejected locally,
+    even if the configured API key has permission for them.
+  * No `expand` passthrough: job.info is always called WITHOUT the
+    `compensation` expansion, and any `expand` values are filtered against
+    EXPAND_ALLOWLIST before the request is sent.
+  * Response redaction: every API response is recursively scrubbed —
+    keys matching SENSITIVE_KEY_PATTERNS (compensation, salary, equity,
+    bonus, CTC, pay, offer amounts...) are replaced with "[REDACTED]".
+    Form/survey answers whose field titles look compensation-related are
+    redacted the same way.
+  * The Ashby API key used with this tool should additionally NOT have the
+    `offersRead` / `offersWrite` permissions, so offer data is blocked at the
+    key level too (defense in depth).
+
+Usage (called by the agent via Bash):
+  python3 tools/ashby.py list-jobs --status Open
+  python3 tools/ashby.py list-applications --job-id 463d3765-... --status Active
+  python3 tools/ashby.py export-application 1f3a6f32-...
+"""
+
+import asyncio
+import base64
+import json
+import os
+import re
+import sys
+from typing import Any
+
+import aiohttp
+
+ASHBY_BASE_URL = "https://api.ashbyhq.com"
+
+# Only these endpoints may ever be called. Everything else (offer.*, apiKey.*,
+# any write endpoint) is rejected before a request is made.
+ENDPOINT_ALLOWLIST = {
+    "job.list",
+    "job.info",
+    "interviewPlan.list",
+    "interviewStage.list",
+    "candidate.list",
+    "candidate.info",
+    "application.list",
+    "application.info",
+    "applicationFeedback.list",
+    "file.info",
+    "archiveReason.list",
+    "source.list",
+}
+
+# `expand` values that are safe to forward. "compensation" is deliberately
+# absent and can never be requested through this tool.
+EXPAND_ALLOWLIST: set[str] = {"openings"}
+
+# Any dict key matching one of these patterns is redacted from every response.
+SENSITIVE_KEY_PATTERNS = [
+    r"compensation",
+    r"salary",
+    r"equity",
+    r"bonus",
+    r"\bctc\b",
+    r"payrate",
+    r"pay_rate",
+    r"remuneration",
+    r"offeramount",
+    r"offer_amount",
+]
+
+# Form-field titles (application questions, survey questions, custom fields)
+# matching these patterns get their VALUES redacted.
+SENSITIVE_TITLE_PATTERNS = [
+    r"compensation",
+    r"salary",
+    r"\bctc\b",
+    r"equity",
+    r"\bpay\b",
+    r"remuneration",
+]
+
+_SENSITIVE_KEY_RE = re.compile("|".join(SENSITIVE_KEY_PATTERNS), re.IGNORECASE)
+_SENSITIVE_TITLE_RE = re.compile("|".join(SENSITIVE_TITLE_PATTERNS), re.IGNORECASE)
+
+REDACTED = "[REDACTED:compensation-data-blocked-by-loma]"
+
+
+class AshbyToolError(Exception):
+    pass
+
+
+def _get_api_key() -> str:
+    key = os.environ.get("ASHBY_API_KEY", "")
+    if not key:
+        raise AshbyToolError(
+            "ASHBY_API_KEY environment variable is not set. "
+            "Configure a READ-ONLY Ashby API key (without offersRead/offersWrite) before using this tool."
+        )
+    return key
+
+
+def redact_sensitive(obj: Any) -> Any:
+    """Recursively scrub compensation-related data from any API response.
+
+    - Dict keys matching SENSITIVE_KEY_PATTERNS -> value replaced with REDACTED.
+    - Dicts whose title/path/label looks compensation-related get their
+      answer/value fields redacted (covers form submissions and custom fields).
+    """
+    if isinstance(obj, list):
+        return [redact_sensitive(item) for item in obj]
+    if not isinstance(obj, dict):
+        return obj
+
+    title_is_sensitive = any(
+        isinstance(obj.get(k), str) and _SENSITIVE_TITLE_RE.search(obj[k])
+        for k in ("title", "humanReadablePath", "path", "label", "name")
+    )
+    result: dict[str, Any] = {}
+    for key, value in obj.items():
+        if _SENSITIVE_KEY_RE.search(key):
+            result[key] = REDACTED
+        elif title_is_sensitive and key in ("value", "answer", "answers", "selectedValues", "response"):
+            result[key] = REDACTED
+        else:
+            result[key] = redact_sensitive(value)
+    return result
+
+
+def _sanitize_expand(expand: list[str] | None) -> list[str]:
+    if not expand:
+        return []
+    return [e for e in expand if e in EXPAND_ALLOWLIST]
+
+
+async def _post(endpoint: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Call an allowlisted Ashby endpoint and return the redacted JSON response."""
+    if endpoint not in ENDPOINT_ALLOWLIST:
+        raise AshbyToolError(
+            f"Endpoint '{endpoint}' is not allowed by tools/ashby.py. "
+            f"This tool is read-only and blocks offer/compensation endpoints. "
+            f"Allowed: {sorted(ENDPOINT_ALLOWLIST)}"
+        )
+    payload = dict(payload or {})
+    if "expand" in payload:
+        payload["expand"] = _sanitize_expand(payload.get("expand"))
+        if not payload["expand"]:
+            del payload["expand"]
+
+    basic = base64.b64encode(f"{_get_api_key()}:".encode()).decode()
+    async with aiohttp.ClientSession() as session:
+        async with session.post(
+            f"{ASHBY_BASE_URL}/{endpoint}",
+            json=payload,
+            headers={
+                "Authorization": f"Basic {basic}",
+                "Content-Type": "application/json",
+                "Accept": "application/json; version=1",
+            },
+            timeout=aiohttp.ClientTimeout(total=60),
+        ) as resp:
+            if resp.status == 429:
+                raise AshbyToolError("Ashby rate limit reached. Retry shortly.")
+            if resp.status == 401:
+                raise AshbyToolError("Ashby API key is invalid or revoked.")
+            data = await resp.json(content_type=None)
+
+    if not data.get("success", False):
+        errors = data.get("errors") or [data.get("errorInfo", {}).get("code", "unknown_error")]
+        if "missing_endpoint_permission" in errors:
+            raise AshbyToolError(
+                f"The configured Ashby API key does not have permission for '{endpoint}'."
+            )
+        raise AshbyToolError(f"Ashby API error on '{endpoint}': {errors}")
+
+    return redact_sensitive(data)
+
+
+async def _paginate(endpoint: str, payload: dict[str, Any], max_pages: int = 50) -> list[dict[str, Any]]:
+    """Fetch all pages of a list endpoint (cursor-based)."""
+    results: list[dict[str, Any]] = []
+    cursor: str | None = None
+    for _ in range(max_pages):
+        body = dict(payload)
+        if cursor:
+            body["cursor"] = cursor
+        data = await _post(endpoint, body)
+        results.extend(data.get("results", []))
+        if not data.get("moreDataAvailable"):
+            break
+        cursor = data.get("nextCursor")
+        if not cursor:
+            break
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+async def check_auth() -> dict[str, Any]:
+    """Probe which allowlisted endpoints the configured key can access."""
+    access: dict[str, str] = {}
+    probes = {
+        "job.list": {"limit": 1},
+        "candidate.list": {"limit": 1},
+        "application.list": {"limit": 1},
+        "applicationFeedback.list": {"limit": 1},
+    }
+    for endpoint, payload in probes.items():
+        try:
+            await _post(endpoint, payload)
+            access[endpoint] = "ok"
+        except AshbyToolError as e:
+            access[endpoint] = str(e)
+    return {
+        "base_url": ASHBY_BASE_URL,
+        "endpoint_access": access,
+        "note": "Offer endpoints (offer.list/offer.info) are blocked by this tool regardless of key permissions. Compensation fields are always redacted.",
+    }
+
+
+def _format_job(job: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": job.get("id"),
+        "title": job.get("title"),
+        "status": job.get("status"),
+        "confidential": job.get("confidential"),
+        "employmentType": job.get("employmentType"),
+        "locationId": job.get("locationId"),
+        "departmentId": job.get("departmentId"),
+        "createdAt": job.get("createdAt"),
+        "openedAt": job.get("openedAt"),
+        "closedAt": job.get("closedAt"),
+    }
+
+
+async def list_jobs(status: str | None = None) -> dict[str, Any]:
+    jobs = await _paginate("job.list", {})
+    if status:
+        jobs = [j for j in jobs if (j.get("status") or "").lower() == status.lower()]
+    return {"count": len(jobs), "jobs": [_format_job(j) for j in jobs]}
+
+
+async def get_job(job_id: str) -> dict[str, Any]:
+    data = await _post("job.info", {"id": job_id})
+    return data.get("results", {})
+
+
+async def list_stages(job_id: str) -> dict[str, Any]:
+    job = await get_job(job_id)
+    plan_ids = job.get("interviewPlanIds") or []
+    stages: list[dict[str, Any]] = []
+    for plan_id in plan_ids:
+        data = await _post("interviewStage.list", {"interviewPlanId": plan_id})
+        for s in data.get("results", []):
+            stages.append({
+                "id": s.get("id"),
+                "title": s.get("title"),
+                "type": s.get("type"),
+                "orderInInterviewPlan": s.get("orderInInterviewPlan"),
+                "interviewPlanId": plan_id,
+            })
+    return {"jobId": job_id, "jobTitle": job.get("title"), "count": len(stages), "stages": stages}
+
+
+def _format_candidate(c: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": c.get("id"),
+        "name": c.get("name"),
+        "primaryEmail": (c.get("primaryEmailAddress") or {}).get("value"),
+        "phoneNumbers": [p.get("value") for p in (c.get("phoneNumbers") or [])],
+        "socialLinks": c.get("socialLinks"),
+        "position": c.get("position"),
+        "company": c.get("company"),
+        "school": c.get("school"),
+        "applicationIds": c.get("applicationIds"),
+        "tags": [t.get("title") for t in (c.get("tags") or []) if isinstance(t, dict)],
+        "createdAt": c.get("createdAt"),
+    }
+
+
+async def list_candidates(limit: int = 100) -> dict[str, Any]:
+    max_pages = max(1, (limit + 99) // 100)
+    candidates = await _paginate("candidate.list", {"limit": min(limit, 100)}, max_pages=max_pages)
+    candidates = candidates[:limit]
+    return {"count": len(candidates), "candidates": [_format_candidate(c) for c in candidates]}
+
+
+async def _resolve_file_url(file_handle: dict[str, Any] | None) -> str | None:
+    if not file_handle or not file_handle.get("handle"):
+        return None
+    try:
+        data = await _post("file.info", {"fileHandle": file_handle["handle"]})
+        return (data.get("results") or {}).get("url")
+    except AshbyToolError:
+        return None
+
+
+async def get_candidate(candidate_id: str) -> dict[str, Any]:
+    data = await _post("candidate.info", {"id": candidate_id})
+    candidate = data.get("results", {})
+    result = _format_candidate(candidate)
+    result["resumeUrl"] = await _resolve_file_url(candidate.get("resumeFileHandle"))
+    result["fileHandles"] = candidate.get("fileHandles")
+    return result
+
+
+def _format_application(a: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": a.get("id"),
+        "candidate": a.get("candidate"),
+        "status": a.get("status"),
+        "currentStage": (a.get("currentInterviewStage") or {}).get("title"),
+        "currentStageId": (a.get("currentInterviewStage") or {}).get("id"),
+        "source": (a.get("source") or {}).get("title"),
+        "archiveReason": (a.get("archiveReason") or {}).get("text"),
+        "createdAt": a.get("createdAt"),
+        "updatedAt": a.get("updatedAt"),
+        "archivedAt": a.get("archivedAt"),
+    }
+
+
+async def list_applications(job_id: str, status: str | None = None) -> dict[str, Any]:
+    payload: dict[str, Any] = {"jobId": job_id, "limit": 100}
+    if status:
+        payload["status"] = status
+    apps = await _paginate("application.list", payload)
+    by_stage: dict[str, int] = {}
+    for a in apps:
+        stage = (a.get("currentInterviewStage") or {}).get("title") or "Unknown"
+        by_stage[stage] = by_stage.get(stage, 0) + 1
+    return {
+        "jobId": job_id,
+        "status_filter": status,
+        "count": len(apps),
+        "by_stage": by_stage,
+        "applications": [_format_application(a) for a in apps],
+    }
+
+
+async def get_application(application_id: str) -> dict[str, Any]:
+    data = await _post("application.info", {"applicationId": application_id})
+    return data.get("results", {})
+
+
+async def export_application(application_id: str) -> dict[str, Any]:
+    """Aggregate everything needed to review one application with AI."""
+    app = await get_application(application_id)
+    if not app:
+        return {"error": f"Application not found: {application_id}"}
+
+    candidate_id = (app.get("candidate") or {}).get("id")
+    candidate = await get_candidate(candidate_id) if candidate_id else None
+
+    resume_url = await _resolve_file_url(app.get("resumeFileHandle"))
+    if not resume_url and candidate:
+        resume_url = candidate.get("resumeUrl")
+
+    feedback: list[dict[str, Any]] = []
+    try:
+        fb = await _post("applicationFeedback.list", {"applicationId": application_id})
+        feedback = fb.get("results", [])
+    except AshbyToolError:
+        pass
+
+    return {
+        "application": {
+            **_format_application(app),
+            "customFields": app.get("customFields"),
+            "applicationHistory": app.get("applicationHistory"),
+            "job": {"id": (app.get("job") or {}).get("id"), "title": (app.get("job") or {}).get("title")},
+        },
+        "candidate": candidate,
+        "resumeUrl": resume_url,
+        "feedback": feedback,
+    }
+
+
+async def export_job_applications(job_id: str, status: str | None = None, limit: int = 200) -> dict[str, Any]:
+    """Bulk export for AI review: every application on a job with candidate + resume URL."""
+    listing = await list_applications(job_id, status=status)
+    apps = listing["applications"][:limit]
+
+    async def _one(a: dict[str, Any]) -> dict[str, Any]:
+        try:
+            return await export_application(a["id"])
+        except AshbyToolError as e:
+            return {"application": a, "error": str(e)}
+
+    exported: list[dict[str, Any]] = []
+    batch = 5
+    for i in range(0, len(apps), batch):
+        exported.extend(await asyncio.gather(*[_one(a) for a in apps[i:i + batch]]))
+
+    return {
+        "jobId": job_id,
+        "status_filter": status,
+        "total_on_job": listing["count"],
+        "exported": len(exported),
+        "by_stage": listing["by_stage"],
+        "applications": exported,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _print_usage():
+    print(__doc__)
+    sys.exit(1)
+
+
+def _flag(rest: list[str], name: str) -> str | None:
+    if name in rest:
+        idx = rest.index(name)
+        if idx + 1 < len(rest):
+            return rest[idx + 1]
+    return None
+
+
+def main() -> None:
+    try:
+        from dotenv import load_dotenv
+        load_dotenv()
+    except ImportError:
+        pass
+
+    if len(sys.argv) < 2:
+        _print_usage()
+
+    command = sys.argv[1]
+    rest = sys.argv[2:]
+
+    try:
+        if command == "check-auth":
+            result = asyncio.run(check_auth())
+        elif command == "list-jobs":
+            result = asyncio.run(list_jobs(status=_flag(rest, "--status")))
+        elif command == "get-job":
+            if not rest:
+                raise AshbyToolError("get-job requires a JOB_ID")
+            result = asyncio.run(get_job(rest[0]))
+        elif command == "list-stages":
+            job_id = _flag(rest, "--job-id")
+            if not job_id:
+                raise AshbyToolError("list-stages requires --job-id")
+            result = asyncio.run(list_stages(job_id))
+        elif command == "list-candidates":
+            limit = int(_flag(rest, "--limit") or 100)
+            result = asyncio.run(list_candidates(limit=limit))
+        elif command == "get-candidate":
+            if not rest:
+                raise AshbyToolError("get-candidate requires a CANDIDATE_ID")
+            result = asyncio.run(get_candidate(rest[0]))
+        elif command == "list-applications":
+            job_id = _flag(rest, "--job-id")
+            if not job_id:
+                raise AshbyToolError("list-applications requires --job-id")
+            result = asyncio.run(list_applications(job_id, status=_flag(rest, "--status")))
+        elif command == "get-application":
+            if not rest:
+                raise AshbyToolError("get-application requires an APPLICATION_ID")
+            result = asyncio.run(get_application(rest[0]))
+        elif command == "export-application":
+            if not rest:
+                raise AshbyToolError("export-application requires an APPLICATION_ID")
+            result = asyncio.run(export_application(rest[0]))
+        elif command == "export-job-applications":
+            job_id = _flag(rest, "--job-id")
+            if not job_id:
+                raise AshbyToolError("export-job-applications requires --job-id")
+            limit = int(_flag(rest, "--limit") or 200)
+            result = asyncio.run(export_job_applications(job_id, status=_flag(rest, "--status"), limit=limit))
+        else:
+            print(f"Unknown command: {command}")
+            _print_usage()
+            return
+    except AshbyToolError as e:
+        print(json.dumps({"error": str(e)}, indent=2))
+        sys.exit(1)
+
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds an Ashby ATS integration following the Grain CLI pattern:

- `tools/ashby.py` — read-only CLI: `check-auth`, `list-jobs`, `get-job`, `list-stages`, `list-candidates`, `get-candidate`, `list-applications`, `get-application`, `export-application`, `export-job-applications` (bulk export for AI review). Auth via `ASHBY_API_KEY` env var (HTTP Basic, key as username).
- `seed/skills/ashby/SKILL.md` — agent playbook incl. the AI shortlisting workflow (Loma reviews and proposes; a human acts in Ashby).
- `tests/test_ashby_tool.py` — 28 offline tests, all passing.

## Compensation-leak guardrails (defense in depth)

1. **Endpoint allowlist** — only 12 read endpoints callable. `offer.*`, `apiKey.*`, and every write endpoint (`application.changeStage`, `candidate.update`, `job.update`, ...) are rejected locally before any network request.
2. **Expand stripping** — `expand: ["compensation"]` is removed from every request before it is sent; only `openings` is forwardable.
3. **Recursive response redaction** — keys matching compensation/salary/equity/bonus/CTC/pay patterns, and form answers whose question titles look comp-related (e.g. "Expected CTC"), are replaced with `[REDACTED:compensation-data-blocked-by-loma]`.
4. **Key-level block** — verified live: the provided key has no `offersRead`/`offersWrite`, so `offer.list`/`offer.info` return `missing_endpoint_permission` at the API too.

## Live testing (real Ashby workspace, 2026-08-07)

Verified against the newly created **Technical Support Engineer** job (`463d3765-d0db-4657-b312-92ae87e88128`, opened 2026-08-06):

| Check | Result |
|---|---|
| Key valid, read endpoints reachable | ✅ jobs/candidates/applications/feedback all `ok` |
| `offer.list` via raw API | ✅ blocked by Ashby (`missing_endpoint_permission`) |
| `offer.list` via tool | ✅ blocked locally by allowlist |
| `job.info` + `expand:["compensation"]` via tool | ✅ expand stripped — no `compensation` key in output |
| Raw API compensation probe | ⚠️ raw key CAN expand compensation (empty tiers today) — tool-level stripping + redaction is what protects this; see note below |
| TSE applications accessible | ✅ 171 applications, all in "Application Review", full export works (candidate + form data + resume URL + feedback) |
| Unit tests | ✅ 28/28 passed |

### Screenshots

**1. check-auth — key + endpoint access**
![check-auth](https://cdn.plotline.so/loma-images/loma-pr-evidence/ashby/01-check-auth.png)

**2. list-jobs --status Open (18 open jobs)**
![list-jobs](https://cdn.plotline.so/loma-images/loma-pr-evidence/ashby/02-list-jobs.png)

**3. get-job on Technical Support Engineer — no compensation field in output**
![get-job](https://cdn.plotline.so/loma-images/loma-pr-evidence/ashby/03-get-job-tse.png)

**4. list-stages for the TSE interview plan**
![list-stages](https://cdn.plotline.so/loma-images/loma-pr-evidence/ashby/04-list-stages.png)

**5. list-applications — 171 applications on the new TSE job**
![list-applications](https://cdn.plotline.so/loma-images/loma-pr-evidence/ashby/05-list-applications.png)

**6. export-application — full AI-review export (candidate, resume URL, feedback)**
![export-application](https://cdn.plotline.so/loma-images/loma-pr-evidence/ashby/06-export-application.png)

**7. Compensation leak attempts — all blocked**
![leak-attempts](https://cdn.plotline.so/loma-images/loma-pr-evidence/ashby/07-leak-attempts.png)

**8. Unit tests — 28 passed**
![unit-tests](https://cdn.plotline.so/loma-images/loma-pr-evidence/ashby/08-unit-tests.png)

## Note for reviewers

Ashby gates job compensation under `jobsRead` (not a separate permission), so any process holding the raw key could expand compensation directly. The tool blocks this, but for full isolation keep comp tiers off jobs in Ashby (currently they are — all jobs have 0 tiers) and keep `offersRead` off this key (offer letters are the strong, key-level protection and it is confirmed off).

## Setup

Set `ASHBY_API_KEY` in the Loma environment (read-only key, no offer permissions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)