### PR TITLE
Delete Claude/Codex credential dirs when a user is removed

### DIFF
--- a/api/claude_auth_routes.py
+++ b/api/claude_auth_routes.py
@@ -116,13 +116,44 @@ async def handle_claude_terminal_token(request: web.Request) -> web.Response:
     return web.json_response({"token": token, "autoCommand": auto_command})
 
 
+async def remove_claude_credentials(user_email: str) -> bool:
+    """Gracefully log out and delete a user's Claude credential dir.
+
+    Shared by the disconnect route and user deletion (governance) so a removed
+    user's OAuth file cannot be re-discovered by the pool's disk rescan.
+    Returns True if the dir is gone (or never existed), False on removal failure.
+    """
+    config_dir = _get_claude_users_dir() / user_email
+    if not config_dir.exists():
+        return True
+
+    # Try graceful logout first
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "claude", "auth", "logout",
+            env={**os.environ, "CLAUDE_CONFIG_DIR": str(config_dir)},
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        await asyncio.wait_for(proc.communicate(), timeout=10)
+    except Exception as e:
+        logger.warning("Claude logout failed for %s: %s", user_email, e)
+
+    # Remove the config directory
+    try:
+        shutil.rmtree(config_dir)
+        logger.info("Removed Claude config dir for %s", user_email)
+        return True
+    except OSError as e:
+        logger.error("Failed to remove config dir for %s: %s", user_email, e)
+        return False
+
+
 async def handle_claude_disconnect(request: web.Request) -> web.Response:
     """POST /api/claude-auth/disconnect — remove user's Claude credentials."""
     user_email = get_user_email(request)
     if not user_email:
         return web.json_response({"error": "Not authenticated"}, status=401)
-
-    config_dir = _get_claude_users_dir() / user_email
 
     # Refresh pool accounts after disconnect
     try:
@@ -130,26 +161,8 @@ async def handle_claude_disconnect(request: web.Request) -> web.Response:
     except RuntimeError:
         pool = None
 
