### PR TITLE
feat: Telegram personal channel — chat with your own Loma agent

### DIFF
--- a/agent/client.py
+++ b/agent/client.py
@@ -743,7 +743,7 @@ async def stream_agent(
             f"[Authenticated User: {user_email}]\n"
             f"[Personal Tools Auth Token: {auth_token}]\n"
             f"When using personal tools (gmail, google_drive, google_calendar, "
-            f"google_sheets, google_slides, google_docs_personal, slack_user), you MUST pass "
+            f"google_sheets, google_slides, google_docs_personal, slack_user, telegram), you MUST pass "
             f"`--user-email {user_email} --auth-token {auth_token}`. "
             f"Never use a different user's email with --user-email.\n"
             f"IMPORTANT: Always use the personal CLI tools (e.g. `python3 tools/google_drive.py`, "

--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -138,11 +138,15 @@ You are responding in the dashboard. Use standard Markdown.
 _FORMATTING_POOLED = f"""
 ## Response Formatting
 
-Each message may specify its output channel with a `[Source: slack]`, `[Source: dashboard]`, or `[Source: github_webhook]` marker. Apply the formatting rules for the indicated source.
+Each message may specify its output channel with a `[Source: slack]`, `[Source: dashboard]`, `[Source: telegram]`, or `[Source: github_webhook]` marker. Apply the formatting rules for the indicated source.
 
 {_FORMATTING_SLACK}
 
 {_FORMATTING_DASHBOARD}
+
+### Telegram
+
+You are responding in a Telegram DM. Use plain text only — no Markdown syntax, no tables, no heading markers. Keep responses short and mobile-friendly; use simple dashes for lists.
 
 ### GitHub Webhook
 

--- a/api/telegram_routes.py
+++ b/api/telegram_routes.py
@@ -1,0 +1,174 @@
+"""Telegram personal-channel API routes.
+
+Backs the Telegram card on Integrations > Personal:
+
+  GET    /api/telegram/status         — bot configured? current user linked?
+  POST   /api/telegram/link           — mint a one-time code + t.me deep link
+  DELETE /api/telegram/link           — unlink the current user's Telegram
+  POST   /api/telegram/setup-webhook  — (admin) register the webhook with Telegram
+
+Linking flow: the dashboard calls POST /link, shows the returned
+``https://t.me/<bot>?start=<code>`` deep link, and polls GET /status until
+``linked`` flips to true (the webhook consumes the code — see
+``webhooks/telegram_ingestion.py``).
+"""
+
+import logging
+import os
+import secrets
+from datetime import datetime, timedelta, timezone
+
+from aiohttp import web
+
+from api.auth_helpers import get_user_email, require_admin
+from observability.db import get_db
+from webhooks.telegram_ingestion import _telegram_api
+
+logger = logging.getLogger(__name__)
+
+_LINK_CODE_TTL_MINUTES = 10
+
+# getMe result cached per-process — the bot identity never changes at runtime.
+_cached_bot_username: str | None = None
+
+
+def _serialize_dt(value):
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return value
+
+
+async def _get_bot_username() -> str | None:
+    """Fetch (and cache) the bot's username via getMe."""
+    global _cached_bot_username
+    if _cached_bot_username:
+        return _cached_bot_username
+    data = await _telegram_api("getMe", {})
+    if data.get("ok"):
+        _cached_bot_username = data.get("result", {}).get("username")
+    return _cached_bot_username
+
+
+async def handle_telegram_status(request: web.Request) -> web.Response:
+    """GET /api/telegram/status — configuration + link state for current user."""
+    db = get_db()
+    if db is None:
+        return web.json_response({"error": "DB not configured"}, status=503)
+
+    email = get_user_email(request)
+    if not email:
+        return web.json_response({"error": "User not authenticated"}, status=401)
+
+    configured = bool(os.environ.get("TELEGRAM_BOT_TOKEN", "").strip())
+    payload = {
+        "configured": configured,
+        "linked": False,
+        "bot_username": None,
+        "telegram_username": None,
+        "linked_at": None,
+    }
+    if configured:
+        payload["bot_username"] = await _get_bot_username()
+        link = await db.telegram_links.find_one({"user_email": email})
+        if link:
+            payload["linked"] = True
+            payload["telegram_username"] = link.get("telegram_username") or link.get("telegram_first_name")
+            payload["linked_at"] = _serialize_dt(link.get("linked_at"))
+
+    return web.json_response(payload)
+
+
+async def handle_telegram_create_link(request: web.Request) -> web.Response:
+    """POST /api/telegram/link — mint a one-time code and deep link."""
+    db = get_db()
+    if db is None:
+        return web.json_response({"error": "DB not configured"}, status=503)
+
+    email = get_user_email(request)
+    if not email:
+        return web.json_response({"error": "User not authenticated"}, status=401)
+
+    if not os.environ.get("TELEGRAM_BOT_TOKEN", "").strip():
+        return web.json_response({"error": "Telegram bot is not configured on this deployment"}, status=503)
+
+    bot_username = await _get_bot_username()
+    if not bot_username:
+        return web.json_response({"error": "Could not reach the Telegram Bot API"}, status=502)
+
+    now = datetime.now(timezone.utc)
+    # start payload charset is [A-Za-z0-9_-], max 64 chars — token_urlsafe fits.
+    code = secrets.token_urlsafe(24)
+    await db.telegram_link_codes.insert_one({
+        "code": code,
+        "user_email": email,
+        "created_at": now,
+        "expires_at": now + timedelta(minutes=_LINK_CODE_TTL_MINUTES),
+        "used": False,
+    })
+
+    return web.json_response({
+        "deep_link": f"https://t.me/{bot_username}?start={code}",
+        "bot_username": bot_username,
+        "expires_in_minutes": _LINK_CODE_TTL_MINUTES,
+    })
+
+
+async def handle_telegram_unlink(request: web.Request) -> web.Response:
+    """DELETE /api/telegram/link — remove the current user's mapping."""
+    db = get_db()
+    if db is None:
+        return web.json_response({"error": "DB not configured"}, status=503)
+
+    email = get_user_email(request)
+    if not email:
+        return web.json_response({"error": "User not authenticated"}, status=401)
+
+    result = await db.telegram_links.delete_many({"user_email": email})
+    if not result.deleted_count:
+        return web.json_response({"error": "No Telegram connection found"}, status=404)
+
+    return web.json_response({"disconnected": True})
+
+
+async def handle_telegram_setup_webhook(request: web.Request) -> web.Response:
+    """POST /api/telegram/setup-webhook — (admin) call Telegram setWebhook.
+
+    Body: {"url": "https://<public-backend-host>/webhooks/telegram"} — falls
+    back to the TELEGRAM_WEBHOOK_URL env var. If TELEGRAM_WEBHOOK_SECRET is
+    set, it is registered as the webhook secret_token.
+    """
+    require_admin(request)
+
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+
+    url = (body.get("url") or os.environ.get("TELEGRAM_WEBHOOK_URL", "")).strip()
+    if not url:
+        return web.json_response(
+            {"error": "Provide a webhook url in the body or set TELEGRAM_WEBHOOK_URL"},
+            status=400,
+        )
+
+    payload = {"url": url, "allowed_updates": ["message"]}
+    secret = os.environ.get("TELEGRAM_WEBHOOK_SECRET", "").strip()
+    if secret:
+        payload["secret_token"] = secret
+
+    data = await _telegram_api("setWebhook", payload)
+    if not data.get("ok"):
+        return web.json_response(
+            {"error": data.get("description", "setWebhook failed")}, status=502,
+        )
+
+    logger.info("[TELEGRAM] Webhook registered at %s", url)
+    return web.json_response({"ok": True, "url": url})
+
+
+def setup_telegram_routes(app: web.Application):
+    """Register Telegram API routes."""
+    app.router.add_get("/api/telegram/status", handle_telegram_status)
+    app.router.add_post("/api/telegram/link", handle_telegram_create_link)
+    app.router.add_delete("/api/telegram/link", handle_telegram_unlink)
+    app.router.add_post("/api/telegram/setup-webhook", handle_telegram_setup_webhook)

--- a/app.py
+++ b/app.py
@@ -24,6 +24,7 @@ from webhooks.pylon import setup_pylon_webhook_routes
 from webhooks.hubspot import setup_hubspot_webhook_routes
 from webhooks.github import setup_github_webhook_routes
 from webhooks.incoming import setup_incoming_webhook_routes
+from webhooks.telegram import setup_telegram_webhook_routes
 from observability.db import init_observability, get_db
 from api.skill_seed import seed_default_skills
 from api.routes import setup_api_routes
@@ -39,6 +40,7 @@ from api.codex_auth_routes import setup_codex_auth_routes
 from api.file_routes import setup_file_routes
 from api.integration_routes import setup_integration_routes
 from api.prompt_settings_routes import setup_prompt_settings_routes
+from api.telegram_routes import setup_telegram_routes
 from recovery import start_recovery_loop, mark_all_running_interrupted
 from scheduler.engine import init_scheduler
 from agent.client import load_config, merge_db_integrations
@@ -125,6 +127,7 @@ async def main():
         setup_hubspot_webhook_routes(webhook_app)
         setup_github_webhook_routes(webhook_app)
         setup_incoming_webhook_routes(webhook_app)
+        setup_telegram_webhook_routes(webhook_app)
     setup_api_routes(webhook_app)
     setup_governance_routes(webhook_app)
     setup_oauth_routes(webhook_app)
@@ -137,6 +140,7 @@ async def main():
     setup_file_routes(webhook_app)
     setup_integration_routes(webhook_app)
     setup_prompt_settings_routes(webhook_app)
+    setup_telegram_routes(webhook_app)
     async def on_shutdown(_app):
         await mark_all_running_interrupted()
 

--- a/dashboard/src/app/integrations/manage/page.tsx
+++ b/dashboard/src/app/integrations/manage/page.tsx
@@ -24,6 +24,13 @@ import {
   type CodexAuthStatus,
 } from "../../../lib/codex-auth-api";
 import {
+  fetchTelegramStatus,
+  createTelegramLink,
+  disconnectTelegram,
+  type TelegramStatus,
+  type TelegramLink,
+} from "../../../lib/telegram-api";
+import {
   fetchIntegrations,
   connectIntegration,
   disconnectIntegration,
@@ -151,6 +158,18 @@ function SlackLogo() {
       <path d="M8.834 5.042a2.528 2.528 0 0 1-2.521-2.52A2.528 2.528 0 0 1 8.834 0a2.528 2.528 0 0 1 2.521 2.522v2.52H8.834zM8.834 6.313a2.528 2.528 0 0 1 2.521 2.521 2.528 2.528 0 0 1-2.521 2.521H2.522A2.528 2.528 0 0 1 0 8.834a2.528 2.528 0 0 1 2.522-2.521h6.312z" fill="#36C5F0"/>
       <path d="M18.956 8.834a2.528 2.528 0 0 1 2.522-2.521A2.528 2.528 0 0 1 24 8.834a2.528 2.528 0 0 1-2.522 2.521h-2.522V8.834zM17.688 8.834a2.528 2.528 0 0 1-2.523 2.521 2.527 2.527 0 0 1-2.52-2.521V2.522A2.527 2.527 0 0 1 15.165 0a2.528 2.528 0 0 1 2.523 2.522v6.312z" fill="#2EB67D"/>
       <path d="M15.165 18.956a2.528 2.528 0 0 1 2.523 2.522A2.528 2.528 0 0 1 15.165 24a2.527 2.527 0 0 1-2.52-2.522v-2.522h2.52zM15.165 17.688a2.527 2.527 0 0 1-2.52-2.523 2.526 2.526 0 0 1 2.52-2.52h6.313A2.527 2.527 0 0 1 24 15.165a2.528 2.528 0 0 1-2.522 2.523h-6.313z" fill="#ECB22E"/>
+    </svg>
+  );
+}
+
+function TelegramLogo() {
+  return (
+    <svg className="w-8 h-8" viewBox="0 0 24 24">
+      <circle cx="12" cy="12" r="12" fill="#229ED9" />
+      <path
+        d="M5.29 11.71l12.3-4.74c.57-.21 1.07.14.88.99l-2.09 9.87c-.15.7-.57.87-1.15.54l-3.19-2.35-1.54 1.48c-.17.17-.31.31-.64.31l.23-3.25 5.92-5.35c.26-.23-.06-.36-.4-.13L8.29 13.7l-3.15-.98c-.68-.22-.7-.68.15-1.01z"
+        fill="#fff"
+      />
     </svg>
   );
 }
@@ -343,17 +362,24 @@ export default function IntegrationsPage() {
   const [codexAutoCommand, setCodexAutoCommand] = useState<string | undefined>();
   const [disconnectingCodex, setDisconnectingCodex] = useState(false);
 
+  const [telegramStatus, setTelegramStatus] = useState<TelegramStatus | null>(null);
+  const [telegramLink, setTelegramLink] = useState<TelegramLink | null>(null);
+  const [linkingTelegram, setLinkingTelegram] = useState(false);
+  const [disconnectingTelegram, setDisconnectingTelegram] = useState(false);
+
   const loadConnections = useCallback(async () => {
     try {
-      const [conns, claude, codex, orgInteg] = await Promise.all([
+      const [conns, claude, codex, orgInteg, telegram] = await Promise.all([
         fetchOAuthConnections().catch(() => []),
         fetchClaudeAuthStatus().catch(() => null),
         fetchCodexAuthStatus().catch(() => null),
         fetchIntegrations().catch(() => []),
+        fetchTelegramStatus().catch(() => null),
       ]);
       setConnections(conns);
       if (claude) setClaudeAuth(claude);
       if (codex) setCodexAuth(codex);
+      if (telegram) setTelegramStatus(telegram);
       setOrgIntegrations(orgInteg);
 
       const urls: Record<string, string> = {};
@@ -413,6 +439,22 @@ export default function IntegrationsPage() {
   }, [showCodexTerminal]);
 
   useEffect(() => {
+    if (!telegramLink || telegramStatus?.linked) return;
+    const interval = setInterval(async () => {
+      try {
+        const status = await fetchTelegramStatus();
+        if (status.linked) {
+          setTelegramStatus(status);
+          setTelegramLink(null);
+        }
+      } catch {
+        // ignore polling errors
+      }
+    }, 3000);
+    return () => clearInterval(interval);
+  }, [telegramLink, telegramStatus?.linked]);
+
+  useEffect(() => {
     function handleMessage(event: MessageEvent) {
       if (event.data?.type === "oauth-complete") {
         const prov = event.data.provider;
@@ -431,6 +473,38 @@ export default function IntegrationsPage() {
     window.addEventListener("message", handleMessage);
     return () => window.removeEventListener("message", handleMessage);
   }, [loadConnections]);
+
+  const handleConnectTelegram = async () => {
+    setLinkingTelegram(true);
+    setError(null);
+    try {
+      const link = await createTelegramLink();
+      setTelegramLink(link);
+      window.open(link.deep_link, "_blank", "noopener,noreferrer");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to create Telegram link");
+    } finally {
+      setLinkingTelegram(false);
+    }
+  };
+
+  const handleDisconnectTelegram = async () => {
+    if (!confirm("Disconnect your Telegram account? Loma will no longer respond to your Telegram messages.")) {
+      return;
+    }
+    setDisconnectingTelegram(true);
+    setError(null);
+    try {
+      await disconnectTelegram();
+      setTelegramLink(null);
+      const status = await fetchTelegramStatus().catch(() => null);
+      if (status) setTelegramStatus(status);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to disconnect Telegram");
+    } finally {
+      setDisconnectingTelegram(false);
+    }
+  };
 
   const handleConnect = async () => {
     setConnecting(true);
@@ -1449,6 +1523,112 @@ export default function IntegrationsPage() {
                           <Badge
                             key={perm}
                             className="bg-purple-50 text-purple-600 border-transparent"
+                          >
+                            {perm}
+                          </Badge>
+                        ))}
+                      </div>
+                    </>
+                  )}
+                </CardContent>
+              </Card>
+
+              {/* Telegram Integration Card */}
+              <Card>
+                <CardContent>
+                  <div className="flex items-start justify-between">
+                    <div className="flex items-center gap-3">
+                      <div className="w-8 h-8 bg-muted rounded-lg flex items-center justify-center">
+                        <TelegramLogo />
+                      </div>
+                      <div>
+                        <div className="flex items-center gap-2">
+                          <h2 className="text-[13px] font-semibold text-foreground">
+                            Telegram
+                          </h2>
+                          <StatusBadge status={telegramStatus?.linked ? "connected" : "not_connected"} />
+                        </div>
+                        <p className="text-xs text-muted-foreground mt-0.5 line-clamp-2">
+                          Chat with your Loma agent from Telegram
+                        </p>
+                      </div>
+                    </div>
+
+                    <div className="shrink-0">
+                      {telegramStatus?.linked ? (
+                        <Button
+                          variant="destructive"
+                          size="sm"
+                          className="whitespace-nowrap"
+                          onClick={handleDisconnectTelegram}
+                          disabled={disconnectingTelegram}
+                        >
+                          {disconnectingTelegram ? "Disconnecting..." : "Disconnect"}
+                        </Button>
+                      ) : (
+                        <Button
+                          size="sm"
+                          className="whitespace-nowrap"
+                          onClick={handleConnectTelegram}
+                          disabled={linkingTelegram || telegramStatus?.configured === false}
+                        >
+                          {linkingTelegram ? "Connecting..." : "Connect Telegram"}
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+
+                  {telegramStatus?.linked && (
+                    <>
+                      <Separator className="my-5" />
+                      <p className="text-xs text-muted-foreground">
+                        Linked to {telegramStatus.telegram_username ? `@${telegramStatus.telegram_username}` : "your Telegram account"}
+                        {telegramStatus.linked_at ? ` — connected ${formatDate(telegramStatus.linked_at)}` : ""}
+                      </p>
+                      <p className="text-xs text-muted-foreground mt-1">
+                        Message {telegramStatus.bot_username ? `@${telegramStatus.bot_username}` : "the Loma bot"} on
+                        Telegram and it will reply as your agent. Send /stop to disconnect.
+                      </p>
+                    </>
+                  )}
+
+                  {telegramStatus?.configured === false && (
+                    <Alert className="mt-2 bg-amber-50 border-amber-100">
+                      <AlertDescription className="text-amber-700">
+                        The Telegram bot is not configured on this deployment. Ask an admin to set TELEGRAM_BOT_TOKEN.
+                      </AlertDescription>
+                    </Alert>
+                  )}
+
+                  {!telegramStatus?.linked && telegramLink && (
+                    <Alert className="mt-2 bg-sky-50 border-sky-100">
+                      <AlertDescription className="text-sky-700">
+                        Waiting for you to open Telegram…{" "}
+                        <a
+                          href={telegramLink.deep_link}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="underline font-medium"
+                        >
+                          Open @{telegramLink.bot_username}
+                        </a>{" "}
+                        and tap Start. The link expires in {telegramLink.expires_in_minutes} minutes.
+                      </AlertDescription>
+                    </Alert>
+                  )}
+
+                  {!telegramStatus?.linked && !telegramLink && telegramStatus?.configured !== false && (
+                    <>
+                      <Separator className="my-5" />
+                      <p className="text-[13px] text-muted-foreground">
+                        Link your Telegram account to chat with your own Loma agent from your phone.
+                        Click Connect, open the bot in Telegram, and tap Start — no tokens needed.
+                      </p>
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        {["Chat with your agent", "DMs only", "Runs as your account", "Unlink anytime with /stop"].map((perm) => (
+                          <Badge
+                            key={perm}
+                            className="bg-sky-50 text-sky-600 border-transparent"
                           >
                             {perm}
                           </Badge>

--- a/dashboard/src/lib/telegram-api.ts
+++ b/dashboard/src/lib/telegram-api.ts
@@ -1,0 +1,52 @@
+/**
+ * Telegram API client — typed fetch wrappers for the Telegram personal channel.
+ */
+
+const API_BASE = process.env.NEXT_PUBLIC_BASE_PATH || "";
+
+async function apiError(res: Response, fallback: string): Promise<Error> {
+  try {
+    const data = await res.json();
+    if (typeof data?.error === "string" && data.error.trim()) {
+      return new Error(data.error);
+    }
+  } catch {
+    // Fall through to the generic status message.
+  }
+  return new Error(`${fallback}: ${res.status}`);
+}
+
+// ── Types ─────────────────────────────────────────────────────────────────
+
+export interface TelegramStatus {
+  configured: boolean;
+  linked: boolean;
+  bot_username: string | null;
+  telegram_username: string | null;
+  linked_at: string | null;
+}
+
+export interface TelegramLink {
+  deep_link: string;
+  bot_username: string;
+  expires_in_minutes: number;
+}
+
+// ── API calls ─────────────────────────────────────────────────────────────
+
+export async function fetchTelegramStatus(): Promise<TelegramStatus> {
+  const res = await fetch(`${API_BASE}/api/telegram/status`);
+  if (!res.ok) throw await apiError(res, "Failed to fetch Telegram status");
+  return res.json();
+}
+
+export async function createTelegramLink(): Promise<TelegramLink> {
+  const res = await fetch(`${API_BASE}/api/telegram/link`, { method: "POST" });
+  if (!res.ok) throw await apiError(res, "Failed to create Telegram link");
+  return res.json();
+}
+
+export async function disconnectTelegram(): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/telegram/link`, { method: "DELETE" });
+  if (!res.ok) throw await apiError(res, "Failed to disconnect Telegram");
+}

--- a/tests/test_telegram_webhook.py
+++ b/tests/test_telegram_webhook.py
@@ -143,7 +143,7 @@ class TestProcessTelegramUpdate:
     async def test_start_with_valid_code_links_account(self):
         db = _make_db()
         db.telegram_link_codes.find_one_and_update.return_value = {
-            "code": "abc", "user_email": "adarsh@plotline.so",
+            "code": "abc", "user_email": "user@example.com",
         }
         send = AsyncMock()
         with patch.object(telegram_ingestion, "get_db", return_value=db), \
@@ -152,9 +152,9 @@ class TestProcessTelegramUpdate:
 
         db.telegram_links.update_one.assert_awaited_once()
         filter_arg, update_arg = db.telegram_links.update_one.await_args.args
-        assert filter_arg == {"user_email": "adarsh@plotline.so"}
+        assert filter_arg == {"user_email": "user@example.com"}
         assert update_arg["$set"]["telegram_user_id"] == 42
-        assert "Connected as adarsh@plotline.so" in send.await_args.args[1]
+        assert "Connected as user@example.com" in send.await_args.args[1]
 
     @pytest.mark.asyncio
     async def test_start_with_invalid_code_replies_error(self):
@@ -190,13 +190,13 @@ class TestProcessTelegramUpdate:
     async def test_linked_sender_runs_agent(self):
         db = _make_db()
         db.telegram_links.find_one.return_value = {
-            "user_email": "adarsh@plotline.so",
+            "user_email": "user@example.com",
             "telegram_user_id": 42,
             "telegram_chat_id": 42,
         }
 
         async def fake_stream(**kwargs):
-            assert kwargs["user_email"] == "adarsh@plotline.so"
+            assert kwargs["user_email"] == "user@example.com"
             assert kwargs["source"] == "telegram"
             yield "part one"
             yield "part two"

--- a/tests/test_telegram_webhook.py
+++ b/tests/test_telegram_webhook.py
@@ -1,0 +1,242 @@
+"""Tests for webhooks/telegram.py and webhooks/telegram_ingestion.py.
+
+Covers:
+- handle_telegram_webhook: secret verification, config gating, bad payloads
+- process_telegram_update: dedup, /start linking, /stop unlink,
+  unlinked-sender reply, linked-sender agent run
+- send_telegram_message: message splitting at the length limit
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp.test_utils import make_mocked_request
+
+from webhooks.telegram import handle_telegram_webhook
+from webhooks import telegram_ingestion
+from webhooks.telegram_ingestion import (
+    process_telegram_update,
+    send_telegram_message,
+    _MAX_MESSAGE_LEN,
+)
+
+
+def _mocked_request(body: dict, headers: dict | None = None):
+    raw = json.dumps(body).encode()
+    req = make_mocked_request(
+        "POST", "/webhooks/telegram", headers=headers or {},
+    )
+    req.read = AsyncMock(return_value=raw)
+    return req
+
+
+def _make_db():
+    """Build a mock db with the collections the ingestion module touches."""
+    db = MagicMock()
+    # Dedup: default to "new update" (upserted_id set)
+    upsert_result = MagicMock()
+    upsert_result.upserted_id = "new-id"
+    db.telegram_updates.update_one = AsyncMock(return_value=upsert_result)
+    db.telegram_link_codes.find_one_and_update = AsyncMock(return_value=None)
+    db.telegram_links.find_one = AsyncMock(return_value=None)
+    db.telegram_links.update_one = AsyncMock()
+    delete_result = MagicMock()
+    delete_result.deleted_count = 0
+    db.telegram_links.delete_many = AsyncMock(return_value=delete_result)
+    db.conversations.find_one = AsyncMock(return_value=None)
+    return db
+
+
+def _dm_update(text: str, update_id: int = 1, user_id: int = 42):
+    return {
+        "update_id": update_id,
+        "message": {
+            "message_id": 10,
+            "from": {"id": user_id, "is_bot": False, "first_name": "V", "username": "vaibhav"},
+            "chat": {"id": user_id, "type": "private"},
+            "text": text,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# handle_telegram_webhook — auth and gating
+# ---------------------------------------------------------------------------
+
+
+class TestTelegramWebhookHandler:
+    @pytest.mark.asyncio
+    async def test_not_configured_returns_503(self):
+        req = _mocked_request(_dm_update("hi"))
+        with patch.dict("os.environ", {"TELEGRAM_BOT_TOKEN": ""}):
+            resp = await handle_telegram_webhook(req)
+        assert resp.status == 503
+
+    @pytest.mark.asyncio
+    async def test_secret_mismatch_returns_401(self):
+        req = _mocked_request(
+            _dm_update("hi"), headers={"X-Telegram-Bot-Api-Secret-Token": "wrong"},
+        )
+        env = {"TELEGRAM_BOT_TOKEN": "123:abc", "TELEGRAM_WEBHOOK_SECRET": "right"}
+        with patch.dict("os.environ", env):
+            resp = await handle_telegram_webhook(req)
+        assert resp.status == 401
+
+    @pytest.mark.asyncio
+    async def test_secret_match_accepts(self):
+        req = _mocked_request(
+            _dm_update("hi"), headers={"X-Telegram-Bot-Api-Secret-Token": "right"},
+        )
+        env = {"TELEGRAM_BOT_TOKEN": "123:abc", "TELEGRAM_WEBHOOK_SECRET": "right"}
+        with patch.dict("os.environ", env), \
+             patch("webhooks.telegram.process_telegram_update", new=AsyncMock()):
+            resp = await handle_telegram_webhook(req)
+        assert resp.status == 200
+        assert json.loads(resp.body)["status"] == "accepted"
+
+    @pytest.mark.asyncio
+    async def test_no_secret_configured_accepts(self):
+        req = _mocked_request(_dm_update("hi"))
+        env = {"TELEGRAM_BOT_TOKEN": "123:abc", "TELEGRAM_WEBHOOK_SECRET": ""}
+        with patch.dict("os.environ", env), \
+             patch("webhooks.telegram.process_telegram_update", new=AsyncMock()):
+            resp = await handle_telegram_webhook(req)
+        assert resp.status == 200
+
+    @pytest.mark.asyncio
+    async def test_missing_update_id_returns_400(self):
+        req = _mocked_request({"message": {}})
+        with patch.dict("os.environ", {"TELEGRAM_BOT_TOKEN": "123:abc"}):
+            resp = await handle_telegram_webhook(req)
+        assert resp.status == 400
+
+
+# ---------------------------------------------------------------------------
+# process_telegram_update — routing
+# ---------------------------------------------------------------------------
+
+
+class TestProcessTelegramUpdate:
+    @pytest.mark.asyncio
+    async def test_duplicate_update_skipped(self):
+        db = _make_db()
+        db.telegram_updates.update_one.return_value.upserted_id = None  # already seen
+        send = AsyncMock()
+        with patch.object(telegram_ingestion, "get_db", return_value=db), \
+             patch.object(telegram_ingestion, "send_telegram_message", send):
+            await process_telegram_update(_dm_update("hello"))
+        send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_group_chat_ignored(self):
+        db = _make_db()
+        update = _dm_update("hello")
+        update["message"]["chat"]["type"] = "group"
+        send = AsyncMock()
+        with patch.object(telegram_ingestion, "get_db", return_value=db), \
+             patch.object(telegram_ingestion, "send_telegram_message", send):
+            await process_telegram_update(update)
+        send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_start_with_valid_code_links_account(self):
+        db = _make_db()
+        db.telegram_link_codes.find_one_and_update.return_value = {
+            "code": "abc", "user_email": "adarsh@plotline.so",
+        }
+        send = AsyncMock()
+        with patch.object(telegram_ingestion, "get_db", return_value=db), \
+             patch.object(telegram_ingestion, "send_telegram_message", send):
+            await process_telegram_update(_dm_update("/start abc"))
+
+        db.telegram_links.update_one.assert_awaited_once()
+        filter_arg, update_arg = db.telegram_links.update_one.await_args.args
+        assert filter_arg == {"user_email": "adarsh@plotline.so"}
+        assert update_arg["$set"]["telegram_user_id"] == 42
+        assert "Connected as adarsh@plotline.so" in send.await_args.args[1]
+
+    @pytest.mark.asyncio
+    async def test_start_with_invalid_code_replies_error(self):
+        db = _make_db()
+        send = AsyncMock()
+        with patch.object(telegram_ingestion, "get_db", return_value=db), \
+             patch.object(telegram_ingestion, "send_telegram_message", send):
+            await process_telegram_update(_dm_update("/start expired-code"))
+        db.telegram_links.update_one.assert_not_called()
+        assert "invalid or has expired" in send.await_args.args[1]
+
+    @pytest.mark.asyncio
+    async def test_stop_unlinks(self):
+        db = _make_db()
+        db.telegram_links.delete_many.return_value.deleted_count = 1
+        send = AsyncMock()
+        with patch.object(telegram_ingestion, "get_db", return_value=db), \
+             patch.object(telegram_ingestion, "send_telegram_message", send):
+            await process_telegram_update(_dm_update("/stop"))
+        db.telegram_links.delete_many.assert_awaited_once_with({"telegram_user_id": 42})
+        assert "Disconnected" in send.await_args.args[1]
+
+    @pytest.mark.asyncio
+    async def test_unlinked_sender_gets_connect_prompt(self):
+        db = _make_db()
+        send = AsyncMock()
+        with patch.object(telegram_ingestion, "get_db", return_value=db), \
+             patch.object(telegram_ingestion, "send_telegram_message", send):
+            await process_telegram_update(_dm_update("what's up"))
+        assert "not linked" in send.await_args.args[1]
+
+    @pytest.mark.asyncio
+    async def test_linked_sender_runs_agent(self):
+        db = _make_db()
+        db.telegram_links.find_one.return_value = {
+            "user_email": "adarsh@plotline.so",
+            "telegram_user_id": 42,
+            "telegram_chat_id": 42,
+        }
+
+        async def fake_stream(**kwargs):
+            assert kwargs["user_email"] == "adarsh@plotline.so"
+            assert kwargs["source"] == "telegram"
+            yield "part one"
+            yield "part two"
+
+        observer = MagicMock()
+        observer.start = AsyncMock()
+        observer.resume = AsyncMock()
+
+        send = AsyncMock()
+        api = AsyncMock(return_value={"ok": True})
+        with patch.object(telegram_ingestion, "get_db", return_value=db), \
+             patch.object(telegram_ingestion, "send_telegram_message", send), \
+             patch.object(telegram_ingestion, "_telegram_api", api), \
+             patch.object(telegram_ingestion, "ConversationObserver", return_value=observer), \
+             patch("agent.client.stream_agent", side_effect=fake_stream):
+            await process_telegram_update(_dm_update("summarize my day"))
+
+        # Both agent chunks were sent back to the chat
+        sent_texts = [c.args[1] for c in send.await_args_list]
+        assert "part one" in sent_texts
+        assert "part two" in sent_texts
+        observer.start.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# send_telegram_message — splitting
+# ---------------------------------------------------------------------------
+
+
+class TestSendTelegramMessage:
+    @pytest.mark.asyncio
+    async def test_long_message_is_split(self):
+        api = AsyncMock(return_value={"ok": True})
+        with patch.object(telegram_ingestion, "_telegram_api", api):
+            await send_telegram_message(42, "x" * (_MAX_MESSAGE_LEN + 10))
+        assert api.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_empty_message_not_sent(self):
+        api = AsyncMock(return_value={"ok": True})
+        with patch.object(telegram_ingestion, "_telegram_api", api):
+            await send_telegram_message(42, "   ")
+        api.assert_not_called()

--- a/tools/telegram.py
+++ b/tools/telegram.py
@@ -1,0 +1,171 @@
+"""Telegram personal tool — send messages to the authenticated user's Telegram.
+
+Uses the shared Loma bot (TELEGRAM_BOT_TOKEN) to message the Telegram
+account the user linked from Integrations > Personal > Telegram. The
+mapping lives in the ``telegram_links`` collection; a user can only send
+to their own linked chat (or an explicit chat id they own).
+
+Commands:
+  telegram.py --auth-token T --user-email E send-message --text MSG
+  telegram.py --auth-token T --user-email E status
+"""
+
+import asyncio
+import json
+import os
+import sys
+import logging
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+TELEGRAM_API_BASE = "https://api.telegram.org"
+_MAX_MESSAGE_LEN = 4000
+
+
+# ── Auth ──────────────────────────────────────────────────────────────────
+
+
+def _verify_auth(auth_token: str, user_email: str) -> bool:
+    """Verify the HMAC auth token matches the user email."""
+    sys.path.insert(0, os.path.dirname(__file__))
+    from _auth_token import verify_user_auth_token
+    return verify_user_auth_token(auth_token, user_email)
+
+
+async def _get_link(user_email: str) -> dict | None:
+    """Look up the user's Telegram link in MongoDB."""
+    from motor.motor_asyncio import AsyncIOMotorClient
+
+    uri = os.environ.get("OBSERVABILITY_MONGODB_URI", "").strip()
+    if not uri:
+        raise ValueError("OBSERVABILITY_MONGODB_URI environment variable is not set")
+    db_name = os.environ.get("OBSERVABILITY_DB_NAME", "loma_observability").strip()
+    client = AsyncIOMotorClient(uri)
+    try:
+        return await client[db_name].telegram_links.find_one({"user_email": user_email})
+    finally:
+        client.close()
+
+
+# ── Commands ──────────────────────────────────────────────────────────────
+
+
+def _bot_token() -> str:
+    token = os.environ.get("TELEGRAM_BOT_TOKEN", "").strip()
+    if not token:
+        raise ValueError("TELEGRAM_BOT_TOKEN environment variable is not set")
+    return token
+
+
+def send_message(user_email: str, text: str) -> dict:
+    """Send a plain-text message to the user's own linked Telegram chat."""
+    link = asyncio.run(_get_link(user_email))
+    if not link:
+        return {
+            "error": "No Telegram account linked for this user. "
+            "Connect one from Integrations > Personal > Telegram in the dashboard."
+        }
+
+    chat_id = link["telegram_chat_id"]
+    token = _bot_token()
+    sent = []
+    remaining = text.strip()
+    while remaining:
+        chunk, remaining = remaining[:_MAX_MESSAGE_LEN], remaining[_MAX_MESSAGE_LEN:]
+        resp = requests.post(
+            f"{TELEGRAM_API_BASE}/bot{token}/sendMessage",
+            json={"chat_id": chat_id, "text": chunk},
+            timeout=30,
+        )
+        data = resp.json()
+        if not data.get("ok"):
+            return {"error": f"Telegram sendMessage failed: {data.get('description')}", "sent_chunks": len(sent)}
+        sent.append(data["result"]["message_id"])
+
+    return {"sent": True, "chat_id": chat_id, "message_ids": sent}
+
+
+def status(user_email: str) -> dict:
+    """Show whether this user has a linked Telegram account."""
+    link = asyncio.run(_get_link(user_email))
+    if not link:
+        return {"linked": False}
+    return {
+        "linked": True,
+        "telegram_username": link.get("telegram_username"),
+        "telegram_first_name": link.get("telegram_first_name"),
+    }
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────
+
+
+def _parse_single(args: list[str], flag: str, default: str | None = None) -> str | None:
+    """Extract a single value for a flag."""
+    for i, arg in enumerate(args):
+        if arg == flag and i + 1 < len(args):
+            return args[i + 1]
+    return default
+
+
+def _print_usage():
+    print(json.dumps({
+        "usage": [
+            "telegram.py --auth-token T --user-email E send-message --text MSG",
+            "telegram.py --auth-token T --user-email E status",
+        ]
+    }))
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    from dotenv import load_dotenv
+    load_dotenv()
+
+    args = sys.argv[1:]
+    auth_token = _parse_single(args, "--auth-token")
+    user_email = _parse_single(args, "--user-email")
+
+    if not auth_token or not user_email:
+        print(json.dumps({"error": "Missing required --auth-token and --user-email arguments"}))
+        sys.exit(1)
+
+    if not _verify_auth(auth_token, user_email):
+        print(json.dumps({
+            "error": "Authentication failed. The auth token is invalid, expired, or doesn't match the user email. "
+            "This is a system error — please try your request again."
+        }))
+        sys.exit(1)
+
+    filtered = []
+    skip_next = False
+    for arg in args:
+        if skip_next:
+            skip_next = False
+            continue
+        if arg in ("--auth-token", "--user-email"):
+            skip_next = True
+            continue
+        filtered.append(arg)
+
+    if not filtered:
+        _print_usage()
+
+    command = filtered[0]
+    rest = filtered[1:]
+
+    if command == "send-message":
+        text = _parse_single(rest, "--text")
+        if not text:
+            print(json.dumps({"error": "send-message requires --text"}))
+            sys.exit(1)
+        print(json.dumps(send_message(user_email, text), indent=2))
+
+    elif command == "status":
+        print(json.dumps(status(user_email), indent=2))
+
+    else:
+        print(json.dumps({"error": f"Unknown command: {command}"}))
+        _print_usage()

--- a/webhooks/telegram.py
+++ b/webhooks/telegram.py
@@ -1,0 +1,77 @@
+"""Telegram bot webhook handler.
+
+Receives updates from the Telegram Bot API on:
+
+    POST /webhooks/telegram
+
+The single shared Loma bot (token in ``TELEGRAM_BOT_TOKEN``) serves every
+Loma user. Users link their Telegram account from the dashboard
+(Integrations > Personal > Telegram), which generates a one-time code and
+a ``https://t.me/<bot>?start=<code>`` deep link. The resulting
+``/start <code>`` message is handled here and saved as a mapping in the
+``telegram_links`` collection. After linking, any DM from that Telegram
+user runs the agent as the linked Loma user.
+
+Security:
+  - If ``TELEGRAM_WEBHOOK_SECRET`` is set, the
+    ``X-Telegram-Bot-Api-Secret-Token`` header must match (constant-time
+    comparison). Configure the same value via Telegram's setWebhook
+    ``secret_token`` parameter (see POST /api/telegram/setup-webhook).
+  - Only private (DM) chats are processed; group messages are ignored.
+  - Updates are deduplicated on ``update_id``.
+"""
+
+import asyncio
+import hmac
+import json
+import logging
+import os
+
+from aiohttp import web
+
+from webhooks.telegram_ingestion import process_telegram_update
+
+logger = logging.getLogger(__name__)
+
+
+def _verify_secret(request: web.Request) -> bool:
+    """Verify X-Telegram-Bot-Api-Secret-Token if a secret is configured."""
+    secret = os.environ.get("TELEGRAM_WEBHOOK_SECRET", "").strip()
+    if not secret:
+        return True
+    header = request.headers.get("X-Telegram-Bot-Api-Secret-Token", "")
+    return hmac.compare_digest(header, secret)
+
+
+async def handle_telegram_webhook(request: web.Request) -> web.Response:
+    """Handle POST /webhooks/telegram."""
+    if not os.environ.get("TELEGRAM_BOT_TOKEN", "").strip():
+        return web.json_response({"error": "Telegram not configured"}, status=503)
+
+    if not _verify_secret(request):
+        logger.warning("[TELEGRAM-WEBHOOK] secret token mismatch")
+        return web.json_response({"error": "Unauthorized"}, status=401)
+
+    try:
+        raw_body = await request.read()
+        update = json.loads(raw_body) if raw_body else {}
+    except Exception:
+        logger.warning("[TELEGRAM-WEBHOOK] invalid JSON body")
+        return web.json_response({"error": "Invalid JSON"}, status=400)
+
+    update_id = update.get("update_id")
+    if update_id is None:
+        return web.json_response({"error": "missing update_id"}, status=400)
+
+    logger.info("[TELEGRAM-WEBHOOK] received update_id=%s", update_id)
+
+    # Ack immediately — Telegram retries on slow/failed responses. Processing
+    # (dedup, linking, agent run) happens in the background.
+    asyncio.create_task(process_telegram_update(update))
+
+    return web.json_response({"status": "accepted", "update_id": update_id})
+
+
+def setup_telegram_webhook_routes(app: web.Application) -> None:
+    """Register Telegram webhook route."""
+    app.router.add_post("/webhooks/telegram", handle_telegram_webhook)

--- a/webhooks/telegram_ingestion.py
+++ b/webhooks/telegram_ingestion.py
@@ -1,0 +1,243 @@
+"""Telegram update processing — account linking and agent runs.
+
+Handles updates dispatched by ``webhooks/telegram.py``:
+
+  - ``/start <code>``  — completes the dashboard-initiated linking flow by
+    consuming a one-time code from ``telegram_link_codes`` and saving the
+    ``telegram_user_id -> user_email`` mapping in ``telegram_links``.
+  - ``/stop``          — unlinks the Telegram account.
+  - any other DM text  — runs the agent as the linked Loma user and sends
+    the response back through the Bot API.
+
+Conversations are persisted per Telegram chat: messages in the same chat
+reuse the same Loma conversation (``metadata.telegram_chat_id``), mirroring
+how Slack threads map to conversations.
+"""
+
+import logging
+import os
+from datetime import datetime, timezone
+
+import aiohttp
+
+from observability.db import get_db
+from observability.observer import ConversationObserver
+
+logger = logging.getLogger(__name__)
+
+TELEGRAM_API_BASE = "https://api.telegram.org"
+
+# Telegram sendMessage hard limit is 4096 chars per message.
+_MAX_MESSAGE_LEN = 4000
+
+_NOT_LINKED_REPLY = (
+    "This Telegram account is not linked to Loma yet.\n\n"
+    "Open the Loma dashboard > Integrations > Personal > Telegram and "
+    "click Connect to link your account."
+)
+
+
+def _bot_token() -> str:
+    return os.environ.get("TELEGRAM_BOT_TOKEN", "").strip()
+
+
+async def _telegram_api(method: str, payload: dict) -> dict:
+    """Call a Telegram Bot API method. Returns the parsed JSON response."""
+    token = _bot_token()
+    if not token:
+        return {"ok": False, "description": "TELEGRAM_BOT_TOKEN not set"}
+    url = f"{TELEGRAM_API_BASE}/bot{token}/{method}"
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, json=payload, timeout=aiohttp.ClientTimeout(total=30)) as resp:
+                data = await resp.json()
+                if not data.get("ok"):
+                    logger.warning("[TELEGRAM] %s failed: %s", method, data.get("description"))
+                return data
+    except Exception:
+        logger.exception("[TELEGRAM] %s request error", method)
+        return {"ok": False, "description": "request error"}
+
+
+async def send_telegram_message(chat_id: int | str, text: str) -> None:
+    """Send a plain-text message, splitting at Telegram's length limit."""
+    text = (text or "").strip()
+    if not text:
+        return
+    while text:
+        chunk, text = text[:_MAX_MESSAGE_LEN], text[_MAX_MESSAGE_LEN:]
+        await _telegram_api("sendMessage", {"chat_id": chat_id, "text": chunk})
+
+
+async def _is_duplicate_update(db, update_id: int) -> bool:
+    """Dedup on update_id — Telegram redelivers on slow/failed responses."""
+    result = await db.telegram_updates.update_one(
+        {"update_id": update_id},
+        {"$setOnInsert": {
+            "update_id": update_id,
+            "received_at": datetime.now(timezone.utc),
+        }},
+        upsert=True,
+    )
+    return result.upserted_id is None
+
+
+async def _handle_start(db, message: dict, payload: str) -> None:
+    """Handle ``/start [code]`` — complete the dashboard linking flow."""
+    from_user = message.get("from", {})
+    chat_id = message["chat"]["id"]
+    telegram_user_id = from_user.get("id")
+
+    code = payload.strip()
+    if not code:
+        await send_telegram_message(chat_id, _NOT_LINKED_REPLY)
+        return
+
+    now = datetime.now(timezone.utc)
+    code_doc = await db.telegram_link_codes.find_one_and_update(
+        {"code": code, "used": False, "expires_at": {"$gt": now}},
+        {"$set": {"used": True, "used_at": now}},
+    )
+    if not code_doc:
+        await send_telegram_message(
+            chat_id,
+            "That connect link is invalid or has expired. Please generate a "
+            "new one from the Loma dashboard (Integrations > Personal > Telegram).",
+        )
+        return
+
+    user_email = code_doc["user_email"]
+    await db.telegram_links.update_one(
+        {"user_email": user_email},
+        {"$set": {
+            "user_email": user_email,
+            "telegram_user_id": telegram_user_id,
+            "telegram_chat_id": chat_id,
+            "telegram_username": from_user.get("username"),
+            "telegram_first_name": from_user.get("first_name"),
+            "linked_at": now,
+        }},
+        upsert=True,
+    )
+    # A Telegram account can only be linked to one Loma user — drop any other
+    # mapping that points at this same Telegram user.
+    await db.telegram_links.delete_many({
+        "telegram_user_id": telegram_user_id,
+        "user_email": {"$ne": user_email},
+    })
+
+    logger.info("[TELEGRAM] Linked telegram_user=%s to %s", telegram_user_id, user_email)
+    await send_telegram_message(
+        chat_id,
+        f"Connected as {user_email}. Send me a message and I'll run it "
+        "through your Loma agent. Send /stop to disconnect.",
+    )
+
+
+async def _handle_stop(db, message: dict) -> None:
+    """Handle ``/stop`` — unlink this Telegram account."""
+    telegram_user_id = message.get("from", {}).get("id")
+    chat_id = message["chat"]["id"]
+    result = await db.telegram_links.delete_many({"telegram_user_id": telegram_user_id})
+    if result.deleted_count:
+        await send_telegram_message(chat_id, "Disconnected. You can reconnect anytime from the Loma dashboard.")
+    else:
+        await send_telegram_message(chat_id, "This Telegram account was not linked to Loma.")
+
+
+async def _run_agent_for_message(db, link: dict, message: dict) -> None:
+    """Run the agent as the linked user and send the response back."""
+    from agent.client import stream_agent
+
+    chat_id = message["chat"]["id"]
+    text = (message.get("text") or "").strip()
+    user_email = link["user_email"]
+
+    await _telegram_api("sendChatAction", {"chat_id": chat_id, "action": "typing"})
+
+    try:
+        # Reuse the existing conversation for this Telegram chat, like Slack
+        # threads reuse conversations.
+        existing_convo = await db.conversations.find_one({
+            "metadata.source": "telegram",
+            "metadata.telegram_chat_id": str(chat_id),
+        })
+        metadata = {
+            "source": "telegram",
+            "prompt": text,
+            "model": os.environ.get("AGENT_DEFAULT_MODEL", "opencode-go/deepseek-v4-flash"),
+            "telegram_user_id": str(link.get("telegram_user_id")),
+            "telegram_chat_id": str(chat_id),
+            "user_name": user_email,
+        }
+        if existing_convo:
+            observer = ConversationObserver(
+                db, metadata=metadata,
+                conversation_id=existing_convo["conversation_id"],
+            )
+            await observer.resume()
+        else:
+            observer = ConversationObserver(db, metadata=metadata)
+            await observer.start()
+
+        logger.info("[TELEGRAM] Running agent for %s (chat=%s)", user_email, chat_id)
+        async for chunk in stream_agent(
+            prompt=text,
+            observer=observer,
+            source="telegram",
+            user_email=user_email,
+        ):
+            if isinstance(chunk, str):
+                await send_telegram_message(chat_id, chunk)
+        logger.info("[TELEGRAM] Agent run complete for %s (chat=%s)", user_email, chat_id)
+    except Exception as e:
+        logger.exception("[TELEGRAM] Agent run failed for %s", user_email)
+        await send_telegram_message(chat_id, f"Sorry, something went wrong: {e}")
+
+
+async def process_telegram_update(update: dict) -> None:
+    """Entry point — dispatched as a background task by the webhook handler."""
+    db = get_db()
+    if db is None:
+        logger.warning("[TELEGRAM] DB unavailable, dropping update")
+        return
+
+    try:
+        update_id = update.get("update_id")
+        if await _is_duplicate_update(db, update_id):
+            logger.info("[TELEGRAM] Duplicate update_id=%s, skipping", update_id)
+            return
+
+        message = update.get("message")
+        if not message:
+            return  # edited_message, callback_query, etc. — not supported yet
+
+        chat = message.get("chat", {})
+        if chat.get("type") != "private":
+            return  # DMs only — group chats are out of scope
+
+        from_user = message.get("from", {})
+        if from_user.get("is_bot"):
+            return
+
+        text = (message.get("text") or "").strip()
+        if not text:
+            await send_telegram_message(
+                chat["id"], "I can only handle text messages right now.")
+            return
+
+        if text.startswith("/start"):
+            await _handle_start(db, message, text[len("/start"):])
+            return
+        if text.split("@")[0].strip() == "/stop":
+            await _handle_stop(db, message)
+            return
+
+        link = await db.telegram_links.find_one({"telegram_user_id": from_user.get("id")})
+        if not link:
+            await send_telegram_message(chat["id"], _NOT_LINKED_REPLY)
+            return
+
+        await _run_agent_for_message(db, link, message)
+    except Exception:
+        logger.exception("[TELEGRAM] Failed to process update")


### PR DESCRIPTION
## Summary
- Adds **Telegram** as a personal channel: every Loma user can link their own Telegram account and chat 1:1 with their own agent from their phone.
- One shared bot (`TELEGRAM_BOT_TOKEN`) + per-user account linking — no per-user bots, no tokens for users to handle. Connect is a 2-tap `t.me` deep-link flow.

## How it works
1. User clicks **Connect Telegram** on Integrations > Personal. Backend mints a one-time code (10 min TTL, single use) and returns `https://t.me/<bot>?start=<code>`.
2. Telegram sends `/start <code>` to `POST /webhooks/telegram`; the code is consumed and the mapping is saved in the `telegram_links` collection. The dashboard polls status until linked.
3. Any DM from a linked Telegram user runs `stream_agent()` as the linked user (`source="telegram"`), and the replies go back via the Bot API. Same chat -> same Loma conversation (mirrors Slack-thread continuity).
4. `/stop` in Telegram or **Disconnect** in the dashboard unlinks.

## Security
- Optional `TELEGRAM_WEBHOOK_SECRET` verified against `X-Telegram-Bot-Api-Secret-Token` (constant-time compare); registered via setWebhook `secret_token`.
- One-time codes: 10-minute expiry, single-use, atomically consumed (`find_one_and_update`).
- DMs only — group messages ignored. Updates deduplicated on `update_id`.
- A Telegram account can be linked to only one Loma user (stale mappings dropped on relink).
- `tools/telegram.py` uses the same HMAC `--auth-token` verification as other personal tools; a user can only message their own linked chat.

## Changes
- `webhooks/telegram.py` — webhook route, secret verification, async dispatch
- `webhooks/telegram_ingestion.py` — dedup, `/start` linking, `/stop` unlink, agent run + Bot API replies (4096-char splitting)
- `api/telegram_routes.py` — `GET /api/telegram/status`, `POST/DELETE /api/telegram/link`, admin `POST /api/telegram/setup-webhook`
- `tools/telegram.py` — personal CLI tool (`send-message`, `status`)
- `agent/client.py` — telegram added to the personal-tools credential instruction
- `agent/prompt.py` — `[Source: telegram]` formatting section (plain text, mobile-friendly)
- `app.py` — route registration (webhook under `LOMA_ENABLE_WEBHOOKS`)
- `dashboard/src/lib/telegram-api.ts` — typed fetch wrappers
- `dashboard/src/app/integrations/manage/page.tsx` — Telegram card (connect deep link + status polling, disconnect)
- `tests/test_telegram_webhook.py` — 14 unit tests

## Config
| Env var | Required | Purpose |
|---|---|---|
| `TELEGRAM_BOT_TOKEN` | yes | shared bot token from @BotFather |
| `TELEGRAM_WEBHOOK_SECRET` | recommended | webhook secret_token verification |
| `TELEGRAM_WEBHOOK_URL` | optional | default url for the admin setup-webhook endpoint |

## Testing
- **Unit tests**: `tests/test_telegram_webhook.py` — 14/14 pass (secret auth, config gating, dedup, linking, unlink, unlinked-sender prompt, linked-sender agent run, message splitting). Full suite: 321 passed; the 2 failures (`test_archive_extraction`, `test_opencode_runtime`) are pre-existing on `main` (verified via stash).
- **Local closed-loop run** (isolated stack, throwaway DB, dummy bot token):
  - `POST /webhooks/telegram` with wrong secret -> 401; correct secret -> 202-style accept
  - Simulated `/start <code>` -> code consumed (single-use verified), `telegram_links` mapping created, backend log: `Linked telegram_user=777000111 to <admin>`
  - Redelivered the same `update_id` -> `Duplicate update_id=3, skipping`
  - `GET /api/telegram/status` unauthenticated -> 401; authenticated via dashboard proxy -> correct linked/unlinked payloads
  - `DELETE /api/telegram/link` via the logged-in dashboard -> unlinked

**Connected state** (after simulated `/start` linking):

![connected](https://cdn.plotline.so/loma-images/loma-pr/telegram-connected.png)

**Default state** (after disconnect):

![not connected](https://cdn.plotline.so/loma-images/loma-pr/telegram-notconnected.png)

## Notes
- This PR was generated by the Plotline IE Bot based on the request above
- Please review carefully before merging
- Rollout: create the bot via @BotFather, set `TELEGRAM_BOT_TOKEN` + `TELEGRAM_WEBHOOK_SECRET`, then call `POST /api/telegram/setup-webhook` with the public backend URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)
