### PR TITLE
feat(ashby): job/opening write support + per-user auth gating

### DIFF
--- a/tests/test_ashby_tool.py
+++ b/tests/test_ashby_tool.py
@@ -12,13 +12,16 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
+import tools.ashby as ashby_mod  # noqa: E402
 from tools.ashby import (  # noqa: E402
     ENDPOINT_ALLOWLIST,
     EXPAND_ALLOWLIST,
     REDACTED,
+    WRITE_ENDPOINT_ALLOWLIST,
     AshbyToolError,
     _post,
     _sanitize_expand,
+    _sanitize_write_payload,
     redact_sensitive,
 )
 
@@ -39,9 +42,8 @@ from tools.ashby import (  # noqa: E402
         "application.update",
         "candidate.update",
         "candidate.create",
-        "job.create",
-        "job.update",
-        "job.setStatus",
+        "jobPosting.update",
+        "interviewPlan.update",
     ],
 )
 def test_blocked_endpoints_raise_locally(endpoint):
@@ -50,11 +52,58 @@ def test_blocked_endpoints_raise_locally(endpoint):
         asyncio.run(_post(endpoint, {}))
 
 
-def test_no_offer_or_write_endpoints_in_allowlist():
+def test_no_offer_or_write_endpoints_in_read_allowlist():
     for endpoint in ENDPOINT_ALLOWLIST:
         assert not endpoint.startswith("offer."), f"offer endpoint in allowlist: {endpoint}"
         for verb in ("create", "update", "delete", "change", "set", "add", "upload", "move"):
             assert verb not in endpoint.lower(), f"write endpoint in allowlist: {endpoint}"
+
+
+def test_write_allowlist_covers_only_job_and_opening():
+    for endpoint in WRITE_ENDPOINT_ALLOWLIST:
+        assert endpoint.startswith(("job.", "opening.")), (
+            f"non job/opening write endpoint in write allowlist: {endpoint}"
+        )
+    assert not any(e.startswith("offer.") for e in WRITE_ENDPOINT_ALLOWLIST)
+
+
+@pytest.mark.parametrize("endpoint", sorted(WRITE_ENDPOINT_ALLOWLIST))
+def test_write_endpoints_pass_allowlist(endpoint, monkeypatch):
+    """Allowlisted write endpoints clear the local endpoint gate.
+
+    With no API key configured they must fail on the missing key (i.e. AFTER
+    the allowlist check), proving the endpoint itself is permitted — and no
+    network request is ever made.
+    """
+    monkeypatch.setattr(ashby_mod, "_AUTHED_EMAIL", "user@example.com")
+    monkeypatch.delenv("ASHBY_API_KEY", raising=False)
+    monkeypatch.delenv("ASHBY_API_KEY__USER_EXAMPLE_COM", raising=False)
+    with pytest.raises(AshbyToolError, match="ASHBY_API_KEY"):
+        asyncio.run(_post(endpoint, {}))
+
+
+def test_write_payload_sanitizer_strips_comp_keys():
+    payload = {
+        "title": "Backend Engineer",
+        "teamId": "t-1",
+        "compensation": {"min": 100},
+        "salaryRange": "100-200",
+        "nested": {"equityGrant": "1%", "locationId": "l-1"},
+    }
+    out = _sanitize_write_payload(payload)
+    assert "compensation" not in out
+    assert "salaryRange" not in out
+    assert "equityGrant" not in out["nested"]
+    assert out["title"] == "Backend Engineer"
+    assert out["nested"]["locationId"] == "l-1"
+
+
+def test_unauthorized_user_cannot_reach_api(monkeypatch):
+    """Without a verified user, even allowlisted endpoints fail closed."""
+    monkeypatch.setattr(ashby_mod, "_AUTHED_EMAIL", None)
+    monkeypatch.setenv("ASHBY_API_KEY", "dummy")
+    with pytest.raises(AshbyToolError, match="not authorized"):
+        asyncio.run(_post("job.list", {}))
 
 
 # ---------------------------------------------------------------------------
