### PR TITLE
feat: notification inbox — persistent notifications with conversation deep-links

### DIFF
--- a/agent/client.py
+++ b/agent/client.py
@@ -743,13 +743,27 @@ async def stream_agent(
             f"[Authenticated User: {user_email}]\n"
             f"[Personal Tools Auth Token: {auth_token}]\n"
             f"When using personal tools (gmail, google_drive, google_calendar, "
-            f"google_sheets, google_slides, google_docs_personal, slack_user, telegram), you MUST pass "
+            f"google_sheets, google_slides, google_docs_personal, slack_user, telegram, notify), you MUST pass "
             f"`--user-email {user_email} --auth-token {auth_token}`. "
             f"Never use a different user's email with --user-email.\n"
             f"IMPORTANT: Always use the personal CLI tools (e.g. `python3 tools/google_drive.py`, "
             f"`python3 tools/gmail.py`) instead of any MCP equivalents (e.g. mcp__claude_ai_Google_Drive__*, "
             f"mcp__claude_ai_Gmail__*). The CLI tools use the user's own authenticated credentials and are "
             f"more reliable. Do NOT fall back to MCP Google Drive or Gmail tools."
+        )
+
+    # Expose the conversation id so tools (e.g. tools/notify.py) can deep-link
+    # notifications back to this conversation.
+    conversation_id = getattr(observer, "conversation_id", None) if observer else None
+    if user_email and conversation_id:
+        text_parts.append(
+            f"[Conversation ID: {conversation_id}]\n"
+            f"To leave a persistent notification in this user's Loma inbox (the bell icon "
+            f"in the dashboard), run `python3 tools/notify.py --user-email {user_email} "
+            f"--auth-token {auth_token} send --title \"...\" --body \"...\" "
+            f"--conversation-id {conversation_id}`. Use it when a flow or long-running "
+            f"task finishes with a result the user should see — the notification "
+            f"deep-links back to this conversation and persists until dismissed."
         )
 
     if conversation_context:

--- a/api/notification_routes.py
+++ b/api/notification_routes.py
@@ -1,0 +1,132 @@
+"""Notification inbox routes.
+
+Per-user persistent notifications (see observability/notifications.py).
+`read` clears the unread badge; `dismissed` removes the card from the
+inbox list. All routes are scoped to the authenticated user.
+"""
+
+import logging
+from datetime import datetime, timezone
+
+from aiohttp import web
+
+from observability.db import get_db
+from api.auth_helpers import get_user_email
+
+logger = logging.getLogger(__name__)
+
+_MAX_LIMIT = 100
+
+
+def _serialize(doc: dict) -> dict:
+    """Stringify _id and isoformat datetimes for JSON responses."""
+    out = {}
+    for key, value in doc.items():
+        if key == "_id":
+            continue
+        if isinstance(value, datetime):
+            if value.tzinfo is None:
+                out[key] = value.isoformat() + "Z"
+            else:
+                out[key] = value.isoformat()
+        else:
+            out[key] = value
+    return out
+
+
+async def handle_list_notifications(request: web.Request) -> web.Response:
+    """GET /api/notifications?include_dismissed=1&limit=50 — own inbox, newest first."""
+    db = get_db()
+    if db is None:
+        return web.json_response({"error": "Observability not configured"}, status=503)
+    user_email = get_user_email(request)
+    if not user_email:
+        return web.json_response({"error": "Authentication required"}, status=401)
+
+    try:
+        limit = min(int(request.query.get("limit", "50")), _MAX_LIMIT)
+    except ValueError:
+        limit = 50
+    query: dict = {"user_email": user_email}
+    if request.query.get("include_dismissed") not in ("1", "true"):
+        query["dismissed"] = {"$ne": True}
+
+    docs = await db.notifications.find(query).sort("created_at", -1).to_list(limit)
+    return web.json_response({"notifications": [_serialize(d) for d in docs]})
+
+
+async def handle_unread_count(request: web.Request) -> web.Response:
+    """GET /api/notifications/unread-count — cheap poll target for the bell badge."""
+    db = get_db()
+    if db is None:
+        return web.json_response({"count": 0})
+    user_email = get_user_email(request)
+    if not user_email:
+        return web.json_response({"error": "Authentication required"}, status=401)
+
+    count = await db.notifications.count_documents({
+        "user_email": user_email,
+        "read": {"$ne": True},
+        "dismissed": {"$ne": True},
+    })
+    return web.json_response({"count": count})
+
+
+async def handle_read_all(request: web.Request) -> web.Response:
+    """POST /api/notifications/read-all — mark every own notification read."""
+    db = get_db()
+    if db is None:
+        return web.json_response({"error": "Observability not configured"}, status=503)
+    user_email = get_user_email(request)
+    if not user_email:
+        return web.json_response({"error": "Authentication required"}, status=401)
+
+    result = await db.notifications.update_many(
+        {"user_email": user_email, "read": {"$ne": True}},
+        {"$set": {"read": True, "read_at": datetime.now(timezone.utc)}},
+    )
+    return web.json_response({"updated": result.modified_count})
+
+
+async def _update_own_notification(request: web.Request, updates: dict) -> web.Response:
+    """Shared guard: update a notification only if it belongs to the caller."""
+    db = get_db()
+    if db is None:
+        return web.json_response({"error": "Observability not configured"}, status=503)
+    user_email = get_user_email(request)
+    if not user_email:
+        return web.json_response({"error": "Authentication required"}, status=401)
+
+    notification_id = request.match_info.get("notification_id", "")
+    result = await db.notifications.update_one(
+        {"notification_id": notification_id, "user_email": user_email},
+        {"$set": updates},
+    )
+    if result.matched_count == 0:
+        return web.json_response({"error": "Notification not found"}, status=404)
+    return web.json_response({"ok": True})
+
+
+async def handle_mark_read(request: web.Request) -> web.Response:
+    """POST /api/notifications/{notification_id}/read"""
+    return await _update_own_notification(
+        request, {"read": True, "read_at": datetime.now(timezone.utc)},
+    )
+
+
+async def handle_dismiss(request: web.Request) -> web.Response:
+    """POST /api/notifications/{notification_id}/dismiss — also marks read."""
+    return await _update_own_notification(
+        request,
+        {"dismissed": True, "read": True, "dismissed_at": datetime.now(timezone.utc)},
+    )
+
+
+def setup_notification_routes(app: web.Application):
+    """Register notification inbox routes on the aiohttp app."""
+    # Static paths before {notification_id} routes.
+    app.router.add_get("/api/notifications", handle_list_notifications)
+    app.router.add_get("/api/notifications/unread-count", handle_unread_count)
+    app.router.add_post("/api/notifications/read-all", handle_read_all)
+    app.router.add_post("/api/notifications/{notification_id}/read", handle_mark_read)
+    app.router.add_post("/api/notifications/{notification_id}/dismiss", handle_dismiss)

