### PR TITLE
feat: capture Slack messages with :loma-task:

### DIFF
--- a/api/task_service.py
+++ b/api/task_service.py
@@ -1,0 +1,66 @@
+"""Shared task creation helpers used by HTTP and external integrations."""
+
+import uuid
+from datetime import datetime, timezone
+
+from api.task_routes import _get_board_config_for
+
+
+async def create_staged_task(
+    db,
+    user_email: str,
+    prompt: str,
+    *,
+    title: str | None = None,
+    model: str = "",
+    metadata: dict | None = None,
+    dedupe_filter: dict | None = None,
+) -> tuple[dict, bool]:
+    """Create a Todo task, returning ``(document, created)``.
+
+    ``dedupe_filter`` lets event-driven callers make retries idempotent.
+    """
+    if dedupe_filter:
+        existing = await db.conversations.find_one(dedupe_filter)
+        if existing:
+            return existing, False
+
+    board = await _get_board_config_for(db, user_email)
+    lane = board["lanes"][0]["id"]
+    now = datetime.now(timezone.utc)
+    task_metadata = {"user_name": user_email}
+    task_metadata.update(metadata or {})
+    doc = {
+        "conversation_id": str(uuid.uuid4()),
+        "source": task_metadata.get("source", "dashboard"),
+        "started_at": None,
+        "finished_at": None,
+        "duration_ms": None,
+        "status": None,
+        "metadata": task_metadata,
+        "prompt": prompt,
+        "model": model,
+        "total_turns": 0,
+        "final_response": "",
+        "messages": [],
+        "confidence": None,
+        "cost": None,
+        "savings": None,
+        "claude_account": None,
+        "error": None,
+        "deleted": False,
+        "title": title,
+        "title_edited": bool(title),
+        "task_status": "todo",
+        "task_lane": lane,
+        "task_rank": -now.timestamp(),
+        "task_created_at": now,
+        "task_staged_at": now,
+        "task_started_at": None,
+        "task_done_at": None,
+        "task_tag_ids": [],
+        "task_priority": None,
+        "task_deadline": None,
+    }
+    await db.conversations.insert_one(doc)
+    return doc, True

--- a/slack_app/handlers.py
+++ b/slack_app/handlers.py
@@ -24,6 +24,7 @@ from draft_with_loma.auth import get_user_slack_token
 logger = logging.getLogger(__name__)
 
 THINKING_EMOJI = "hourglass_flowing_sand"
+TASK_CAPTURE_EMOJI = "loma-task"
 
 CONVERSATION_TRACKER_BASE_URL = os.environ.get("PUBLIC_BASE_URL", "http://localhost:3001").rstrip("/") + "/conversations"
 
@@ -366,6 +367,16 @@ def register_handlers(app):
             "slack_dm", user,
         )
 
+    @app.event("reaction_added")
+    async def handle_task_reaction(event, client):
+        """Capture a Slack message as a staged Loma task."""
+        if event.get("reaction") != TASK_CAPTURE_EMOJI:
+            return
+        item = event.get("item") or {}
+        if item.get("type") != "message" or not item.get("channel") or not item.get("ts"):
+            return
+        await _capture_loma_task(client, event)
+
     # ─── Draft with Loma: message shortcut ───────────────────────────
 
     @app.shortcut("draft_with_loma")
@@ -539,6 +550,105 @@ async def _resolve_user_email(client, slack_user_id: str) -> str | None:
     except Exception as e:
         logger.warning("[DRAFT] Failed to resolve email for %s: %s", slack_user_id, e)
         return None