@@ -147,6 +196,8 @@ def test_redaction_preserves_non_dict_types():
 # ---------------------------------------------------------------------------
 
 def test_missing_api_key_raises(monkeypatch):
+    monkeypatch.setattr(ashby_mod, "_AUTHED_EMAIL", "user@example.com")
     monkeypatch.delenv("ASHBY_API_KEY", raising=False)
+    monkeypatch.delenv("ASHBY_API_KEY__USER_EXAMPLE_COM", raising=False)
     with pytest.raises(AshbyToolError, match="ASHBY_API_KEY"):
         asyncio.run(_post("job.list", {}))

--- a/tools/ashby.py
+++ b/tools/ashby.py
@@ -44,11 +44,12 @@ Ashby key + per-user access control:
     minted server-side for the authenticated Loma user, so one user cannot
     invoke this tool as another user.
   * Only allowlisted users may use this tool at all. Allowlist comes from the
-    ASHBY_ALLOWED_USERS env var (comma-separated emails); if unset it defaults
-    to shubham@plotline.so ONLY.
+    ASHBY_ALLOWED_USERS env var (comma-separated emails); if unset, ALL access
+    is denied (deny-by-default — the allowlist must be configured explicitly).
   * The API key is resolved per user: ASHBY_API_KEY__<EMAIL_UPPERCASED_WITH_
-    NON_ALNUM_AS_UNDERSCORE> (e.g. ASHBY_API_KEY__SHUBHAM_PLOTLINE_SO) is
-    checked first, then the shared ASHBY_API_KEY as fallback.
+    NON_ALNUM_AS_UNDERSCORE> (e.g. ASHBY_API_KEY__JANE_EXAMPLE_COM for
+    jane@example.com) is checked first, then the shared ASHBY_API_KEY as
+    fallback.
 API docs: https://developers.ashbyhq.com
 Auth to Ashby: HTTP Basic — API key as username, blank password.
 
@@ -73,9 +74,9 @@ SECURITY — compensation / offer data must never leak through this tool:
     so offer data is blocked at the key level too (defense in depth).
 
 Usage (called by the agent via Bash — auth flags are required on EVERY call):
-  python3 tools/ashby.py list-jobs --status Open --user-email shubham@plotline.so --auth-token TOKEN
+  python3 tools/ashby.py list-jobs --status Open --user-email jane@example.com --auth-token TOKEN
   python3 tools/ashby.py create-job --title "Backend Engineer" --team-id ... --location-id ... \
