### PR TITLE
feat: prioritize dictation in mobile composers

### DIFF
--- a/dashboard/src/components/ChatPanel.tsx
+++ b/dashboard/src/components/ChatPanel.tsx
@@ -1374,10 +1374,10 @@ export default function ChatPanel({
                   <div className="flex min-w-0 items-center">
                     <ModelPicker models={agentModels} selectedModel={selectedModel} onSelect={selectModel} loadState={modelLoadState} disabled={isStreaming} />
                   </div>
-                  <div className="flex items-center gap-1 shrink-0">
+                  <div className="flex items-center gap-1 max-md:gap-2 shrink-0">
                     <DictationButton
                       onText={(t) => setInput((prev) => appendDictation(prev, t))}
-                      mobileProminent={!input.trim() && pendingFiles.length === 0}
+                      mobileProminent
                     />
                     <Button
                       type="button"
@@ -1695,10 +1695,10 @@ export default function ChatPanel({
                   <div className="flex min-w-0 items-center">
                     <ModelPicker models={agentModels} selectedModel={selectedModel} onSelect={selectModel} loadState={modelLoadState} disabled={isStreaming} />
                   </div>
-                  <div className="flex items-center gap-1 shrink-0">
+                  <div className="flex items-center gap-1 max-md:gap-2 shrink-0">
                     <DictationButton
                       onText={(t) => setInput((prev) => appendDictation(prev, t))}
-                      mobileProminent={!input.trim() && pendingFiles.length === 0}
+                      mobileProminent
                     />
                     <Button
                       type="button"

--- a/dashboard/src/components/ChatPanel.tsx
+++ b/dashboard/src/components/ChatPanel.tsx
@@ -1375,21 +1375,27 @@ export default function ChatPanel({
                     <ModelPicker models={agentModels} selectedModel={selectedModel} onSelect={selectModel} loadState={modelLoadState} disabled={isStreaming} />
                   </div>
                   <div className="flex items-center gap-1 shrink-0">
-                    <DictationButton onText={(t) => setInput((prev) => appendDictation(prev, t))} />
+                    <DictationButton
+                      onText={(t) => setInput((prev) => appendDictation(prev, t))}
+                      mobileProminent={!input.trim() && pendingFiles.length === 0}
+                    />
                     <Button
                       type="button"
                       variant="ghost"
                       size="icon-sm"
                       onClick={() => fileInputRef.current?.click()}
                       title="Attach files"
-                      className="text-muted-foreground hover:text-foreground"
+                      className="text-muted-foreground hover:text-foreground max-md:size-11 max-md:rounded-xl"
                     >
                       <RiAttachmentLine size={16} />
                     </Button>
                     <Button
                       type="submit"
                       disabled={!input.trim() && pendingFiles.length === 0}
-                      className="bg-accent-200 hover:bg-accent-300 disabled:opacity-30 disabled:hover:bg-accent-200 text-accent-on rounded-lg press-scale"
+                      className={cn(
+                        "bg-accent-200 hover:bg-accent-300 disabled:opacity-30 disabled:hover:bg-accent-200 text-accent-on rounded-lg press-scale max-md:size-12 max-md:rounded-xl",
+                        !input.trim() && pendingFiles.length === 0 && "max-md:hidden",
+                      )}
                       size="icon-sm"
                     >
                       <RiSendPlaneLine size={16} />
@@ -1690,14 +1696,17 @@ export default function ChatPanel({
                     <ModelPicker models={agentModels} selectedModel={selectedModel} onSelect={selectModel} loadState={modelLoadState} disabled={isStreaming} />
                   </div>
                   <div className="flex items-center gap-1 shrink-0">
-                    <DictationButton onText={(t) => setInput((prev) => appendDictation(prev, t))} />
+                    <DictationButton
+                      onText={(t) => setInput((prev) => appendDictation(prev, t))}
+                      mobileProminent={!input.trim() && pendingFiles.length === 0}
+                    />
                     <Button
                       type="button"
                       variant="ghost"
                       size="icon-sm"
                       onClick={() => fileInputRef.current?.click()}
                       title="Attach files"
-                      className="text-muted-foreground hover:text-foreground"
+                      className="text-muted-foreground hover:text-foreground max-md:size-11 max-md:rounded-xl"
                     >
                       <RiAttachmentLine size={16} />
                     </Button>
@@ -1717,7 +1726,10 @@ export default function ChatPanel({
                       type="submit"
                       size="icon-sm"
                       disabled={!input.trim() && pendingFiles.length === 0}
-                      className="bg-accent-200 hover:bg-accent-300 disabled:opacity-40 disabled:hover:bg-accent-200 text-accent-on rounded-lg press-scale"
+                      className={cn(
+                        "bg-accent-200 hover:bg-accent-300 disabled:opacity-40 disabled:hover:bg-accent-200 text-accent-on rounded-lg press-scale max-md:size-12 max-md:rounded-xl",
+                        !input.trim() && pendingFiles.length === 0 && "max-md:hidden",
+                      )}
                     >
                       <RiSendPlaneLine size={16} />
                     </Button>

--- a/dashboard/src/components/composer/DictationButton.tsx
+++ b/dashboard/src/components/composer/DictationButton.tsx
@@ -15,13 +15,14 @@ export function appendDictation(prev: string, text: string): string {
 interface DictationButtonProps {
   onText: (text: string) => void;
   disabled?: boolean;
+  mobileProminent?: boolean;
   className?: string;
 }
 
 /** Mic toggle for composers: tap to record, tap again to stop + transcribe
  * (server-side, Deepgram Nova-3). Hidden where MediaRecorder/getUserMedia
  * are unavailable (e.g. plain HTTP). */
-export function DictationButton({ onText, disabled, className }: DictationButtonProps) {
+export function DictationButton({ onText, disabled, mobileProminent, className }: DictationButtonProps) {
   const { state, seconds, error, supported, toggle } = useDictation(onText);
   const buttonRef = useRef<HTMLButtonElement>(null);
 
@@ -62,7 +63,7 @@ export function DictationButton({ onText, disabled, className }: DictationButton
         title="Stop and transcribe (Option + Space)"
         aria-keyshortcuts="Alt+Space"
         className={cn(
-          "h-7 gap-1.5 rounded-lg px-2 text-red-600 hover:text-red-600 hover:bg-red-500/10",
+          "h-7 gap-1.5 rounded-lg px-2 text-red-600 hover:text-red-600 hover:bg-red-500/10 max-md:h-11 max-md:px-3",
           className,
         )}
       >
@@ -90,6 +91,8 @@ export function DictationButton({ onText, disabled, className }: DictationButton
       aria-keyshortcuts="Alt+Space"
       className={cn(
         error ? "text-destructive" : "text-muted-foreground hover:text-foreground",
+        "max-md:size-11 max-md:rounded-xl",
+        mobileProminent && "max-md:size-12 max-md:bg-accent-200 max-md:text-accent-on max-md:hover:bg-accent-300 max-md:hover:text-accent-on max-md:[&_svg]:size-5",
         className,
       )}
     >

--- a/dashboard/src/components/composer/DictationButton.tsx
+++ b/dashboard/src/components/composer/DictationButton.tsx
@@ -59,11 +59,12 @@ export function DictationButton({ onText, disabled, mobileProminent, className }
         type="button"
         variant="ghost"
         size="sm"
-        onClick={toggle}
-        title="Stop and transcribe (Option + Space)"
-        aria-keyshortcuts="Alt+Space"
-        className={cn(
-          "h-7 gap-1.5 rounded-lg px-2 text-red-600 hover:text-red-600 hover:bg-red-500/10 max-md:h-11 max-md:px-3",
+      onClick={toggle}
+      title="Stop and transcribe (Option + Space)"
+      aria-label="Stop dictation and transcribe"
+      aria-keyshortcuts="Alt+Space"
+      className={cn(
+          "h-7 gap-1.5 rounded-lg px-2 text-red-600 hover:text-red-600 hover:bg-red-500/10 max-md:order-last max-md:h-12 max-md:px-4 max-md:ring-2 max-md:ring-red-500/20",
           className,
         )}
       >
@@ -88,11 +89,12 @@ export function DictationButton({ onText, disabled, mobileProminent, className }
       onClick={toggle}
       disabled={disabled || state === "transcribing"}
       title={error ?? "Dictate (Option + Space)"}
+      aria-label={state === "transcribing" ? "Transcribing dictation" : "Start dictation"}
       aria-keyshortcuts="Alt+Space"
       className={cn(
         error ? "text-destructive" : "text-muted-foreground hover:text-foreground",
-        "max-md:size-11 max-md:rounded-xl",
-        mobileProminent && "max-md:size-12 max-md:bg-accent-200 max-md:text-accent-on max-md:hover:bg-accent-300 max-md:hover:text-accent-on max-md:[&_svg]:size-5",
+        "max-md:order-last max-md:size-11 max-md:rounded-xl",
+        mobileProminent && "max-md:size-12 max-md:bg-accent-200 max-md:text-accent-on max-md:ring-2 max-md:ring-accent-200/25 max-md:ring-offset-2 max-md:hover:bg-accent-300 max-md:hover:text-accent-on max-md:[&_svg]:size-6",
         className,
       )}
     >

--- a/dashboard/src/components/tasks/QuickAddTask.tsx
+++ b/dashboard/src/components/tasks/QuickAddTask.tsx
@@ -108,10 +108,10 @@ export function QuickAddTask({ onAdded }: QuickAddTaskProps) {
               loadState={loadState}
             />
           </div>
-          <div className="flex items-center gap-1 shrink-0">
+          <div className="flex items-center gap-1 max-md:gap-2 shrink-0">
             <DictationButton
               onText={(t) => setValue((prev) => appendDictation(prev, t))}
-              mobileProminent={!value.trim() && files.length === 0}
+              mobileProminent
             />
             <Button
               type="button"

--- a/dashboard/src/components/tasks/QuickAddTask.tsx
+++ b/dashboard/src/components/tasks/QuickAddTask.tsx
@@ -10,6 +10,7 @@ import { useAgentModels } from "@/hooks/useAgentModels";
 import { ModelPicker } from "@/components/composer/ModelPicker";
 import { PendingFilesStrip } from "@/components/composer/PendingFilesStrip";
 import { DictationButton, appendDictation } from "@/components/composer/DictationButton";
+import { cn } from "@/lib/utils";
 
 interface QuickAddTaskProps {
   onAdded: () => void;
@@ -108,14 +109,17 @@ export function QuickAddTask({ onAdded }: QuickAddTaskProps) {
             />
           </div>
           <div className="flex items-center gap-1 shrink-0">
-            <DictationButton onText={(t) => setValue((prev) => appendDictation(prev, t))} />
+            <DictationButton
+              onText={(t) => setValue((prev) => appendDictation(prev, t))}
+              mobileProminent={!value.trim() && files.length === 0}
+            />
             <Button
               type="button"
               variant="ghost"
               size="icon-sm"
               onClick={() => fileInputRef.current?.click()}
               title="Attach files"
-              className="text-muted-foreground hover:text-foreground"
+              className="text-muted-foreground hover:text-foreground max-md:size-11 max-md:rounded-xl"
             >
               <RiAttachmentLine size={16} />
             </Button>
@@ -125,7 +129,10 @@ export function QuickAddTask({ onAdded }: QuickAddTaskProps) {
               onClick={() => void submit()}
               disabled={(!value.trim() && files.length === 0) || busy}
               aria-label="Add task"
-              className="bg-accent-200 hover:bg-accent-300 disabled:opacity-30 disabled:hover:bg-accent-200 text-accent-on rounded-lg press-scale"
+              className={cn(
+                "bg-accent-200 hover:bg-accent-300 disabled:opacity-30 disabled:hover:bg-accent-200 text-accent-on rounded-lg press-scale max-md:size-12 max-md:rounded-xl",
+                !value.trim() && files.length === 0 && "max-md:hidden",
+              )}
             >
               {busy
                 ? <RiLoader4Line size={16} className="animate-spin" />

--- a/dashboard/src/components/tasks/TaskDialog.tsx
+++ b/dashboard/src/components/tasks/TaskDialog.tsx
@@ -141,7 +141,8 @@ export function TaskDialog({ open, onOpenChange, lanes, task, defaultLane, onSub
               <Label htmlFor="task-details">Details</Label>
               <DictationButton
                 onText={(t) => setPrompt((prev) => appendDictation(prev, t))}
-                className="-my-1"
+                mobileProminent={!prompt.trim()}
+                className="-my-1 max-md:my-0"
               />
             </div>
             <Textarea

--- a/dashboard/src/components/tasks/TaskDialog.tsx
+++ b/dashboard/src/components/tasks/TaskDialog.tsx
@@ -141,7 +141,7 @@ export function TaskDialog({ open, onOpenChange, lanes, task, defaultLane, onSub
               <Label htmlFor="task-details">Details</Label>
               <DictationButton
                 onText={(t) => setPrompt((prev) => appendDictation(prev, t))}
-                mobileProminent={!prompt.trim()}
+                mobileProminent
                 className="-my-1 max-md:my-0"
               />
             </div>


### PR DESCRIPTION
## Summary
- Keeps dictation in the rightmost mobile action position in every composer state
- Makes the mic a persistent 48px highlighted target, including after the user has typed text
- Adds stronger visual separation, a larger mic glyph, visible focus ring, and explicit screen-reader labels

## Testing
- `npx tsc --noEmit` ✅
- Targeted ESLint on the four changed files ✅
- `npm run build` ✅
- Full `npm run lint` remains blocked by 20 pre-existing errors outside these files
- Ran Loma locally against an isolated throwaway database and verified at a 390x844 mobile viewport

### Empty composer: dictation is primary and rightmost
![Empty mobile composer](https://cdn.plotline.so/loma-images/pr-screenshots/loma-mobile-dictation-empty.png)

### Typed composer: dictation remains available in the rightmost slot
![Typed mobile composer](https://cdn.plotline.so/loma-images/pr-screenshots/loma-mobile-dictation-typed.png)

## Context
On mobile, typing already has a large interaction area. This change makes starting dictation equally easy without removing access after the user has typed text. The mic stays at the right edge for predictable thumb reach and muscle memory.

## Changes
- `dashboard/src/components/composer/DictationButton.tsx`: adds a persistent prominent mobile state, rightmost ordering, focus treatment, and accessible labels
- `dashboard/src/components/ChatPanel.tsx`: keeps the mic rightmost and increases action spacing in both chat composers
- `dashboard/src/components/tasks/QuickAddTask.tsx`: keeps the mic rightmost and prominent in quick task creation
- `dashboard/src/components/tasks/TaskDialog.tsx`: enlarges and promotes dictation in task details on mobile

## Notes
- Desktop behavior remains unchanged
- This is a draft PR and should be reviewed before merging