-    # Try graceful logout first
-    if config_dir.exists():
-        try:
-            proc = await asyncio.create_subprocess_exec(
-                "claude", "auth", "logout",
-                env={**os.environ, "CLAUDE_CONFIG_DIR": str(config_dir)},
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
-            await asyncio.wait_for(proc.communicate(), timeout=10)
-        except Exception as e:
-            logger.warning("Claude logout failed for %s: %s", user_email, e)
-
-        # Remove the config directory
-        try:
-            shutil.rmtree(config_dir)
-            logger.info("Removed Claude config dir for %s", user_email)
-        except OSError as e:
-            logger.error("Failed to remove config dir for %s: %s", user_email, e)
-            return web.json_response({"error": "Failed to remove credentials"}, status=500)
+    if not await remove_claude_credentials(user_email):
+        return web.json_response({"error": "Failed to remove credentials"}, status=500)
 
     # Re-scan accounts so the pool drops this user
     if pool is not None:

--- a/api/codex_auth_routes.py
+++ b/api/codex_auth_routes.py
@@ -101,38 +101,51 @@ async def handle_codex_terminal_token(request: web.Request) -> web.Response:
     return web.json_response({"token": token, "autoCommand": auto_command})
 
 
+async def remove_codex_credentials(user_email: str) -> bool:
+    """Gracefully log out and delete a user's Codex credential dir.
+
+    Shared by the disconnect route and user deletion (governance) so a removed
+    user's auth file cannot be re-discovered by the pool's disk rescan.
+    Returns True if the dir is gone (or never existed), False on removal failure.
+    """
+    config_dir = _get_codex_users_dir() / user_email
+    if not config_dir.exists():
+        return True
+
+    # Try graceful logout first (revokes the token server-side)
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "codex", "logout",
+            env={**os.environ, "CODEX_HOME": str(config_dir)},
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        await asyncio.wait_for(proc.communicate(), timeout=10)
+    except Exception as e:
+        logger.warning("Codex logout failed for %s: %s", user_email, e)
+
+    try:
+        shutil.rmtree(config_dir)
+        logger.info("Removed Codex config dir for %s", user_email)
+        return True
+    except OSError as e:
+        logger.error("Failed to remove Codex config dir for %s: %s", user_email, e)
+        return False
+
+
 async def handle_codex_disconnect(request: web.Request) -> web.Response:
     """POST /api/codex-auth/disconnect — remove user's Codex credentials."""
     user_email = get_user_email(request)
     if not user_email:
         return web.json_response({"error": "Not authenticated"}, status=401)
 
-    config_dir = _get_codex_users_dir() / user_email
-
     try:
         pool = get_codex_pool()
     except RuntimeError:
         pool = None
 
-    if config_dir.exists():
-        # Try graceful logout first (revokes the token server-side)
-        try:
-            proc = await asyncio.create_subprocess_exec(
-                "codex", "logout",
-                env={**os.environ, "CODEX_HOME": str(config_dir)},
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
-            await asyncio.wait_for(proc.communicate(), timeout=10)
-        except Exception as e:
-            logger.warning("Codex logout failed for %s: %s", user_email, e)
-
-        try:
-            shutil.rmtree(config_dir)
-            logger.info("Removed Codex config dir for %s", user_email)
-        except OSError as e:
-            logger.error("Failed to remove Codex config dir for %s: %s", user_email, e)
-            return web.json_response({"error": "Failed to remove credentials"}, status=500)
+    if not await remove_codex_credentials(user_email):
+        return web.json_response({"error": "Failed to remove credentials"}, status=500)
 
     if pool is not None:
         pool.refresh_accounts()

--- a/api/governance_routes.py
+++ b/api/governance_routes.py
@@ -293,6 +293,17 @@ async def handle_delete_user(request: web.Request) -> web.Response:
 
     await db.users.delete_one({"email": email})
 
+    # Delete any Claude/Codex credential dirs BEFORE refreshing the pools.
+    # The pool rescans the credentials dir on disk, and a deleted user has no
+    # user doc left to exclude them via the pool toggle — so a leftover OAuth
+    # file would resurrect them as a pool account forever.
+    from api.claude_auth_routes import remove_claude_credentials
+    from api.codex_auth_routes import remove_codex_credentials
+    if not await remove_claude_credentials(email):
+        logger.error("Could not remove Claude credentials for deleted user %s", email)
+    if not await remove_codex_credentials(email):
+        logger.error("Could not remove Codex credentials for deleted user %s", email)
+
     # The removed user may have been a Claude/Codex pool account — refresh the lists.
     try:
         from agent.pool import get_pool


### PR DESCRIPTION
## Problem

Deleting a user from Admin > Users (`handle_delete_user`) only removed the Mongo user doc and called `refresh_accounts()` on the pools. But the Claude pool scans **credential folders on disk** (`CLAUDE_USERS_DIR`), so the deleted user's leftover OAuth folder got re-discovered on every rescan and the account stayed in Claude Pooling forever.

Worse, a deleted user has no user doc left, so the `claude_pool_enabled: false` exclusion can never apply — there is no way to remove the stale account from the dashboard at all.

Real occurrence: `adarsh@revninja.co` was deleted from Admin > Users but kept showing in Claude Pooling.

## Fix

- Extracted the disconnect routes' cleanup into reusable helpers: `remove_claude_credentials()` (`api/claude_auth_routes.py`) and `remove_codex_credentials()` (`api/codex_auth_routes.py`) — graceful CLI logout, then `rmtree` of the credential dir.
- `handle_delete_user` (`api/governance_routes.py`) now calls both helpers **before** refreshing the pools, so the rescan can no longer resurrect the deleted user.
- `handle_claude_disconnect` / `handle_codex_disconnect` now use the shared helpers (behavior unchanged).

## Testing (local stack via run-loma-local)

Booted the full stack against a throwaway DB with an isolated `CLAUDE_USERS_DIR`, created a fake pool account `stale-test@revninja.co` (credential dir + user doc), then deleted the user via `DELETE /api/governance/users/...`:

```
POOL_BEFORE accounts=["stale-test@revninja.co"]
DELETE_RESULT {"status":200,"body":{"deleted":true}}
POOL_AFTER accounts=[]
```

Backend log:
```
api.claude_auth_routes: Removed Claude config dir for stale-test@revninja.co
agent.pool: Account scan: 0 accounts found (disabled=0): []
```

The credential dir was confirmed removed from disk, and the pool no longer lists the account after the rescan.

### Before deletion — 2 users, stale account in pool (`Claude · 1/1 available`)
![before](https://cdn.plotline.so/loma-images/loma-pr/delete-user-before.png)

### After deletion — 1 user, pool empty (`Claude · no accounts`)
![after](https://cdn.plotline.so/loma-images/loma-pr/delete-user-after.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)