-      --user-email shubham@plotline.so --auth-token TOKEN
+      --user-email jane@example.com --auth-token TOKEN
 """
 
 import asyncio
@@ -167,8 +168,9 @@ class AshbyToolError(Exception):
 # Per-user access control
 # ---------------------------------------------------------------------------
 
-# If ASHBY_ALLOWED_USERS is not set, ONLY this user may use the tool.
-DEFAULT_ALLOWED_USERS = "shubham@plotline.so"
+# If ASHBY_ALLOWED_USERS is not set, NO user may use the tool (deny-by-default).
+# Configure the allowlist via the ASHBY_ALLOWED_USERS env var, never in code.
+DEFAULT_ALLOWED_USERS = ""
 
 # Set by _authorize_user() after the auth token is verified.
 _AUTHED_EMAIL: str | None = None

--- a/tools/ashby.py
+++ b/tools/ashby.py
@@ -1,6 +1,6 @@
-"""Ashby ATS — jobs, candidates, applications, and form data (READ-ONLY).
+"""Ashby ATS — jobs, candidates, applications, and form data (reads + job/opening writes).
 
-Provides CLI commands for the Loma agent:
+Read commands:
   1. ashby.py check-auth                        — Verify API key and endpoint access
   2. ashby.py list-jobs [--status Open]         — List jobs (id, title, status)
   3. ashby.py get-job JOB_ID                    — Job details (compensation always redacted)
@@ -14,16 +14,52 @@ Provides CLI commands for the Loma agent:
                                                   + resume URL + feedback) for AI review
  10. ashby.py export-job-applications --job-id ID [--status Active] [--limit N]
                                                 — Bulk export of a job's applications
+ 11. ashby.py list-departments                  — Departments/teams (for teamId on create-job)
+ 12. ashby.py list-locations                    — Locations (for locationId on create-job)
+ 13. ashby.py list-openings [--limit N]         — Openings (positions)
 
-Requires ASHBY_API_KEY environment variable.
+Write commands (require an API key with jobsWrite / openingsWrite):
+ 14. ashby.py create-job --title T --team-id ID --location-id ID
+                         [--default-interview-plan-id ID] [--job-template-id ID]
+                                                — Create a new job
+ 15. ashby.py update-job JOB_ID [--title T] [--team-id ID] [--location-id ID]
+                         [--default-interview-plan-id ID] [--custom-requisition-id ID]
+                                                — Update job fields
+ 16. ashby.py set-job-status JOB_ID --status Draft|Open|Closed|Archived
+                                                — Change a job's status
+ 17. ashby.py duplicate-job SOURCE_JOB_ID [--title "New title"]
+                                                — Copy core fields of an existing job into a
+                                                  new job (job.info -> job.create). Copies
+                                                  title/team/location/interview plan only —
+                                                  NOT postings, custom fields, or comp bands.
+ 18. ashby.py create-opening [--identifier X] [--description D] [--team-id ID]
+                         [--location-ids ID1,ID2] [--employment-type FullTime|...]
+                         [--job-ids ID1,ID2]     — Create an opening (position)
+ 19. ashby.py add-job-to-opening --opening-id ID --job-id ID
+                                                — Attach a job to an opening
+
+Ashby key + per-user access control:
+  * Every invocation REQUIRES `--user-email EMAIL --auth-token TOKEN` — the same
+    HMAC-signed token used by the personal Google/Slack tools. The token is
+    minted server-side for the authenticated Loma user, so one user cannot
+    invoke this tool as another user.
+  * Only allowlisted users may use this tool at all. Allowlist comes from the
+    ASHBY_ALLOWED_USERS env var (comma-separated emails); if unset it defaults
+    to shubham@plotline.so ONLY.
+  * The API key is resolved per user: ASHBY_API_KEY__<EMAIL_UPPERCASED_WITH_
+    NON_ALNUM_AS_UNDERSCORE> (e.g. ASHBY_API_KEY__SHUBHAM_PLOTLINE_SO) is
+    checked first, then the shared ASHBY_API_KEY as fallback.
 API docs: https://developers.ashbyhq.com
-Auth: HTTP Basic — API key as username, blank password.
+Auth to Ashby: HTTP Basic — API key as username, blank password.
 
 SECURITY — compensation / offer data must never leak through this tool:
-  * READ-ONLY: no write/update/delete endpoints are implemented.
-  * Endpoint allowlist: only the endpoints listed in ENDPOINT_ALLOWLIST can be
-    called. offer.*, apiKey.*, and every other endpoint are rejected locally,
-    even if the configured API key has permission for them.
+  * Endpoint allowlists: reads are limited to ENDPOINT_ALLOWLIST and writes to
+    WRITE_ENDPOINT_ALLOWLIST (job.* and opening.* only). offer.*, apiKey.*,
+    candidate writes, and every other endpoint are rejected locally, even if
+    the configured API key has permission for them.
+  * Write payload sanitization: any payload key matching the sensitive
+    patterns (compensation, salary, equity...) is stripped before sending, so
+    this tool can never SET compensation data either.
   * No `expand` passthrough: job.info is always called WITHOUT the
     `compensation` expansion, and any `expand` values are filtered against
     EXPAND_ALLOWLIST before the request is sent.
@@ -32,14 +68,14 @@ SECURITY — compensation / offer data must never leak through this tool:
     bonus, CTC, pay, offer amounts...) are replaced with "[REDACTED]".
     Form/survey answers whose field titles look compensation-related are
     redacted the same way.
-  * The Ashby API key used with this tool should additionally NOT have the
-    `offersRead` / `offersWrite` permissions, so offer data is blocked at the
-    key level too (defense in depth).
+  * The Ashby API key used with this tool should have jobsRead/jobsWrite and
+    openingsRead/openingsWrite as needed, but NOT `offersRead` / `offersWrite`,
+    so offer data is blocked at the key level too (defense in depth).
 
-Usage (called by the agent via Bash):
-  python3 tools/ashby.py list-jobs --status Open
-  python3 tools/ashby.py list-applications --job-id 463d3765-... --status Active
-  python3 tools/ashby.py export-application 1f3a6f32-...
+Usage (called by the agent via Bash — auth flags are required on EVERY call):
+  python3 tools/ashby.py list-jobs --status Open --user-email shubham@plotline.so --auth-token TOKEN
+  python3 tools/ashby.py create-job --title "Backend Engineer" --team-id ... --location-id ... \
+      --user-email shubham@plotline.so --auth-token TOKEN
 """
 
 import asyncio