+
+
+def _task_title(message: dict) -> str:
+    text = " ".join((message.get("text") or "").split())
+    return f"Slack: {text[:72]}" if text else "Slack task"
+
+
+async def _capture_loma_task(client, event: dict) -> None:
+    """Create an idempotent Todo task from a ``:loma-task:`` reaction."""
+    from slack_sdk.web.async_client import AsyncWebClient
+    from api.task_service import create_staged_task
+
+    item = event["item"]
+    channel_id = item["channel"]
+    message_ts = item["ts"]
+    slack_user_id = event["user"]
+
+    try:
+        user_email = await _resolve_user_email(client, slack_user_id)
+        if not user_email:
+            raise RuntimeError("Couldn't resolve your Slack email")
+
+        user_token = await get_user_slack_token(user_email)
+        user_client = AsyncWebClient(token=user_token)
+        history = await user_client.conversations_history(
+            channel=channel_id, latest=message_ts, oldest=message_ts,
+            inclusive=True, limit=1,
+        )
+        messages = history.get("messages", [])
+        if not messages:
+            raise RuntimeError("Couldn't read the reacted Slack message")
+        reacted_message = messages[0]
+        thread_ts = reacted_message.get("thread_ts") or message_ts
+
+        replies = await user_client.conversations_replies(
+            channel=channel_id, ts=thread_ts, limit=100,
+        )
+        thread_messages = replies.get("messages", []) or [reacted_message]
+        permalink_result = await user_client.chat_getPermalink(
+            channel=channel_id, message_ts=message_ts,
+        )
+        permalink = permalink_result.get("permalink", "")
+
+        parts = []
+        for message in thread_messages:
+            author = message.get("user") or message.get("bot_profile", {}).get("name") or "unknown"
+            marker = " [selected]" if message.get("ts") == message_ts else ""
+            parts.append(f"[{author}]{marker}: {message.get('text', '')}")
+        prompt = (
+            "Follow up on this Slack message. Use the thread as context and complete the action requested.\n\n"
+            f"Slack link: {permalink}\n"
+            f"Channel: {channel_id}\n"
+            f"Thread:\n" + "\n".join(parts)
+        )
+
+        db = get_db()
+        if db is None:
+            raise RuntimeError("Loma task storage is unavailable")
+        metadata = {
+            "source": "slack_task",
+            "slack_user_id": slack_user_id,
+            "slack_channel_id": channel_id,
+            "slack_message_ts": message_ts,
+            "slack_thread_ts": thread_ts,
+            "slack_permalink": permalink,
+        }
+        task, created = await create_staged_task(
+            db, user_email, prompt,
+            title=_task_title(reacted_message),
+            metadata=metadata,
+            dedupe_filter={
+                "metadata.source": "slack_task",
+                "metadata.slack_channel_id": channel_id,
+                "metadata.slack_message_ts": message_ts,
+                "metadata.user_name": user_email,
+                "deleted": {"$ne": True},
+            },
+        )
+        task_url = f"{os.environ.get('PUBLIC_BASE_URL', 'http://localhost:3001').rstrip('/')}/tasks"
+        confirmation = (
+            f":white_check_mark: {'Added' if created else 'Already added'} to Loma tasks: "
+            f"<{task_url}|{task.get('title') or 'Open task'}>"
+        )
+        await _post_ephemeral_safe(
+            client, user_client, channel_id, slack_user_id, thread_ts, confirmation,
+        )
+        if created:
+            try:
+                await client.reactions_add(
+                    name="white_check_mark", channel=channel_id, timestamp=message_ts,
+                )
+            except Exception as exc:
+                logger.debug("[TASK CAPTURE] Acknowledgement reaction failed: %s", exc)
+    except Exception as exc:
+        logger.exception("[TASK CAPTURE] Failed for %s:%s", channel_id, message_ts)
+        await _post_ephemeral_safe(
+            client, None, channel_id, slack_user_id, message_ts,
+            f":x: Couldn't add this to Loma tasks: {exc}",
+        )
 
 
 async def _read_thread_with_user_token(user_token: str, channel_id: str, thread_ts: str) -> str:

