### PR TITLE
fix: remove completion tick from Slack task capture

### DIFF
--- a/slack_app/handlers.py
+++ b/slack_app/handlers.py
@@ -630,19 +630,12 @@ async def _capture_loma_task(client, event: dict) -> None:
         )
         task_url = f"{os.environ.get('PUBLIC_BASE_URL', 'http://localhost:3001').rstrip('/')}/tasks"
         confirmation = (
-            f":white_check_mark: {'Added' if created else 'Already added'} to Loma tasks: "
+            f":inbox_tray: {'Added' if created else 'Already added'} to Loma tasks: "
             f"<{task_url}|{task.get('title') or 'Open task'}>"
         )
         await _post_ephemeral_safe(
             client, user_client, channel_id, slack_user_id, thread_ts, confirmation,
         )
-        if created:
-            try:
-                await client.reactions_add(
-                    name="white_check_mark", channel=channel_id, timestamp=message_ts,
-                )
-            except Exception as exc:
-                logger.debug("[TASK CAPTURE] Acknowledgement reaction failed: %s", exc)
     except Exception as exc:
         logger.exception("[TASK CAPTURE] Failed for %s:%s", channel_id, message_ts)
         await _post_ephemeral_safe(

--- a/tests/test_slack_task_capture.py
+++ b/tests/test_slack_task_capture.py
@@ -84,8 +84,9 @@ async def test_capture_creates_owned_task_with_thread_and_permalink():
     assert "https://slack.test/message" in args[2]
     assert kwargs["metadata"]["slack_thread_ts"] == "1699999999.000001"
     assert kwargs["dedupe_filter"]["metadata.user_name"] == "owner@example.com"
-    bot.reactions_add.assert_awaited_once()
+    bot.reactions_add.assert_not_awaited()
     bot.chat_postEphemeral.assert_awaited_once()
+    assert bot.chat_postEphemeral.await_args.kwargs["text"].startswith(":inbox_tray: Added")
 
 
 @pytest.mark.asyncio
@@ -108,4 +109,4 @@ async def test_capture_does_not_acknowledge_duplicate_with_reaction():
         await _capture_loma_task(bot, _event())
 
     bot.reactions_add.assert_not_awaited()
-    assert "Already added" in bot.chat_postEphemeral.await_args.kwargs["text"]
+    assert bot.chat_postEphemeral.await_args.kwargs["text"].startswith(":inbox_tray: Already added")


### PR DESCRIPTION
## Summary
- Stop adding `:white_check_mark:` to Slack messages captured as Loma tasks
- Use `:inbox_tray:` in the private confirmation so capture is not confused with completion
- Update tests to ensure no acknowledgement reaction is added

## Context
Follow-up to #131. The automatic tick made message authors think the task had already been completed.

## Testing
- `5 passed` in `tests/test_slack_task_capture.py`
- `git diff --check` passed

## Testing screenshot
Not applicable: this is a Slack reaction-side behavior change with no Loma UI change. The automated test asserts that `reactions_add` is never called.