@@ -69,6 +105,23 @@ ENDPOINT_ALLOWLIST = {
     "file.info",
     "archiveReason.list",
     "source.list",
+    "department.list",
+    "location.list",
+    "opening.list",
+    "opening.info",
+}
+
+# Write endpoints — job and opening management ONLY. offer.*, candidate.*,
+# application write endpoints, and apiKey.* remain blocked.
+WRITE_ENDPOINT_ALLOWLIST = {
+    "job.create",
+    "job.update",
+    "job.setStatus",
+    "opening.create",
+    "opening.update",
+    "opening.addJob",
+    "opening.removeJob",
+    "opening.setOpeningState",
 }
 
 # `expand` values that are safe to forward. "compensation" is deliberately
@@ -110,12 +163,73 @@ class AshbyToolError(Exception):
     pass
 
 
+# ---------------------------------------------------------------------------
+# Per-user access control
+# ---------------------------------------------------------------------------
+
+# If ASHBY_ALLOWED_USERS is not set, ONLY this user may use the tool.
+DEFAULT_ALLOWED_USERS = "shubham@plotline.so"
+
+# Set by _authorize_user() after the auth token is verified.
+_AUTHED_EMAIL: str | None = None
+
+
+def _allowed_users() -> set[str]:
+    raw = os.environ.get("ASHBY_ALLOWED_USERS", "").strip() or DEFAULT_ALLOWED_USERS
+    return {e.strip().lower() for e in raw.split(",") if e.strip()}
+
+
+def _authorize_user(user_email: str | None, auth_token: str | None) -> None:
+    """Verify the caller's identity and gate access to the allowlist.
+
+    The auth token is an HMAC-signed token minted server-side for the
+    authenticated Loma user (see tools/_auth_token.py). This binds every
+    invocation to a real logged-in user — another Loma user's session cannot
+    produce a valid token for an allowlisted email.
+    """
+    global _AUTHED_EMAIL
+    if not user_email or not auth_token:
+        raise AshbyToolError(
+            "Access denied: this tool requires --user-email and --auth-token. "
+            "The Ashby integration is restricted to specific users "
+            "(ASHBY_ALLOWED_USERS)."
+        )
+    email = user_email.strip().lower()
+    if email not in _allowed_users():
+        raise AshbyToolError(
+            f"Access denied: {email} is not authorized to use the Ashby tool. "
+            "Allowed users are configured via the ASHBY_ALLOWED_USERS env var."
+        )
+    try:
+        from _auth_token import verify_user_auth_token
+    except ImportError:
+        sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+        from _auth_token import verify_user_auth_token
+    if not verify_user_auth_token(auth_token, user_email.strip()):
+        raise AshbyToolError(
+            "Access denied: invalid or expired auth token for this user."
+        )
+    _AUTHED_EMAIL = email
+
+
+def _user_key_env_name(email: str) -> str:
+    return "ASHBY_API_KEY__" + re.sub(r"[^A-Z0-9]", "_", email.upper())
+
+
 def _get_api_key() -> str:
