### PR TITLE
feat: surface OpenCode Zen models and make Ox Alpha a favorite

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -145,18 +145,18 @@ SUPPORTED_CLAUDE_MODEL_IDS = (
 
 FAVORITE_MODEL_IDS = (
     "codex/gpt-5.6-sol",
+    "opencode/x-preview-f-free",
     "anthropic/claude-fable-5",
-    "opencode-go/deepseek-v4-flash",
 )
 
 FAVORITE_MODEL_TEMPLATES = {
-    "opencode-go/deepseek-v4-flash": {
-        "id": "opencode-go/deepseek-v4-flash",
-        "provider_id": "opencode-go",
-        "model_id": "deepseek-v4-flash",
-        "label": "OpenCode Go · DeepSeek V4 Flash",
+    "opencode/x-preview-f-free": {
+        "id": "opencode/x-preview-f-free",
+        "provider_id": "opencode",
+        "model_id": "x-preview-f-free",
+        "label": "OpenCode Zen · Ox Alpha Free",
         "context_limit": None,
-        "supports_attachments": False,
+        "supports_attachments": True,
         "supports_reasoning": True,
         "status": "active",
         "cost": {},
@@ -178,8 +178,8 @@ FAVORITE_MODEL_TEMPLATES = {
 def _ensure_favorite_models(models: list[dict]) -> list[dict]:
     """Ensure configured favorite provider/model aliases are available."""
     by_id = {model.get("id"): model for model in models}
-    if os.environ.get("OPENCODE_API_KEY") and "opencode-go/deepseek-v4-flash" not in by_id:
-        models.append(FAVORITE_MODEL_TEMPLATES["opencode-go/deepseek-v4-flash"])
+    if os.environ.get("OPENCODE_API_KEY") and "opencode/x-preview-f-free" not in by_id:
+        models.append(FAVORITE_MODEL_TEMPLATES["opencode/x-preview-f-free"])
     if os.environ.get("OPENAI_API_KEY") and "openai/gpt-5.5" not in by_id:
         models.append(FAVORITE_MODEL_TEMPLATES["openai/gpt-5.5"])
     return models
@@ -1028,7 +1028,7 @@ async def handle_agent_models(request: web.Request) -> web.Response:
         for model in catalog.get("models", []):
             model_id = model.get("model_id") or ""
             provider_id = model.get("provider_id") or ""
-            if provider_id == "opencode-go":
+            if provider_id in ("opencode-go", "opencode"):
                 if os.environ.get("OPENCODE_API_KEY"):
                     filtered_models.append(model)
                 continue

--- a/dashboard/src/app/flows/[id]/page.tsx
+++ b/dashboard/src/app/flows/[id]/page.tsx
@@ -64,7 +64,7 @@ const FAVORITE_MODEL_IDS = [
   "anthropic/claude-fable-5",
   "anthropic/claude-opus-4-7",
   "anthropic/claude-opus-4-6",
-  "opencode-go/deepseek-v4-flash",
+  "opencode/x-preview-f-free",
   "openai/gpt-5.5",
 ] as const;
 

--- a/dashboard/src/components/composer/ModelPicker.tsx
+++ b/dashboard/src/components/composer/ModelPicker.tsx
@@ -18,8 +18,8 @@ import { favoriteModelRank, isFavoriteModel, type ModelLoadState } from "@/hooks
 
 const FAVORITE_LABELS: Record<string, string> = {
   "codex/gpt-5.6-sol": "GPT 5.6 Sol",
+  "opencode/x-preview-f-free": "Ox Alpha",
   "anthropic/claude-fable-5": "Claude Fable 5",
-  "opencode-go/deepseek-v4-flash": "DeepSeek V4 Flash",
 };
 
 interface ModelPickerProps {

--- a/dashboard/src/hooks/useAgentModels.ts
+++ b/dashboard/src/hooks/useAgentModels.ts
@@ -7,8 +7,8 @@ const MODEL_STORAGE_KEY = "dashboard-chat-selected-model";
 
 export const FAVORITE_MODEL_IDS = [
   "codex/gpt-5.6-sol",
+  "opencode/x-preview-f-free",
   "anthropic/claude-fable-5",
-  "opencode-go/deepseek-v4-flash",
 ] as const;
 
 export function favoriteModelRank(model: AgentModel): number | null {


### PR DESCRIPTION
## What

Shows the full **OpenCode Zen** model catalog in the dashboard model picker and updates the favorites row.

- `api/routes.py` — `handle_agent_models` now lets the `opencode` (OpenCode Zen) provider through the filter (gated on `OPENCODE_API_KEY`, same as `opencode-go`). All 62 Zen models are now selectable.
- Favorites are now **GPT 5.6 Sol → Ox Alpha (`opencode/x-preview-f-free`) → Claude Fable 5**, replacing DeepSeek V4 Flash, in:
  - backend `FAVORITE_MODEL_IDS` + fallback `FAVORITE_MODEL_TEMPLATES`
  - `dashboard/src/hooks/useAgentModels.ts`
  - `dashboard/src/components/composer/ModelPicker.tsx` labels
  - flows page favorites list

## Why

Ox Alpha ships under the `opencode` (Zen) provider, which the previous allowlist silently dropped — it never reached the dropdown. Verified against the live OpenCode server: `x-preview-f-free` passes the runtime capability gate (`toolcall: true`, text in/out), so the API-route allowlist was the only blocker.

## Testing (local stack, throwaway DB)

Booted the full stack locally (backend :13000 + dashboard :13001, isolated `loma_local_*` DB), logged in, and asserted via the authed session:

- `GET /api/agent-models` → **135 models total**, **62 with `provider_id == "opencode"`**
- `opencode/x-preview-f-free` present, label `OpenCode Zen · Ox Alpha Free (Unlimited)`
- Top of catalog order: `["codex/gpt-5.6-sol", "opencode/x-preview-f-free", "anthropic/claude-fable-5", ...]`

### Screenshots

**Favorites row (GPT 5.6 Sol / Ox Alpha / Claude Fable 5):**

![favorites](https://cdn.plotline.so/loma-images/loma-pr/zen-favorites-picker.png)

**Searching "ox" finds Ox Alpha (favorite + opencode-go alias):**

![search](https://cdn.plotline.so/loma-images/loma-pr/zen-favorites-search-ox.png)

**`opencode` (Zen) provider group in the full list:**

![zen group](https://cdn.plotline.so/loma-images/loma-pr/zen-favorites-zen-group.png)

Test stack torn down and throwaway DB dropped after verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