--- a/api/routes.py
+++ b/api/routes.py
@@ -1850,5 +1850,9 @@ def setup_api_routes(app: web.Application):
     from api.file_routes import setup_file_routes
     setup_file_routes(app)
 
+    # Notification inbox routes (persistent per-user notifications)
+    from api.notification_routes import setup_notification_routes
+    setup_notification_routes(app)
+
     # CORS catch-all must be last
     app.router.add_route("OPTIONS", "/api/{path:.*}", cors_options)

--- a/dashboard/src/app/notifications/page.tsx
+++ b/dashboard/src/app/notifications/page.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import {
+  RiCheckDoubleLine,
+  RiCloseLine,
+  RiNotification3Line,
+  RiRefreshLine,
+} from "@remixicon/react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EmptyState } from "@/components/EmptyState";
+import ClientTimestamp from "@/components/ClientTimestamp";
+import { cn } from "@/lib/utils";
+import { basePath } from "@/lib/api";
+import {
+  LomaNotification,
+  dismissNotification,
+  fetchNotifications,
+  markAllNotificationsRead,
+  markNotificationRead,
+} from "@/lib/notifications-api";
+import { useNotifications } from "@/lib/NotificationsContext";
+
+export default function NotificationsPage() {
+  const router = useRouter();
+  const { refresh: refreshUnreadCount } = useNotifications();
+  const [notifications, setNotifications] = useState<LomaNotification[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const loadData = useCallback(async () => {
+    try {
+      setNotifications(await fetchNotifications({ limit: 100 }));
+    } catch (e) {
+      console.error("Failed to load notifications:", e);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  const handleOpen = async (n: LomaNotification) => {
+    if (!n.read) {
+      setNotifications((prev) =>
+        prev.map((x) => (x.notification_id === n.notification_id ? { ...x, read: true } : x)),
+      );
+      markNotificationRead(n.notification_id)
+        .then(refreshUnreadCount)
+        .catch(() => {});
+    }
+    if (n.conversation_id) {
+      router.push(`${basePath}/chat?continue=${n.conversation_id}`);
+    } else if (n.link) {
+      window.open(n.link, "_blank", "noopener,noreferrer");
+    }
+  };
+
+  const handleDismiss = async (n: LomaNotification) => {
+    setNotifications((prev) => prev.filter((x) => x.notification_id !== n.notification_id));
+    try {
+      await dismissNotification(n.notification_id);
+      refreshUnreadCount();
+    } catch (e) {
+      console.error("Failed to dismiss notification:", e);
+      loadData();
+    }
+  };
+
+  const handleMarkAllRead = async () => {
+    setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
+    try {
+      await markAllNotificationsRead();
+      refreshUnreadCount();
+    } catch (e) {
+      console.error("Failed to mark all read:", e);
+      loadData();
+    }
+  };
+
+  const hasUnread = notifications.some((n) => !n.read);
+
+  return (
+    <div className="max-w-2xl mx-auto px-4 py-6 space-y-4">
+      {/* Header */}
+      <div className="pwa-header-offset flex items-center justify-between">
+        <h1 className="text-lg font-semibold text-foreground">Notifications</h1>
+        <div className="flex items-center gap-1">
+          {hasUnread && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleMarkAllRead}
+                  className="text-muted-foreground hover:text-foreground press-scale h-8 w-8 p-0"
+                >
+                  <RiCheckDoubleLine size={16} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Mark all as read</TooltipContent>
+            </Tooltip>
+          )}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => loadData()}
+                className="text-muted-foreground hover:text-foreground press-scale h-8 w-8 p-0"
+              >
+                <RiRefreshLine size={16} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Refresh</TooltipContent>
+          </Tooltip>
+        </div>
+      </div>
+
+      {/* List */}
+      <div className="space-y-2">
+        {loading ? (
+          <>
+            <Skeleton className="h-16 w-full" />
+            <Skeleton className="h-16 w-full" />
+            <Skeleton className="h-16 w-full" />
+          </>
+        ) : notifications.length === 0 ? (
+          <EmptyState
+            icon={RiNotification3Line}
+            title="No notifications"
+            description="Flows and long-running tasks will leave their results here"
+          />
+        ) : (
+          notifications.map((n, idx) => (
+            <Card
+              key={n.notification_id}
+              className={cn(
+                "p-3 active:bg-muted/50 transition-colors animate-fade-in-up",
+                (n.conversation_id || n.link) && "cursor-pointer",
+                !n.read && "bg-brand-50/40",
+              )}
+              style={{ animationDelay: `${Math.min(idx * 30, 300)}ms` }}
+              onClick={() => handleOpen(n)}
+            >
+              <CardContent className="p-0">
+                <div className="flex items-start gap-2.5">
+                  <div
+                    className={cn(
+                      "h-2 w-2 rounded-full mt-1.5 shrink-0",
+                      n.read ? "bg-transparent" : "bg-brand-500",
+                    )}
+                  />
+                  <div className="flex-1 min-w-0">
+                    <div
+                      className={cn(
+                        "text-[13px] truncate",
+                        n.read ? "font-normal text-foreground/80" : "font-medium text-foreground",
+                      )}
+                    >
+                      {n.title}
+                    </div>
+                    {n.body && (
+                      <div className="text-xs text-muted-foreground mt-0.5 line-clamp-2">
+                        {n.body}
+                      </div>
+                    )}
+                    <div className="flex items-center gap-2 mt-1.5 text-xs text-muted-foreground">
+                      <ClientTimestamp iso={n.created_at} variant="short" />
+                      {n.conversation_id && <span>Open conversation →</span>}
+                    </div>
+                  </div>
+                  <div className="shrink-0" onClick={(e) => e.stopPropagation()}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon-xs"
+                          onClick={() => handleDismiss(n)}
+                          className="text-muted-foreground hover:text-foreground"
+                          aria-label="Dismiss notification"
+                        >
+                          <RiCloseLine size={14} />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>Dismiss</TooltipContent>
+                    </Tooltip>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/app/notifications/page.tsx
+++ b/dashboard/src/app/notifications/page.tsx
@@ -182,7 +182,7 @@ export default function NotificationsPage() {
                           variant="ghost"
                           size="icon-xs"
                           onClick={() => handleDismiss(n)}
-                          className="text-muted-foreground hover:text-foreground"
+                          className="text-muted-foreground hover:text-foreground h-8 w-8 md:h-6 md:w-6"
                           aria-label="Dismiss notification"
                         >
                           <RiCloseLine size={14} />

--- a/dashboard/src/components/Providers.tsx
+++ b/dashboard/src/components/Providers.tsx
@@ -4,6 +4,7 @@ import { SessionProvider } from "next-auth/react";
 import { UserProvider } from "../lib/UserContext";
 import { ThemeProvider } from "../lib/ThemeContext";
 import { TaskAttentionProvider } from "../lib/TaskAttentionContext";
+import { NotificationsProvider } from "../lib/NotificationsContext";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
 export default function Providers({ children }: { children: React.ReactNode }) {
@@ -11,11 +12,13 @@ export default function Providers({ children }: { children: React.ReactNode }) {
     <SessionProvider>
       <UserProvider>
         <TaskAttentionProvider>
+          <NotificationsProvider>
           <ThemeProvider>
             <TooltipProvider delayDuration={300}>
               {children}
             </TooltipProvider>
           </ThemeProvider>
+          </NotificationsProvider>
         </TaskAttentionProvider>
       </UserProvider>
     </SessionProvider>

--- a/dashboard/src/components/Sidebar.tsx
+++ b/dashboard/src/components/Sidebar.tsx
@@ -8,6 +8,7 @@ import { fetchConversations, fetchPinnedConversations, fetchPoolStatus } from ".
 import type { Conversation, PoolStatus } from "../lib/api";
 import { useUser } from "../lib/UserContext";
 import { useTaskAttention } from "../lib/TaskAttentionContext";
+import { useNotifications } from "../lib/NotificationsContext";
 import type { SystemRole } from "../lib/governance-api";
 import CrosscutIcon from "./CrosscutIcon";
 import ChatContextMenu from "./ChatContextMenu";
@@ -39,6 +40,7 @@ import {
   RiMenuFoldLine,
   RiMenuUnfoldLine,
   RiExpandUpDownLine,
+  RiNotification3Line,
 } from "@remixicon/react";
 
 type NavItem = {
@@ -67,6 +69,12 @@ const navigation: NavItem[] = [
     name: "Activity",
     href: "/conversations",
     icon: <RiGridLine size={16} />,
+  },
+  {
+    name: "Notifications",
+    href: "/notifications",
+    badgeKey: "notifications",
+    icon: <RiNotification3Line size={16} />,
   },
   {
     name: "My Usage",
@@ -351,7 +359,8 @@ export default function Sidebar({
   const [myConversations, setMyConversations] = useState<Conversation[]>([]);
   const [pinnedConversations, setPinnedConversations] = useState<Conversation[]>([]);
   const { needsInputCount } = useTaskAttention();
-  const badgeCounts: Record<string, number> = { tasks: needsInputCount };
+  const { unreadCount: unreadNotificationCount } = useNotifications();
+  const badgeCounts: Record<string, number> = { tasks: needsInputCount, notifications: unreadNotificationCount };
   const [poolStatus, setPoolStatus] = useState<PoolStatus | null>(null);
 
   // Filter nav items by role

--- a/dashboard/src/components/Sidebar.tsx
+++ b/dashboard/src/components/Sidebar.tsx
@@ -61,6 +61,12 @@ const navigation: NavItem[] = [
     icon: <RiCheckboxLine size={16} />,
   },
   {
+    name: "Notifications",
+    href: "/notifications",
+    badgeKey: "notifications",
+    icon: <RiNotification3Line size={16} />,
+  },
+  {
     name: "Chat",
     href: "/chat",
     icon: <RiChat1Line size={16} />,
@@ -69,12 +75,6 @@ const navigation: NavItem[] = [
     name: "Activity",
     href: "/conversations",
     icon: <RiGridLine size={16} />,
-  },
-  {
-    name: "Notifications",
-    href: "/notifications",
-    badgeKey: "notifications",
-    icon: <RiNotification3Line size={16} />,
   },
   {
     name: "My Usage",

--- a/dashboard/src/lib/NotificationsContext.tsx
+++ b/dashboard/src/lib/NotificationsContext.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+import { useSession } from "next-auth/react";
+import { fetchUnreadNotificationCount } from "./notifications-api";
+
+const POLL_INTERVAL_MS = 5000;
+
+interface NotificationsValue {
+  /** Number of the user's notifications that are unread and not dismissed. */
+  unreadCount: number;
+  refresh: () => void;
+}
+
+const NotificationsContext = createContext<NotificationsValue>({
+  unreadCount: 0,
+  refresh: () => {},
+});
+
+export function useNotifications() {
+  return useContext(NotificationsContext);
+}
+
+export function NotificationsProvider({ children }: { children: React.ReactNode }) {
+  const { status } = useSession();
+  const [unreadCount, setUnreadCount] = useState(0);
+
+  const refresh = useCallback(async () => {
+    try {
+      setUnreadCount(await fetchUnreadNotificationCount());
+    } catch {
+      // Transient poll failures keep the last known count.
+    }
+  }, []);
+
+  useEffect(() => {
+    if (status !== "authenticated") return;
+    refresh();
+    const interval = setInterval(refresh, POLL_INTERVAL_MS);
+    return () => clearInterval(interval);
+  }, [status, refresh]);
+
+  return (
+    <NotificationsContext.Provider value={{ unreadCount, refresh }}>
+      {children}
+    </NotificationsContext.Provider>
+  );
+}

--- a/dashboard/src/lib/notifications-api.ts
+++ b/dashboard/src/lib/notifications-api.ts
@@ -1,0 +1,64 @@
+/**
+ * Notifications API client — typed fetch wrappers for the notification inbox.
+ */
+
+const API_BASE = process.env.NEXT_PUBLIC_BASE_PATH || "";
+
+// ── Types ─────────────────────────────────────────────────────────────────
+
+export interface LomaNotification {
+  notification_id: string;
+  user_email: string;
+  title: string;
+  body: string;
+  conversation_id?: string | null;
+  flow_id?: string | null;
+  link?: string | null;
+  source: string;
+  read: boolean;
+  dismissed: boolean;
+  created_at: string;
+  read_at?: string;
+  dismissed_at?: string;
+}
+
+// ── Fetchers ──────────────────────────────────────────────────────────────
+
+export async function fetchNotifications(
+  options: { includeDismissed?: boolean; limit?: number } = {},
+): Promise<LomaNotification[]> {
+  const params = new URLSearchParams();
+  if (options.includeDismissed) params.set("include_dismissed", "1");
+  if (options.limit) params.set("limit", String(options.limit));
+  const qs = params.toString();
+  const res = await fetch(`${API_BASE}/api/notifications${qs ? `?${qs}` : ""}`);
+  if (!res.ok) throw new Error(`Failed to fetch notifications: ${res.status}`);
+  const data = await res.json();
+  return data.notifications ?? [];
+}
+
+export async function fetchUnreadNotificationCount(): Promise<number> {
+  const res = await fetch(`${API_BASE}/api/notifications/unread-count`);
+  if (!res.ok) throw new Error(`Failed to fetch unread count: ${res.status}`);
+  const data = await res.json();
+  return data.count ?? 0;
+}
+
+export async function markNotificationRead(notificationId: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/notifications/${notificationId}/read`, {
+    method: "POST",
+  });
+  if (!res.ok) throw new Error(`Failed to mark notification read: ${res.status}`);
+}
+
+export async function markAllNotificationsRead(): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/notifications/read-all`, { method: "POST" });
+  if (!res.ok) throw new Error(`Failed to mark all read: ${res.status}`);
+}
+
+export async function dismissNotification(notificationId: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/notifications/${notificationId}/dismiss`, {
+    method: "POST",
+  });
+  if (!res.ok) throw new Error(`Failed to dismiss notification: ${res.status}`);
+}

--- a/observability/db.py
+++ b/observability/db.py
@@ -104,6 +104,15 @@ async def init_observability():
     await _db.push_subscriptions.create_index("subscription.endpoint", unique=True)
     await _db.push_subscriptions.create_index("user_email")
 
+    # Notification inbox — persistent per-user notifications
+    await _db.notifications.create_index("notification_id", unique=True)
+    await _db.notifications.create_index(
+        [("user_email", 1), ("dismissed", 1), ("created_at", -1)],
+    )
+    await _db.notifications.create_index(
+        [("user_email", 1), ("read", 1), ("dismissed", 1)],
+    )
+
     # Projects collection (chat organization)
     await _db.projects.create_index("project_id", unique=True)
     await _db.projects.create_index("created_by")

--- a/observability/notifications.py
+++ b/observability/notifications.py
@@ -1,0 +1,83 @@
+"""Notification inbox — persistent per-user notifications.
+
+One doc per notification in the `notifications` collection. Created by
+agents/flows via tools/notify.py (or backend code), listed and managed by
+the dashboard through api/notification_routes.py. A notification persists
+until the user explicitly dismisses it; `read` only clears the unread badge.
+
+Doc shape:
+    notification_id: str (uuid4)
+    user_email: str            — owner (recipient)
+    title: str
+    body: str
+    conversation_id: str|None  — deep-link target (/chat?continue=<id>)
+    flow_id: str|None
+    link: str|None             — fallback URL when there is no conversation
+    source: str                — "flow" | "agent" | "system"
+    read: bool
+    dismissed: bool
+    created_at: datetime (utc)
+"""
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+from observability.push import fire_user_push
+
+MAX_TITLE_LEN = 200
+MAX_BODY_LEN = 2000
+
+
+async def create_notification(
+    db,
+    *,
+    user_email: str,
+    title: str,
+    body: str = "",
+    conversation_id: str | None = None,
+    flow_id: str | None = None,
+    link: str | None = None,
+    source: str = "agent",
+    fire_push: bool = True,
+) -> dict:
+    """Insert a notification and (best-effort) fire a web push to its owner.
+
+    Returns the inserted doc (without Mongo's _id). Raises ValueError on
+    missing required fields.
+    """
+    user_email = (user_email or "").strip().lower()
+    title = (title or "").strip()
+    if not user_email or "@" not in user_email:
+        raise ValueError("user_email is required")
+    if not title:
+        raise ValueError("title is required")
+
+    doc = {
+        "notification_id": str(uuid.uuid4()),
+        "user_email": user_email,
+        "title": title[:MAX_TITLE_LEN],
+        "body": (body or "").strip()[:MAX_BODY_LEN],
+        "conversation_id": conversation_id or None,
+        "flow_id": flow_id or None,
+        "link": (link or "").strip() or None,
+        "source": source or "agent",
+        "read": False,
+        "dismissed": False,
+        "created_at": datetime.now(timezone.utc),
+    }
+    await db.notifications.insert_one({**doc})
+
+    if fire_push:
+        base_url = os.environ.get("PUBLIC_BASE_URL", "").rstrip("/")
+        if doc["conversation_id"]:
+            url = f"{base_url}/chat?continue={doc['conversation_id']}"
+        else:
+            url = doc["link"] or f"{base_url}/notifications"
+        fire_user_push(
+            db, user_email,
+            title=doc["title"], body=doc["body"],
+            url=url, tag=doc["notification_id"],
+        )
+
+    return doc

--- a/observability/push.py
+++ b/observability/push.py
@@ -127,3 +127,65 @@ def fire_task_push(db, conversation_id: str):
     except RuntimeError:
         # No running loop (e.g. sync shutdown path) — skip.
         pass
+
+
+async def send_user_push(db, user_email: str, *, title: str, body: str = "",
+                         url: str = "", tag: str = ""):
+    """Send a web push to every browser a user has subscribed.
+
+    Generic sibling of send_task_needs_input_push — used by the notification
+    inbox so a new inbox notification also reaches the user's lock screen.
+    All failures are swallowed into logs.
+    """
+    try:
+        config = _vapid_config()
+        if not config or db is None or not user_email:
+            return
+        private_key, subject = config
+
+        subscriptions = await db.push_subscriptions.find(
+            {"user_email": user_email}).to_list(50)
+        if not subscriptions:
+            return
+
+        payload = json.dumps({
+            "title": title,
+            "body": (body or "")[:120],
+            "tag": tag or title,
+            "url": url,
+        })
+
+        from pywebpush import WebPushException
+
+        expired: list[str] = []
+        for entry in subscriptions:
+            subscription = entry.get("subscription") or {}
+            try:
+                await asyncio.to_thread(_send_one, subscription, payload, private_key, subject)
+            except WebPushException as e:
+                status_code = getattr(e.response, "status_code", None)
+                if status_code in (404, 410):
+                    expired.append(subscription.get("endpoint", ""))
+                else:
+                    logger.warning("Push: send failed for %s: %s", user_email, e)
+            except Exception as e:
+                logger.warning("Push: send failed for %s: %s", user_email, e)
+
+        if expired:
+            await db.push_subscriptions.delete_many(
+                {"subscription.endpoint": {"$in": expired}},
+            )
+    except Exception as e:
+        logger.warning("Push: user push for %s failed: %s", user_email, e)
+
+
+def fire_user_push(db, user_email: str, *, title: str, body: str = "",
+                   url: str = "", tag: str = ""):
+    """Fire-and-forget wrapper around send_user_push."""
+    try:
+        asyncio.create_task(
+            send_user_push(db, user_email, title=title, body=body, url=url, tag=tag)
+        )
+    except RuntimeError:
+        # No running loop (e.g. sync shutdown path) — skip.
+        pass

--- a/tests/test_notification_routes.py
+++ b/tests/test_notification_routes.py
@@ -1,0 +1,201 @@
+"""Tests for the notification inbox routes and creation helper."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from api.notification_routes import (
+    handle_dismiss,
+    handle_list_notifications,
+    handle_mark_read,
+    handle_read_all,
+    handle_unread_count,
+)
+from observability.notifications import create_notification
+
+
+class FakeRequest(dict):
+    def __init__(self, *, user_email="", role="chatter", query=None,
+                 notification_id="notif-1"):
+        super().__init__(user_email=user_email, system_role=role)
+        self.match_info = {"notification_id": notification_id}
+        self.query = query or {}
+
+
+def response_json(response):
+    return json.loads(response.body)
+
+
+def _db_with_find(docs):
+    db = MagicMock()
+    cursor = MagicMock()
+    cursor.sort.return_value = cursor
+    cursor.to_list = AsyncMock(return_value=docs)
+    db.notifications.find.return_value = cursor
+    return db
+
+
+# ── List ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_list_requires_auth():
+    with patch("api.notification_routes.get_db", return_value=MagicMock()):
+        response = await handle_list_notifications(FakeRequest(user_email=""))
+    assert response.status == 401
+
+
+@pytest.mark.asyncio
+async def test_list_scopes_to_user_and_excludes_dismissed():
+    db = _db_with_find([
+        {"_id": "x", "notification_id": "n1", "user_email": "user@example.com",
+         "title": "Hello", "read": False, "dismissed": False},
+    ])
+    with patch("api.notification_routes.get_db", return_value=db):
+        response = await handle_list_notifications(FakeRequest(user_email="user@example.com"))
+    assert response.status == 200
+    query = db.notifications.find.call_args[0][0]
+    assert query["user_email"] == "user@example.com"
+    assert query["dismissed"] == {"$ne": True}
+    body = response_json(response)
+    assert body["notifications"][0]["notification_id"] == "n1"
+    assert "_id" not in body["notifications"][0]
+
+
+@pytest.mark.asyncio
+async def test_list_can_include_dismissed():
+    db = _db_with_find([])
+    with patch("api.notification_routes.get_db", return_value=db):
+        response = await handle_list_notifications(
+            FakeRequest(user_email="user@example.com", query={"include_dismissed": "1"}),
+        )
+    assert response.status == 200
+    query = db.notifications.find.call_args[0][0]
+    assert "dismissed" not in query
+
+
+# ── Unread count ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_unread_count_scopes_to_user():
+    db = MagicMock()
+    db.notifications.count_documents = AsyncMock(return_value=3)
+    with patch("api.notification_routes.get_db", return_value=db):
+        response = await handle_unread_count(FakeRequest(user_email="user@example.com"))
+    assert response.status == 200
+    assert response_json(response)["count"] == 3
+    query = db.notifications.count_documents.call_args[0][0]
+    assert query["user_email"] == "user@example.com"
+    assert query["read"] == {"$ne": True}
+    assert query["dismissed"] == {"$ne": True}
+
+
+@pytest.mark.asyncio
+async def test_unread_count_zero_without_db():
+    with patch("api.notification_routes.get_db", return_value=None):
+        response = await handle_unread_count(FakeRequest(user_email="user@example.com"))
+    assert response.status == 200
+    assert response_json(response)["count"] == 0
+
+
+# ── Mark read / dismiss ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_mark_read_updates_own_notification():
+    db = MagicMock()
+    db.notifications.update_one = AsyncMock(return_value=MagicMock(matched_count=1))
+    with patch("api.notification_routes.get_db", return_value=db):
+        response = await handle_mark_read(
+            FakeRequest(user_email="user@example.com", notification_id="n1"),
+        )
+    assert response.status == 200
+    query, updates = db.notifications.update_one.call_args[0]
+    assert query == {"notification_id": "n1", "user_email": "user@example.com"}
+    assert updates["$set"]["read"] is True
+
+
+@pytest.mark.asyncio
+async def test_mark_read_404_for_other_users_notification():
+    db = MagicMock()
+    db.notifications.update_one = AsyncMock(return_value=MagicMock(matched_count=0))
+    with patch("api.notification_routes.get_db", return_value=db):
+        response = await handle_mark_read(
+            FakeRequest(user_email="intruder@example.com", notification_id="n1"),
+        )
+    assert response.status == 404
+
+
+@pytest.mark.asyncio
+async def test_dismiss_sets_dismissed_and_read():
+    db = MagicMock()
+    db.notifications.update_one = AsyncMock(return_value=MagicMock(matched_count=1))
+    with patch("api.notification_routes.get_db", return_value=db):
+        response = await handle_dismiss(
+            FakeRequest(user_email="user@example.com", notification_id="n1"),
+        )
+    assert response.status == 200
+    updates = db.notifications.update_one.call_args[0][1]["$set"]
+    assert updates["dismissed"] is True
+    assert updates["read"] is True
+
+
+@pytest.mark.asyncio
+async def test_read_all_scopes_to_user():
+    db = MagicMock()
+    db.notifications.update_many = AsyncMock(return_value=MagicMock(modified_count=4))
+    with patch("api.notification_routes.get_db", return_value=db):
+        response = await handle_read_all(FakeRequest(user_email="user@example.com"))
+    assert response.status == 200
+    assert response_json(response)["updated"] == 4
+    query = db.notifications.update_many.call_args[0][0]
+    assert query["user_email"] == "user@example.com"
+
+
+# ── create_notification helper ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_notification_inserts_doc_and_fires_push():
+    db = MagicMock()
+    db.notifications.insert_one = AsyncMock()
+    with patch("observability.notifications.fire_user_push") as fire:
+        doc = await create_notification(
+            db,
+            user_email="User@Example.com",
+            title="Flow finished",
+            body="3 critical tickets",
+            conversation_id="conv-42",
+            source="flow",
+        )
+    assert doc["user_email"] == "user@example.com"
+    assert doc["title"] == "Flow finished"
+    assert doc["conversation_id"] == "conv-42"
+    assert doc["read"] is False
+    assert doc["dismissed"] is False
+    db.notifications.insert_one.assert_awaited_once()
+    fire.assert_called_once()
+    assert "conv-42" in fire.call_args.kwargs["url"]
+
+
+@pytest.mark.asyncio
+async def test_create_notification_requires_title_and_email():
+    db = MagicMock()
+    db.notifications.insert_one = AsyncMock()
+    with pytest.raises(ValueError):
+        await create_notification(db, user_email="user@example.com", title="  ")
+    with pytest.raises(ValueError):
+        await create_notification(db, user_email="not-an-email", title="Hi")
+
+
+@pytest.mark.asyncio
+async def test_create_notification_can_skip_push():
+    db = MagicMock()
+    db.notifications.insert_one = AsyncMock()
+    with patch("observability.notifications.fire_user_push") as fire:
+        await create_notification(
+            db, user_email="user@example.com", title="Quiet", fire_push=False,
+        )
+    fire.assert_not_called()

--- a/tools/notify.py
+++ b/tools/notify.py
@@ -1,0 +1,187 @@
+"""Notify personal tool — leave a persistent notification in the user's Loma inbox.
+
+Creates a doc in the `notifications` collection (see
+observability/notifications.py) and best-effort fires a web push to the
+user's subscribed browsers. Use at the end of a flow run or long task so
+the result surfaces under the bell icon in the dashboard and deep-links
+back to this conversation.
+
+Commands:
+  notify.py --auth-token T --user-email E send --title TITLE [--body BODY] \
+      [--conversation-id ID] [--link URL]
+  notify.py --auth-token T --user-email E list [--limit N]
+"""
+
+import asyncio
+import json
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+
+
+# ── Auth ──────────────────────────────────────────────────────────────────
+
+
+def _verify_auth(auth_token: str, user_email: str) -> bool:
+    """Verify the HMAC auth token matches the user email."""
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    from _auth_token import verify_user_auth_token
+    return verify_user_auth_token(auth_token, user_email)
+
+
+def _get_client():
+    from motor.motor_asyncio import AsyncIOMotorClient
+
+    uri = os.environ.get("OBSERVABILITY_MONGODB_URI", "").strip()
+    if not uri:
+        raise ValueError("OBSERVABILITY_MONGODB_URI environment variable is not set")
+    db_name = os.environ.get("OBSERVABILITY_DB_NAME", "loma_observability").strip()
+    client = AsyncIOMotorClient(uri)
+    return client, client[db_name]
+
+
+# ── Commands ──────────────────────────────────────────────────────────────
+
+
+async def _send(user_email: str, title: str, body: str,
+                conversation_id: str | None, link: str | None) -> dict:
+    from observability.notifications import create_notification
+    from observability.push import send_user_push
+
+    client, db = _get_client()
+    try:
+        doc = await create_notification(
+            db,
+            user_email=user_email,
+            title=title,
+            body=body,
+            conversation_id=conversation_id,
+            link=link,
+            source="agent",
+            fire_push=False,  # fire-and-forget tasks die with this short-lived CLI; send inline instead
+        )
+        base_url = os.environ.get("PUBLIC_BASE_URL", "").rstrip("/")
+        if doc.get("conversation_id"):
+            url = f"{base_url}/chat?continue={doc['conversation_id']}"
+        else:
+            url = doc.get("link") or f"{base_url}/notifications"
+        await send_user_push(
+            db, user_email,
+            title=doc["title"], body=doc["body"], url=url, tag=doc["notification_id"],
+        )
+        return {
+            "created": True,
+            "notification_id": doc["notification_id"],
+            "conversation_id": doc.get("conversation_id"),
+        }
+    finally:
+        client.close()
+
+
+async def _list(user_email: str, limit: int) -> dict:
+    client, db = _get_client()
+    try:
+        docs = await db.notifications.find(
+            {"user_email": user_email, "dismissed": {"$ne": True}},
+        ).sort("created_at", -1).to_list(limit)
+        return {"notifications": [
+            {
+                "notification_id": d["notification_id"],
+                "title": d.get("title"),
+                "body": d.get("body"),
+                "conversation_id": d.get("conversation_id"),
+                "read": d.get("read", False),
+                "created_at": d["created_at"].isoformat() if d.get("created_at") else None,
+            }
+            for d in docs
+        ]}
+    finally:
+        client.close()
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────
+
+
+def _parse_single(args: list[str], flag: str, default: str | None = None) -> str | None:
+    """Extract a single value for a flag."""
+    for i, arg in enumerate(args):
+        if arg == flag and i + 1 < len(args):
+            return args[i + 1]
+    return default
+
+
+def _print_usage():
+    print(json.dumps({
+        "usage": [
+            "notify.py --auth-token T --user-email E send --title TITLE "
+            "[--body BODY] [--conversation-id ID] [--link URL]",
+            "notify.py --auth-token T --user-email E list [--limit N]",
+        ]
+    }))
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    from dotenv import load_dotenv
+    load_dotenv()
+
+    args = sys.argv[1:]
+    auth_token = _parse_single(args, "--auth-token")
+    user_email = _parse_single(args, "--user-email")
+
+    if not auth_token or not user_email:
+        print(json.dumps({"error": "Missing required --auth-token and --user-email arguments"}))
+        sys.exit(1)
+
+    if not _verify_auth(auth_token, user_email):
+        print(json.dumps({
+            "error": "Authentication failed. The auth token is invalid, expired, or doesn't "
+            "match the user email. This is a system error — please try your request again."
+        }))
+        sys.exit(1)
+
+    filtered = []
+    skip_next = False
+    for arg in args:
+        if skip_next:
+            skip_next = False
+            continue
+        if arg in ("--auth-token", "--user-email"):
+            skip_next = True
+            continue
+        filtered.append(arg)
+
+    if not filtered:
+        _print_usage()
+
+    command = filtered[0]
+    rest = filtered[1:]
+
+    if command == "send":
+        title = _parse_single(rest, "--title")
+        if not title:
+            print(json.dumps({"error": "send requires --title"}))
+            sys.exit(1)
+        body = _parse_single(rest, "--body", "") or ""
+        conversation_id = _parse_single(rest, "--conversation-id")
+        link = _parse_single(rest, "--link")
+        try:
+            result = asyncio.run(_send(user_email, title, body, conversation_id, link))
+        except ValueError as e:
+            result = {"error": str(e)}
+        print(json.dumps(result, indent=2))
+        if "error" in result:
+            sys.exit(1)
+
+    elif command == "list":
+        try:
+            limit = int(_parse_single(rest, "--limit", "20") or "20")
+        except ValueError:
+            limit = 20
+        print(json.dumps(asyncio.run(_list(user_email, min(limit, 100))), indent=2))
+
+    else:
+        print(json.dumps({"error": f"Unknown command: {command}"}))
+        _print_usage()


### PR DESCRIPTION
## Summary
- **Notification inbox**: flows and agents can leave persistent notifications for a user; they stay in the inbox until explicitly dismissed (read ≠ dismissed — read clears the badge, dismiss removes the card)
- **Conversation deep-links**: clicking a notification marks it read and opens the conversation of the flow run that created it (`/chat?continue=<id>`), so the user lands in full context and can keep chatting with the agent
- **Web push included**: creating a notification also fires a web push through the existing `push_subscriptions` infra, deep-linking to the same conversation

## How it works
1. A flow run's agent gets its `[Conversation ID: ...]` injected into the prompt (new, in `agent/client.py`) along with instructions for the new personal tool
2. The agent runs `python3 tools/notify.py ... send --title "..." --body "..." --conversation-id <id>` at the end of a run
3. The notification lands in the `notifications` collection, a push fires, and the dashboard bell badge (5s poll) increments
4. The user opens **Notifications** in the sidebar, clicks the card, and lands inside that flow run's conversation

## Changes
**Backend**
- `observability/notifications.py` — new: `create_notification()` (validation, doc shape, push fire)
- `observability/push.py` — new generic `send_user_push()` / `fire_user_push()` (sibling of the tasks-board push)
- `api/notification_routes.py` — new: `GET /api/notifications`, `GET /api/notifications/unread-count`, `POST /api/notifications/read-all`, `POST .../{id}/read`, `POST .../{id}/dismiss` (all scoped to the authenticated user)
- `api/routes.py` — route registration; `observability/db.py` — indexes
- `tools/notify.py` — new personal tool (`send`, `list`) with HMAC auth, same pattern as `tools/telegram.py`
- `agent/client.py` — injects conversation id + notify-tool usage hint into agent prompts

**Dashboard**
- `src/lib/notifications-api.ts` — typed fetch wrappers
- `src/lib/NotificationsContext.tsx` — 5s unread-count poll (mounted in `Providers.tsx`)
- `src/components/Sidebar.tsx` — Notifications nav item with unread badge (existing badge system)
- `src/app/notifications/page.tsx` — inbox page: unread dots, mark-all-read, per-card dismiss, empty state, deep-link on click

## Testing
- **Unit tests**: 14 new assertions in `tests/test_notification_routes.py` — all pass; the 2 full-suite failures (`test_archive_extraction`, `test_opencode_runtime`) are pre-existing on `main` (verified via `git stash`)
- **Static checks**: `tsc --noEmit` clean, `next build` clean (route `/notifications` in output), `check_public_content.py` + `check_secrets.py` pass
- **End-to-end on a local stack** (isolated throwaway DB): booted backend + dashboard, logged in, seeded a fake flow-run conversation, created 2 notifications **via the real `tools/notify.py` CLI**, then verified via API + Playwright:
  - unread-count = 2, list scoped to user, unauthenticated request → 401
  - sidebar badge shows 2 → [screenshot](https://cdn.plotline.so/loma-images/loma-pr/notify-01-sidebar-badge.png)
  - inbox with two unread cards → [screenshot](https://cdn.plotline.so/loma-images/loma-pr/notify-02-inbox-unread.png)
  - clicking the flow notification deep-links into the flow run's conversation (badge decrements to 1) → [screenshot](https://cdn.plotline.so/loma-images/loma-pr/notify-03-conversation-deeplink.png)
  - back in the inbox, first card shows as read → [screenshot](https://cdn.plotline.so/loma-images/loma-pr/notify-04-inbox-after-read.png)
  - dismissing all cards shows the empty state → [screenshot](https://cdn.plotline.so/loma-images/loma-pr/notify-05-inbox-empty.png)
  - post-UI API state: unread = 0, non-dismissed = 0, `include_dismissed=1` returns both

## Notes
- Notifications with no `conversation_id` can carry a `link` (opens in a new tab); with neither, the card is informational only
- Web push payload reuses the existing service-worker click handling (`sw.js` navigates to the payload URL) — no SW changes needed
- This PR was generated by the Loma agent based on the request above; please review before merging
