### PR TITLE
fix: mobile scroll snap-back on the notifications page

### DIFF
--- a/dashboard/src/app/notifications/page.tsx
+++ b/dashboard/src/app/notifications/page.tsx
@@ -136,7 +136,11 @@ export default function NotificationsPage() {
   const hasUnread = notifications.some((n) => !n.read);
 
   return (
-    <div className="max-w-2xl mx-auto px-4 py-6 space-y-4">
+    // Own scroll container (like /my-usage) so the page never scrolls the
+    // window — window scrolling conflicts with the PWA viewport-height sync
+    // on mobile and caused scroll-jump-to-top when a card was expanded.
+    <div className="flex-1 min-h-0 overflow-y-auto">
+      <div className="max-w-2xl mx-auto px-4 py-6 space-y-4">
       {/* Header */}
       <div className="pwa-header-offset flex items-center justify-between">
         <h1 className="text-lg font-semibold text-foreground">Notifications</h1>
@@ -292,6 +296,7 @@ export default function NotificationsPage() {
             );
           })
         )}
+        </div>
       </div>
     </div>
   );

--- a/dashboard/src/components/ViewportHeightSync.tsx
+++ b/dashboard/src/components/ViewportHeightSync.tsx
@@ -19,10 +19,25 @@ export default function ViewportHeightSync() {
     const vv = window.visualViewport;
     if (!vv) return;
 
+    // Only pin the window scroll while the on-screen keyboard is plausibly
+    // open (an editable element is focused). Pinning unconditionally fights
+    // the user on any page that scrolls at the window level — scrolling down
+    // fires visualViewport events and the page snaps back to the top.
+    const keyboardLikelyOpen = () => {
+      const el = document.activeElement;
+      if (!el) return false;
+      const tag = el.tagName;
+      return (
+        tag === "TEXTAREA" ||
+        tag === "INPUT" ||
+        (el as HTMLElement).isContentEditable === true
+      );
+    };
+
     const sync = () => {
       document.documentElement.style.setProperty("--app-h", `${vv.height}px`);
       // Counteract iOS scrolling the page when the keyboard appears.
-      if (vv.offsetTop > 0 || window.scrollY > 0) {
+      if (keyboardLikelyOpen() && (vv.offsetTop > 0 || window.scrollY > 0)) {
         window.scrollTo(0, 0);
       }
     };


### PR DESCRIPTION
## Problem

On mobile, expanding a notification card and scrolling down caused the page to snap back to the top.

## Root cause (two behaviors fighting each other)

1. **`ViewportHeightSync`** (mounted only in the installed PWA) ran `window.scrollTo(0, 0)` on **every** `visualViewport` scroll/resize event whenever `window.scrollY > 0`. It was meant to counteract iOS pushing the page up when the on-screen keyboard opens — but it also fired while the user was simply scrolling a window-scrolled page.
2. **The notifications page had no scroll container of its own**, making it the rare page that scrolls at the window level. Collapsed, the list fit the viewport (no scroll, bug invisible). Expanded, the page became window-scrollable — scroll down → visualViewport event fires → sync pins back to top.

## Fix

- `ViewportHeightSync` now only pins the scroll while an **editable element is focused** (keyboard plausibly open: `TEXTAREA` / `INPUT` / `contentEditable`). The chat-composer keyboard behavior it exists for is preserved; plain scrolling is never fought again — on any page.
- The notifications page gets its **own scroll container** (`flex-1 min-h-0 overflow-y-auto`, same pattern as `/my-usage`), so it never scrolls the window at all. Belt and braces: the pin can't even observe a scroll here.

## Testing

Full local stack per `run-loma-local` (throwaway DB, ports 13000/13001), Playwright at 390×844 mobile viewport:

- ✅ Expanded a long digest → inner container overflows (1374 > 764), **document/window itself is not scrollable**
- ✅ Scrolled to 400px, fired synthetic window `scroll`/`resize` events → position **sticks** (`scrollTop=400`, `window.scrollY=0`)
- ✅ Position survives 2 unread-count poll cycles (5s each)
- ✅ **Simulated installed PWA** (forced `display-mode: standalone` so `ViewportHeightSync` mounts, verified via `--app-h`) → scroll still sticks with no keyboard open
- ✅ `tsc --noEmit` clean, production build clean, content scans clean
- Stack torn down, throwaway DB dropped, prod verified healthy

### Screenshots
| Expanded (mobile) | Scrolled — holds position | Installed PWA — holds position |
|---|---|---|
| ![expanded](https://cdn.plotline.so/loma-images/loma-pr/notify-scroll-02-mobile-expanded.png) | ![scrolled](https://cdn.plotline.so/loma-images/loma-pr/notify-scroll-03-mobile-scrolled-sticks.png) | ![pwa](https://cdn.plotline.so/loma-images/loma-pr/notify-scroll-05-pwa-standalone-scrolled.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)