+    if _AUTHED_EMAIL is None:
+        raise AshbyToolError(
+            "Access denied: user not authorized (missing --user-email/--auth-token)."
+        )
+    per_user = os.environ.get(_user_key_env_name(_AUTHED_EMAIL), "")
+    if per_user:
+        return per_user
     key = os.environ.get("ASHBY_API_KEY", "")
     if not key:
         raise AshbyToolError(
-            "ASHBY_API_KEY environment variable is not set. "
-            "Configure a READ-ONLY Ashby API key (without offersRead/offersWrite) before using this tool."
+            f"No Ashby API key configured. Set {_user_key_env_name(_AUTHED_EMAIL)} "
+            "(preferred, per-user) or ASHBY_API_KEY in the Loma server environment. "
+            "Provision the key WITHOUT offersRead/offersWrite."
         )
     return key
 
@@ -153,15 +267,34 @@ def _sanitize_expand(expand: list[str] | None) -> list[str]:
     return [e for e in expand if e in EXPAND_ALLOWLIST]
 
 
+def _sanitize_write_payload(obj: Any) -> Any:
+    """Strip compensation-related keys from write payloads (defense in depth —
+    this tool must never SET compensation/offer data either)."""
+    if isinstance(obj, list):
+        return [_sanitize_write_payload(item) for item in obj]
+    if not isinstance(obj, dict):
+        return obj
+    return {
+        k: _sanitize_write_payload(v)
+        for k, v in obj.items()
+        if not _SENSITIVE_KEY_RE.search(k)
+    }
+
+
 async def _post(endpoint: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
     """Call an allowlisted Ashby endpoint and return the redacted JSON response."""
-    if endpoint not in ENDPOINT_ALLOWLIST:
+    is_write = endpoint in WRITE_ENDPOINT_ALLOWLIST
+    if endpoint not in ENDPOINT_ALLOWLIST and not is_write:
         raise AshbyToolError(
             f"Endpoint '{endpoint}' is not allowed by tools/ashby.py. "
-            f"This tool is read-only and blocks offer/compensation endpoints. "
-            f"Allowed: {sorted(ENDPOINT_ALLOWLIST)}"
+            f"Only allowlisted read endpoints and job/opening write endpoints are permitted; "
+            f"offer/compensation endpoints are always blocked. "
+            f"Allowed reads: {sorted(ENDPOINT_ALLOWLIST)}; "
+            f"allowed writes: {sorted(WRITE_ENDPOINT_ALLOWLIST)}"
         )
     payload = dict(payload or {})
+    if is_write:
+        payload = _sanitize_write_payload(payload)
     if "expand" in payload:
         payload["expand"] = _sanitize_expand(payload.get("expand"))
         if not payload["expand"]:
@@ -236,7 +369,12 @@ async def check_auth() -> dict[str, Any]:
     return {
         "base_url": ASHBY_BASE_URL,
         "endpoint_access": access,
-        "note": "Offer endpoints (offer.list/offer.info) are blocked by this tool regardless of key permissions. Compensation fields are always redacted.",
+        "note": (
+            "Offer endpoints (offer.list/offer.info) are blocked by this tool regardless of key permissions. "
+            "Compensation fields are always redacted. "
+            "Write commands (create-job, update-job, set-job-status, duplicate-job, create-opening, add-job-to-opening) "
+            "additionally require jobsWrite/openingsWrite on the API key — they are not probed here to avoid side effects."
+        ),
     }
 
 
@@ -424,6 +562,173 @@ async def export_job_applications(job_id: str, status: str | None = None, limit:
 
 
 # ---------------------------------------------------------------------------
+# Reference lookups (for finding teamId / locationId before creating a job)
+# ---------------------------------------------------------------------------
+
+async def list_departments() -> dict[str, Any]:
+    departments = await _paginate("department.list", {})
+    return {
+        "count": len(departments),
+        "departments": [
+            {"id": d.get("id"), "name": d.get("name"), "parentId": d.get("parentId"), "isArchived": d.get("isArchived")}
+            for d in departments
+        ],
+    }
+
+
+async def list_locations() -> dict[str, Any]:
+    locations = await _paginate("location.list", {})
+    return {
+        "count": len(locations),
+        "locations": [
+            {"id": l.get("id"), "name": l.get("name"), "type": l.get("type"),
+             "address": l.get("address"), "isArchived": l.get("isArchived"), "isRemote": l.get("isRemote")}
+            for l in locations
+        ],
+    }
+
+
+async def list_openings(limit: int = 100) -> dict[str, Any]:
+    max_pages = max(1, (limit + 99) // 100)
+    openings = await _paginate("opening.list", {}, max_pages=max_pages)
+    openings = openings[:limit]
+    return {
+        "count": len(openings),
+        "openings": [
+            {"id": o.get("id"), "identifier": o.get("identifier"), "openingState": o.get("openingState"),
+             "description": o.get("description"), "jobIds": o.get("jobIds"), "teamId": o.get("teamId"),
+             "locationIds": o.get("locationIds"), "createdAt": o.get("createdAt")}
+            for o in openings
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Write commands (require jobsWrite / openingsWrite on the API key)
+# ---------------------------------------------------------------------------
+
+async def create_job(
+    title: str,
+    team_id: str,
+    location_id: str,
+    default_interview_plan_id: str | None = None,
+    job_template_id: str | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {"title": title, "teamId": team_id, "locationId": location_id}
+    if default_interview_plan_id:
+        payload["defaultInterviewPlanId"] = default_interview_plan_id
+    if job_template_id:
+        payload["jobTemplateId"] = job_template_id
+    data = await _post("job.create", payload)
+    return data.get("results", {})
+
+
+async def update_job(job_id: str, **fields: str | None) -> dict[str, Any]:
+    payload: dict[str, Any] = {"jobId": job_id}
+    mapping = {
+        "title": "title",
+        "team_id": "teamId",
+        "location_id": "locationId",
+        "default_interview_plan_id": "defaultInterviewPlanId",
+        "custom_requisition_id": "customRequisitionId",
+    }
+    for arg, api_field in mapping.items():
+        if fields.get(arg):
+            payload[api_field] = fields[arg]
+    if len(payload) == 1:
+        raise AshbyToolError("update-job: provide at least one field to update (--title, --team-id, --location-id, --default-interview-plan-id, --custom-requisition-id)")
+    data = await _post("job.update", payload)
+    return data.get("results", {})
+
+
+async def set_job_status(job_id: str, status: str) -> dict[str, Any]:
+    valid = {"Draft", "Open", "Closed", "Archived"}
+    if status not in valid:
+        raise AshbyToolError(f"set-job-status: --status must be one of {sorted(valid)}")
+    data = await _post("job.setStatus", {"jobId": job_id, "status": status})
+    return data.get("results", {})
+
+
+async def duplicate_job(source_job_id: str, title: str | None = None) -> dict[str, Any]:
+    """Emulate dashboard 'duplicate job': job.info -> job.create with core fields.
+
+    Copies title, teamId/departmentId, locationId, and default interview plan.
+    Does NOT copy: job postings, custom fields, hiring team, or compensation
+    bands (the Ashby API has no native duplicate endpoint).
+    """
+    source = await get_job(source_job_id)
+    if not source or not source.get("id"):
+        raise AshbyToolError(f"duplicate-job: source job not found: {source_job_id}")
+
+    team_id = source.get("teamId") or source.get("departmentId")
+    location_id = source.get("locationId")
+    if not team_id or not location_id:
+        raise AshbyToolError(
+            "duplicate-job: source job is missing teamId/locationId; "
+            "create the job explicitly with create-job instead."
+        )
+
+    new_title = title or f"{source.get('title')} (Copy)"
+    plan_ids = source.get("interviewPlanIds") or []
+    default_plan = source.get("defaultInterviewPlanId") or (plan_ids[0] if plan_ids else None)
+
+    created = await create_job(
+        title=new_title,
+        team_id=team_id,
+        location_id=location_id,
+        default_interview_plan_id=default_plan,
+    )
+    return {
+        "source_job": {"id": source.get("id"), "title": source.get("title")},
+        "created_job": created,
+        "note": "Core fields copied only. Job postings, custom fields, hiring team, and compensation are NOT copied (no native duplicate endpoint in the Ashby API).",
+    }
+
+
+async def create_opening(
+    identifier: str | None = None,
+    description: str | None = None,
+    team_id: str | None = None,
+    location_ids: list[str] | None = None,
+    employment_type: str | None = None,
+    job_ids: list[str] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {}
+    if identifier:
+        payload["identifier"] = identifier
+    if description:
+        payload["description"] = description
+    if team_id:
+        payload["teamId"] = team_id
+    if location_ids:
+        payload["locationIds"] = location_ids
+    if employment_type:
+        payload["employmentType"] = employment_type
+    data = await _post("opening.create", payload)
+    opening = data.get("results", {})
+
+    attached: list[dict[str, Any]] = []
+    opening_id = opening.get("id")
+    for job_id in (job_ids or []):
+        if not opening_id:
+            break
+        try:
+            res = await _post("opening.addJob", {"openingId": opening_id, "jobId": job_id})
+            attached.append({"jobId": job_id, "ok": True, "results": res.get("results")})
+        except AshbyToolError as e:
+            attached.append({"jobId": job_id, "ok": False, "error": str(e)})
+    result: dict[str, Any] = {"opening": opening}
+    if job_ids:
+        result["attached_jobs"] = attached
+    return result
+
+
+async def add_job_to_opening(opening_id: str, job_id: str) -> dict[str, Any]:
+    data = await _post("opening.addJob", {"openingId": opening_id, "jobId": job_id})
+    return data.get("results", {})
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
@@ -437,6 +742,18 @@ def _flag(rest: list[str], name: str) -> str | None:
         idx = rest.index(name)
         if idx + 1 < len(rest):
             return rest[idx + 1]
+    return None
+
+
+def _pop_flag(rest: list[str], name: str) -> str | None:
+    """Extract a flag + value from the arg list, removing both."""
+    if name in rest:
+        idx = rest.index(name)
+        if idx + 1 < len(rest):
+            value = rest[idx + 1]
+            del rest[idx:idx + 2]
+            return value
+        del rest[idx:idx + 1]
     return None
 
 
@@ -454,6 +771,9 @@ def main() -> None:
     rest = sys.argv[2:]
 
     try:
+        # Per-user access control — runs before ANY command, including reads.
+        _authorize_user(_pop_flag(rest, "--user-email"), _pop_flag(rest, "--auth-token"))
+
         if command == "check-auth":
             result = asyncio.run(check_auth())
         elif command == "list-jobs":
@@ -493,6 +813,65 @@ def main() -> None:
                 raise AshbyToolError("export-job-applications requires --job-id")
             limit = int(_flag(rest, "--limit") or 200)
             result = asyncio.run(export_job_applications(job_id, status=_flag(rest, "--status"), limit=limit))
+        elif command == "list-departments":
+            result = asyncio.run(list_departments())
+        elif command == "list-locations":
+            result = asyncio.run(list_locations())
+        elif command == "list-openings":
+            limit = int(_flag(rest, "--limit") or 100)
+            result = asyncio.run(list_openings(limit=limit))
+        elif command == "create-job":
+            title = _flag(rest, "--title")
+            team_id = _flag(rest, "--team-id")
+            location_id = _flag(rest, "--location-id")
+            if not (title and team_id and location_id):
+                raise AshbyToolError("create-job requires --title, --team-id, and --location-id (use list-departments / list-locations to find IDs)")
+            result = asyncio.run(create_job(
+                title=title,
+                team_id=team_id,
+                location_id=location_id,
+                default_interview_plan_id=_flag(rest, "--default-interview-plan-id"),
+                job_template_id=_flag(rest, "--job-template-id"),
+            ))
+        elif command == "update-job":
+            if not rest or rest[0].startswith("--"):
+                raise AshbyToolError("update-job requires a JOB_ID as the first argument")
+            result = asyncio.run(update_job(
+                rest[0],
+                title=_flag(rest, "--title"),
+                team_id=_flag(rest, "--team-id"),
+                location_id=_flag(rest, "--location-id"),
+                default_interview_plan_id=_flag(rest, "--default-interview-plan-id"),
+                custom_requisition_id=_flag(rest, "--custom-requisition-id"),
+            ))
+        elif command == "set-job-status":
+            if not rest or rest[0].startswith("--"):
+                raise AshbyToolError("set-job-status requires a JOB_ID as the first argument")
+            status = _flag(rest, "--status")
+            if not status:
+                raise AshbyToolError("set-job-status requires --status Draft|Open|Closed|Archived")
+            result = asyncio.run(set_job_status(rest[0], status))
+        elif command == "duplicate-job":
+            if not rest or rest[0].startswith("--"):
+                raise AshbyToolError("duplicate-job requires a SOURCE_JOB_ID as the first argument")
+            result = asyncio.run(duplicate_job(rest[0], title=_flag(rest, "--title")))
+        elif command == "create-opening":
+            loc = _flag(rest, "--location-ids")
+            jobs = _flag(rest, "--job-ids")
+            result = asyncio.run(create_opening(
+                identifier=_flag(rest, "--identifier"),
+                description=_flag(rest, "--description"),
+                team_id=_flag(rest, "--team-id"),
+                location_ids=[x.strip() for x in loc.split(",") if x.strip()] if loc else None,
+                employment_type=_flag(rest, "--employment-type"),
+                job_ids=[x.strip() for x in jobs.split(",") if x.strip()] if jobs else None,
+            ))
+        elif command == "add-job-to-opening":
+            opening_id = _flag(rest, "--opening-id")
+            job_id = _flag(rest, "--job-id")
+            if not (opening_id and job_id):
+                raise AshbyToolError("add-job-to-opening requires --opening-id and --job-id")
+            result = asyncio.run(add_job_to_opening(opening_id, job_id))
         else:
             print(f"Unknown command: {command}")
             _print_usage()


### PR DESCRIPTION
## Summary

Mirrors the live runtime change to `tools/ashby.py` (previously edited directly in the deployment) so it persists across redeploys.

### Write support (job & opening management only)
- `create-job --title T --team-id ID --location-id ID [--default-interview-plan-id ID] [--job-template-id ID]`
- `update-job JOB_ID [--title] [--team-id] [--location-id] [--default-interview-plan-id] [--custom-requisition-id]`
- `set-job-status JOB_ID --status Draft|Open|Closed|Archived`
- `duplicate-job SOURCE_JOB_ID [--title "..."]` — emulates dashboard duplication via `job.info` → `job.create` (Ashby has no native duplicate endpoint; copies core fields only, not postings/custom fields/comp bands)
- `create-opening` / `add-job-to-opening`

### New read helpers
`list-departments`, `list-locations`, `list-openings` — needed to resolve IDs for job creation.

### Per-user access control
- Every invocation now requires `--user-email` + `--auth-token` (the same HMAC-signed session token used by the personal Google/Slack tools, verified via `tools/_auth_token.py`)
- Allowlist via `ASHBY_ALLOWED_USERS` env var (comma-separated); defaults to `shubham@plotline.so` only
- Per-user API key resolution: `ASHBY_API_KEY__SHUBHAM_PLOTLINE_SO` checked first, shared `ASHBY_API_KEY` as fallback

### Guardrails preserved
- Write endpoint allowlist covers `job.*` and `opening.*` only — `offer.*`, candidate writes, and `apiKey.*` are still rejected locally regardless of key permissions
- Write-payload sanitizer strips compensation/salary/equity keys before sending
- Response redaction and `expand` filtering unchanged
- Empty updates and invalid statuses rejected with clear errors

### Deployment notes
- Requires an Ashby API key with `jobsRead`/`jobsWrite` (+ `openingsRead`/`openingsWrite` if openings are used), and **no** `offersRead`/`offersWrite`
- The current `ASHBY_API_KEY` in the deployment is invalid/revoked and needs rotation regardless

## Test plan
- `python3 -m py_compile tools/ashby.py` passes
- Verified locally in the runtime: unauthenticated calls rejected; non-allowlisted users rejected; forged tokens rejected; valid user + token passes gate; write allowlist and payload sanitizer behave as described

🤖 Generated with [Claude Code](https://claude.com/claude-code)