--- a/tests/test_slack_task_capture.py
+++ b/tests/test_slack_task_capture.py
@@ -1,0 +1,111 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from slack_app.handlers import _capture_loma_task, _task_title
+from api.task_service import create_staged_task
+
+
+def _event(reaction="loma-task"):
+    return {
+        "reaction": reaction,
+        "user": "U_REACTOR",
+        "item": {"type": "message", "channel": "C123", "ts": "1700000000.000001"},
+    }
+
+
+def test_task_title_uses_message_text():
+    assert _task_title({"text": "  Please   review this  "}) == "Slack: Please review this"
+
+
+@pytest.mark.asyncio
+async def test_create_staged_task_uses_first_lane_and_source_metadata():
+    db = MagicMock()
+    db.conversations.find_one = AsyncMock(return_value=None)
+    db.conversations.insert_one = AsyncMock()
+    with patch("api.task_service._get_board_config_for", AsyncMock(return_value={
+        "lanes": [{"id": "inbox", "name": "Inbox", "order": 0}],
+    })):
+        task, created = await create_staged_task(
+            db, "owner@example.com", "Do the work",
+            title="Slack: Do the work", metadata={"source": "slack_task"},
+            dedupe_filter={"metadata.capture_key": "key"},
+        )
+
+    assert created is True
+    assert task["task_status"] == "todo"
+    assert task["task_lane"] == "inbox"
+    assert task["source"] == "slack_task"
+    assert task["metadata"]["user_name"] == "owner@example.com"
+    db.conversations.insert_one.assert_awaited_once_with(task)
+
+
+@pytest.mark.asyncio
+async def test_create_staged_task_returns_existing_duplicate():
+    existing = {"conversation_id": "existing"}
+    db = MagicMock()
+    db.conversations.find_one = AsyncMock(return_value=existing)
+    db.conversations.insert_one = AsyncMock()
+    task, created = await create_staged_task(
+        db, "owner@example.com", "Do the work",
+        dedupe_filter={"metadata.capture_key": "key"},
+    )
+    assert (task, created) == (existing, False)
+    db.conversations.insert_one.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_capture_creates_owned_task_with_thread_and_permalink():
+    bot = MagicMock()
+    bot.users_info = AsyncMock(return_value={"user": {"profile": {"email": "owner@example.com"}}})
+    bot.chat_postEphemeral = AsyncMock()
+    bot.reactions_add = AsyncMock()
+    user = MagicMock()
+    user.conversations_history = AsyncMock(return_value={"messages": [{
+        "ts": "1700000000.000001", "thread_ts": "1699999999.000001",
+        "user": "U_AUTHOR", "text": "Please review this",
+    }]})
+    user.conversations_replies = AsyncMock(return_value={"messages": [
+        {"ts": "1699999999.000001", "user": "U_PARENT", "text": "Context"},
+        {"ts": "1700000000.000001", "user": "U_AUTHOR", "text": "Please review this"},
+    ]})
+    user.chat_getPermalink = AsyncMock(return_value={"permalink": "https://slack.test/message"})
+    db = MagicMock()
+
+    with patch("slack_app.handlers.get_user_slack_token", AsyncMock(return_value="xoxp-token")), \
+         patch("slack_sdk.web.async_client.AsyncWebClient", return_value=user), \
+         patch("slack_app.handlers.get_db", return_value=db), \
+         patch("api.task_service.create_staged_task", AsyncMock(return_value=({"title": "Slack: Please review this"}, True))) as create:
+        await _capture_loma_task(bot, _event())
+
+    args, kwargs = create.await_args
+    assert args[1] == "owner@example.com"
+    assert "[U_AUTHOR] [selected]: Please review this" in args[2]
+    assert "https://slack.test/message" in args[2]
+    assert kwargs["metadata"]["slack_thread_ts"] == "1699999999.000001"
+    assert kwargs["dedupe_filter"]["metadata.user_name"] == "owner@example.com"
+    bot.reactions_add.assert_awaited_once()
+    bot.chat_postEphemeral.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_capture_does_not_acknowledge_duplicate_with_reaction():
+    bot = MagicMock()
+    bot.users_info = AsyncMock(return_value={"user": {"profile": {"email": "owner@example.com"}}})
+    bot.chat_postEphemeral = AsyncMock()
+    bot.reactions_add = AsyncMock()
+    user = MagicMock()
+    user.conversations_history = AsyncMock(return_value={"messages": [{
+        "ts": "1700000000.000001", "user": "U_AUTHOR", "text": "Do it",
+    }]})
+    user.conversations_replies = AsyncMock(return_value={"messages": []})
+    user.chat_getPermalink = AsyncMock(return_value={"permalink": "https://slack.test/message"})
+
+    with patch("slack_app.handlers.get_user_slack_token", AsyncMock(return_value="xoxp-token")), \
+         patch("slack_sdk.web.async_client.AsyncWebClient", return_value=user), \
+         patch("slack_app.handlers.get_db", return_value=MagicMock()), \
+         patch("api.task_service.create_staged_task", AsyncMock(return_value=({"title": "Slack: Do it"}, False))):
+        await _capture_loma_task(bot, _event())
+
+    bot.reactions_add.assert_not_awaited()
+    assert "Already added" in bot.chat_postEphemeral.await_args.kwargs["text"]


### PR DESCRIPTION
## Summary
- capture Slack messages reacted to with `:loma-task:` as staged Todo tasks
- include the selected message, full thread context, permalink, and Slack source metadata
- make repeated reactions idempotent and acknowledge successful captures in Slack

## Slack setup
Subscribe the Slack app to the `reaction_added` bot event. Existing user-token access is reused to read public, private, and DM conversations available to the reacting user.

## Testing
- `35 passed`: Slack task capture, Slack utilities, and Slack flow tests
- full suite: `346 passed`, with 2 unrelated baseline failures (`ZipFile.mkdir` on Python 3.10 and uninitialized OpenCode client pool)
- isolated Loma task-board UI smoke test

![Captured Slack task on the Loma board](https://cdn.plotline.so/loma-images/loma-prs/slack-emoji-task-capture.png)

## Notes
- This PR was generated by Loma based on the confirmed implementation plan.
- Please review carefully before merging.
