### PR TITLE
Notification inbox UX: expand in place, explicit Open conversation, push lands on inbox

### DIFF
--- a/agent/client.py
+++ b/agent/client.py
@@ -763,7 +763,10 @@ async def stream_agent(
             f"--auth-token {auth_token} send --title \"...\" --body \"...\" "
             f"--conversation-id {conversation_id}`. Use it when a flow or long-running "
             f"task finishes with a result the user should see — the notification "
-            f"deep-links back to this conversation and persists until dismissed."
+            f"deep-links back to this conversation and persists until dismissed. "
+            f"IMPORTANT: after sending a notification, ALWAYS also write the same "
+            f"summary as your final chat response — never end the run with only the "
+            f"tool call, or the conversation the notification points to will be empty."
         )
 
     if conversation_context:

--- a/dashboard/src/app/notifications/page.tsx
+++ b/dashboard/src/app/notifications/page.tsx
@@ -3,8 +3,11 @@
 import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
+  RiArrowDownSLine,
+  RiChat1Line,
   RiCheckDoubleLine,
   RiCloseLine,
+  RiExternalLinkLine,
   RiNotification3Line,
   RiRefreshLine,
 } from "@remixicon/react";
@@ -30,6 +33,7 @@ export default function NotificationsPage() {
   const { refresh: refreshUnreadCount } = useNotifications();
   const [notifications, setNotifications] = useState<LomaNotification[]>([]);
   const [loading, setLoading] = useState(true);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
 
   const loadData = useCallback(async () => {
     try {
@@ -45,24 +49,36 @@ export default function NotificationsPage() {
     loadData();
   }, [loadData]);
 
-  const handleOpen = async (n: LomaNotification) => {
-    if (!n.read) {
-      setNotifications((prev) =>
-        prev.map((x) => (x.notification_id === n.notification_id ? { ...x, read: true } : x)),
-      );
-      markNotificationRead(n.notification_id)
-        .then(refreshUnreadCount)
-        .catch(() => {});
-    }
-    if (n.conversation_id) {
-      router.push(`${basePath}/chat?continue=${n.conversation_id}`);
-    } else if (n.link) {
-      window.open(n.link, "_blank", "noopener,noreferrer");
-    }
+  const markRead = (n: LomaNotification) => {
+    if (n.read) return;
+    setNotifications((prev) =>
+      prev.map((x) => (x.notification_id === n.notification_id ? { ...x, read: true } : x)),
+    );
+    markNotificationRead(n.notification_id)
+      .then(refreshUnreadCount)
+      .catch(() => {});
+  };
+
+  // Clicking a card expands it in place (and marks it read) — it never
+  // navigates. Opening the conversation/link is an explicit button action.
+  const handleToggle = (n: LomaNotification) => {
+    markRead(n);
+    setExpandedId((prev) => (prev === n.notification_id ? null : n.notification_id));
+  };
+
+  const handleOpenConversation = (n: LomaNotification) => {
+    markRead(n);
+    router.push(`${basePath}/chat?continue=${n.conversation_id}`);
+  };
+
+  const handleOpenLink = (n: LomaNotification) => {
+    markRead(n);
+    window.open(n.link!, "_blank", "noopener,noreferrer");
   };
 
   const handleDismiss = async (n: LomaNotification) => {
     setNotifications((prev) => prev.filter((x) => x.notification_id !== n.notification_id));
+    if (expandedId === n.notification_id) setExpandedId(null);
     try {
       await dismissNotification(n.notification_id);
       refreshUnreadCount();
@@ -137,64 +153,110 @@ export default function NotificationsPage() {
             description="Flows and long-running tasks will leave their results here"
           />
         ) : (
-          notifications.map((n, idx) => (
-            <Card
-              key={n.notification_id}
-              className={cn(
-                "p-3 active:bg-muted/50 transition-colors animate-fade-in-up",
-                (n.conversation_id || n.link) && "cursor-pointer",
-                !n.read && "bg-brand-50/40",
-              )}
-              style={{ animationDelay: `${Math.min(idx * 30, 300)}ms` }}
-              onClick={() => handleOpen(n)}
-            >
-              <CardContent className="p-0">
-                <div className="flex items-start gap-2.5">
-                  <div
-                    className={cn(
-                      "h-2 w-2 rounded-full mt-1.5 shrink-0",
-                      n.read ? "bg-transparent" : "bg-brand-500",
-                    )}
-                  />
-                  <div className="flex-1 min-w-0">
+          notifications.map((n, idx) => {
+            const expanded = expandedId === n.notification_id;
+            const hasActions = Boolean(n.conversation_id || n.link);
+            return (
+              <Card
+                key={n.notification_id}
+                className={cn(
+                  "p-3 active:bg-muted/50 transition-colors animate-fade-in-up cursor-pointer",
+                  !n.read && "bg-brand-50/40",
+                )}
+                style={{ animationDelay: `${Math.min(idx * 30, 300)}ms` }}
+                onClick={() => handleToggle(n)}
+                aria-expanded={expanded}
+              >
+                <CardContent className="p-0">
+                  <div className="flex items-start gap-2.5">
                     <div
                       className={cn(
-                        "text-[13px] truncate",
-                        n.read ? "font-normal text-foreground/80" : "font-medium text-foreground",
+                        "h-2 w-2 rounded-full mt-1.5 shrink-0",
+                        n.read ? "bg-transparent" : "bg-brand-500",
                       )}
-                    >
-                      {n.title}
-                    </div>
-                    {n.body && (
-                      <div className="text-xs text-muted-foreground mt-0.5 line-clamp-2">
-                        {n.body}
+                    />
+                    <div className="flex-1 min-w-0">
+                      <div
+                        className={cn(
+                          "text-[13px]",
+                          expanded ? "break-words" : "truncate",
+                          n.read ? "font-normal text-foreground/80" : "font-medium text-foreground",
+                        )}
+                      >
+                        {n.title}
                       </div>
-                    )}
-                    <div className="flex items-center gap-2 mt-1.5 text-xs text-muted-foreground">
-                      <ClientTimestamp iso={n.created_at} variant="short" />
-                      {n.conversation_id && <span>Open conversation →</span>}
+                      {n.body && (
+                        <div
+                          className={cn(
+                            "text-xs text-muted-foreground mt-0.5",
+                            expanded ? "whitespace-pre-wrap break-words" : "line-clamp-2",
+                          )}
+                        >
+                          {n.body}
+                        </div>
+                      )}
+                      <div className="flex items-center gap-2 mt-1.5 text-xs text-muted-foreground">
+                        <ClientTimestamp iso={n.created_at} variant="short" />
+                      </div>
+                      {expanded && hasActions && (
+                        <div
+                          className="flex items-center gap-2 mt-2.5"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          {n.conversation_id && (
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => handleOpenConversation(n)}
+                              className="h-8 text-xs press-scale"
+                            >
+                              <RiChat1Line size={14} className="mr-1.5" />
+                              Open conversation
+                            </Button>
+                          )}
+                          {n.link && (
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => handleOpenLink(n)}
+                              className="h-8 text-xs press-scale"
+                            >
+                              <RiExternalLinkLine size={14} className="mr-1.5" />
+                              Open link
+                            </Button>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                    <div className="shrink-0 flex items-center" onClick={(e) => e.stopPropagation()}>
+                      <RiArrowDownSLine
+                        size={16}
+                        className={cn(
+                          "text-muted-foreground/60 transition-transform mt-1.5 mr-0.5",
+                          expanded && "rotate-180",
+                        )}
+                        onClick={() => handleToggle(n)}
+                      />
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon-xs"
+                            onClick={() => handleDismiss(n)}
+                            className="text-muted-foreground hover:text-foreground h-8 w-8 md:h-6 md:w-6"
+                            aria-label="Dismiss notification"
+                          >
+                            <RiCloseLine size={14} />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>Dismiss</TooltipContent>
+                      </Tooltip>
                     </div>
                   </div>
-                  <div className="shrink-0" onClick={(e) => e.stopPropagation()}>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button
-                          variant="ghost"
-                          size="icon-xs"
-                          onClick={() => handleDismiss(n)}
-                          className="text-muted-foreground hover:text-foreground h-8 w-8 md:h-6 md:w-6"
-                          aria-label="Dismiss notification"
-                        >
-                          <RiCloseLine size={14} />
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent>Dismiss</TooltipContent>
-                    </Tooltip>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-          ))
+                </CardContent>
+              </Card>
+            );
+          })
         )}
       </div>
     </div>

--- a/observability/notifications.py
+++ b/observability/notifications.py
@@ -70,10 +70,9 @@ async def create_notification(
 
     if fire_push:
         base_url = os.environ.get("PUBLIC_BASE_URL", "").rstrip("/")
-        if doc["conversation_id"]:
-            url = f"{base_url}/chat?continue={doc['conversation_id']}"
-        else:
-            url = doc["link"] or f"{base_url}/notifications"
+        # Push clicks always land on the notifications inbox — the user expands
+        # the notification there and opens the conversation explicitly.
+        url = f"{base_url}/notifications"
         fire_user_push(
             db, user_email,
             title=doc["title"], body=doc["body"],

--- a/tests/test_notification_routes.py
+++ b/tests/test_notification_routes.py
@@ -177,7 +177,9 @@ async def test_create_notification_inserts_doc_and_fires_push():
     assert doc["dismissed"] is False
     db.notifications.insert_one.assert_awaited_once()
     fire.assert_called_once()
-    assert "conv-42" in fire.call_args.kwargs["url"]
+    # Push clicks land on the notifications inbox, never directly in a chat
+    assert fire.call_args.kwargs["url"].endswith("/notifications")
+    assert "conv-42" not in fire.call_args.kwargs["url"]
 
 
 @pytest.mark.asyncio

--- a/tools/notify.py
+++ b/tools/notify.py
@@ -63,10 +63,9 @@ async def _send(user_email: str, title: str, body: str,
             fire_push=False,  # fire-and-forget tasks die with this short-lived CLI; send inline instead
         )
         base_url = os.environ.get("PUBLIC_BASE_URL", "").rstrip("/")
-        if doc.get("conversation_id"):
-            url = f"{base_url}/chat?continue={doc['conversation_id']}"
-        else:
-            url = doc.get("link") or f"{base_url}/notifications"
+        # Push clicks always land on the notifications inbox — the user expands
+        # the notification there and opens the conversation explicitly.
+        url = f"{base_url}/notifications"
         await send_user_push(
             db, user_email,
             title=doc["title"], body=doc["body"], url=url, tag=doc["notification_id"],


### PR DESCRIPTION
Follow-up to #124. A flow run that only calls `notify.py` can leave its conversation nearly empty — clicking the notification then dropped the user into a chat with nothing to read. This PR restructures the notification UX so the notification body is the primary reading surface.

## Changes

### Inbox UI (`dashboard/src/app/notifications/page.tsx`)
- Clicking a card now **expands it in place** (marks read, full body with preserved line breaks). Clicking again collapses. It never navigates.
- **Open conversation** is an explicit button inside the expanded card (deep-links to `/chat?continue=<id>`). Link-only notifications get an **Open link** button.
- Chevron indicator rotates on expand; long titles/bodies wrap without overflow (verified at 390px).

### Push click target (`observability/notifications.py`, `tools/notify.py`)
- Web push clicks now always land on **`/notifications`** — never directly in a chat. The user reads the body in the inbox and opens the conversation explicitly.

### Agent behavior (`agent/client.py`)
- The injected notify hint now instructs the model: after sending a notification, **always repeat the same summary as the final chat response** — so the linked conversation is never empty (the failure mode that motivated this PR).
- The DB-backed `send-notification` skill was updated in parallel with the same rule and the new UX description (self-contained bodies, no "details in the run" teasers).

## Testing

**Unit tests** — 12/12 pass (`tests/test_notification_routes.py`); push-URL test updated to assert the inbox-landing behavior.

**Local stack E2E** (isolated throwaway DB `loma_local_719e47`, dropped at teardown) — all assertions green:
- Collapsed card hides the Open conversation button; body is line-clamped → [inbox collapsed](https://cdn.plotline.so/loma-images/loma-pr/notify-ux-02-inbox-collapsed.png)
- Clicking a card stays on `/notifications` and expands the full multi-line body with the Open conversation button → [expanded](https://cdn.plotline.so/loma-images/loma-pr/notify-ux-03-card-expanded.png)
- Second click collapses; Open conversation navigates to `/chat?continue=<id>` with the seeded flow-run transcript → [conversation](https://cdn.plotline.so/loma-images/loma-pr/notify-ux-04-conversation-opened.png)
- Link-only card expands with an Open link button, stays on the inbox → [link card](https://cdn.plotline.so/loma-images/loma-pr/notify-ux-05-link-card-expanded.png)
- 390px mobile viewport: expanded card, no horizontal overflow → [mobile](https://cdn.plotline.so/loma-images/loma-pr/notify-ux-06-mobile-expanded.png)
- Dismiss-all → empty state → [empty](https://cdn.plotline.so/loma-images/loma-pr/notify-ux-07-inbox-empty.png)

`check_public_content.py` and `check_secrets.py` both clean; dashboard production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)