### PR TITLE
fix: capture Slack tasks from thread replies

### DIFF
--- a/slack_app/handlers.py
+++ b/slack_app/handlers.py
@@ -557,6 +557,37 @@ def _task_title(message: dict) -> str:
     return f"Slack: {text[:72]}" if text else "Slack task"
 
 
+async def _fetch_reacted_message(user_client, channel_id: str, message_ts: str) -> dict | None:
+    """Fetch a single message by ts, whether it is a top-level message or a thread reply.
+
+    ``conversations.history`` only returns top-level channel messages — thread
+    replies are invisible to it. Fall back to ``conversations.replies`` with the
+    reply's own ts, which returns the reply itself for threaded messages.
+    """
+    try:
+        history = await user_client.conversations_history(
+            channel=channel_id, latest=message_ts, oldest=message_ts,
+            inclusive=True, limit=1,
+        )
+        for message in history.get("messages", []):
+            if message.get("ts") == message_ts:
+                return message
+    except Exception as e:
+        logger.debug("[TASK CAPTURE] conversations.history failed (%s), trying replies", e)
+
+    # Thread replies don't appear in channel history — read the reply directly.
+    try:
+        replies = await user_client.conversations_replies(
+            channel=channel_id, ts=message_ts, inclusive=True, limit=1,
+        )
+        for message in replies.get("messages", []):
+            if message.get("ts") == message_ts:
+                return message
+    except Exception as e:
+        logger.warning("[TASK CAPTURE] conversations.replies failed for %s:%s: %s", channel_id, message_ts, e)
+    return None
+
+
 async def _capture_loma_task(client, event: dict) -> None:
     """Create an idempotent Todo task from a ``:loma-task:`` reaction."""
     from slack_sdk.web.async_client import AsyncWebClient
@@ -574,14 +605,9 @@ async def _capture_loma_task(client, event: dict) -> None:
 
         user_token = await get_user_slack_token(user_email)
         user_client = AsyncWebClient(token=user_token)
-        history = await user_client.conversations_history(
-            channel=channel_id, latest=message_ts, oldest=message_ts,
-            inclusive=True, limit=1,
-        )
-        messages = history.get("messages", [])
-        if not messages:
+        reacted_message = await _fetch_reacted_message(user_client, channel_id, message_ts)
+        if reacted_message is None:
             raise RuntimeError("Couldn't read the reacted Slack message")
-        reacted_message = messages[0]
         thread_ts = reacted_message.get("thread_ts") or message_ts
 
         replies = await user_client.conversations_replies(

--- a/tests/test_slack_task_capture.py
+++ b/tests/test_slack_task_capture.py
@@ -110,3 +110,62 @@ async def test_capture_does_not_acknowledge_duplicate_with_reaction():
 
     bot.reactions_add.assert_not_awaited()
     assert bot.chat_postEphemeral.await_args.kwargs["text"].startswith(":inbox_tray: Already added")
+
+
+@pytest.mark.asyncio
+async def test_capture_falls_back_to_replies_for_thread_reply_messages():
+    """Thread replies are invisible to conversations.history — the capture must
+    fall back to conversations.replies so reacting inside a thread still works."""
+    bot = MagicMock()
+    bot.users_info = AsyncMock(return_value={"user": {"profile": {"email": "owner@example.com"}}})
+    bot.chat_postEphemeral = AsyncMock()
+    bot.reactions_add = AsyncMock()
+    user = MagicMock()
+    # history returns nothing for thread replies
+    user.conversations_history = AsyncMock(return_value={"messages": []})
+
+    reply_message = {
+        "ts": "1700000000.000001", "thread_ts": "1699999999.000001",
+        "user": "U_AUTHOR", "text": "Reply inside a thread",
+    }
+
+    async def replies_side_effect(channel=None, ts=None, **kwargs):
+        if ts == "1700000000.000001":  # fetch of the reply itself
+            return {"messages": [reply_message]}
+        return {"messages": [  # full-thread fetch by parent ts
+            {"ts": "1699999999.000001", "user": "U_PARENT", "text": "Parent context"},
+            reply_message,
+        ]}
+
+    user.conversations_replies = AsyncMock(side_effect=replies_side_effect)
+    user.chat_getPermalink = AsyncMock(return_value={"permalink": "https://slack.test/reply"})
+
+    with patch("slack_app.handlers.get_user_slack_token", AsyncMock(return_value="xoxp-token")), \
+         patch("slack_sdk.web.async_client.AsyncWebClient", return_value=user), \
+         patch("slack_app.handlers.get_db", return_value=MagicMock()), \
+         patch("api.task_service.create_staged_task", AsyncMock(return_value=({"title": "Slack: Reply inside a thread"}, True))) as create:
+        await _capture_loma_task(bot, _event())
+
+    args, kwargs = create.await_args
+    assert args[1] == "owner@example.com"
+    assert "[U_AUTHOR] [selected]: Reply inside a thread" in args[2]
+    assert "[U_PARENT]: Parent context" in args[2]
+    assert kwargs["metadata"]["slack_thread_ts"] == "1699999999.000001"
+    assert bot.chat_postEphemeral.await_args.kwargs["text"].startswith(":inbox_tray: Added")
+
+
+@pytest.mark.asyncio
+async def test_capture_reports_error_when_message_unreadable_everywhere():
+    bot = MagicMock()
+    bot.users_info = AsyncMock(return_value={"user": {"profile": {"email": "owner@example.com"}}})
+    bot.chat_postEphemeral = AsyncMock()
+    user = MagicMock()
+    user.conversations_history = AsyncMock(return_value={"messages": []})
+    user.conversations_replies = AsyncMock(return_value={"messages": []})
+
+    with patch("slack_app.handlers.get_user_slack_token", AsyncMock(return_value="xoxp-token")), \
+         patch("slack_sdk.web.async_client.AsyncWebClient", return_value=user), \
+         patch("slack_app.handlers.get_db", return_value=MagicMock()):
+        await _capture_loma_task(bot, _event())
+
+    assert "Couldn't read the reacted Slack message" in bot.chat_postEphemeral.await_args.kwargs["text"]


### PR DESCRIPTION
## Summary
- Reacting with `:loma-task:` on a **thread reply** failed with "Couldn't add this to Loma tasks: Couldn't read the reacted Slack message"
- Root cause: `conversations.history` only returns top-level channel messages — thread replies are invisible to it, so the lookup came back empty
- Fix: new `_fetch_reacted_message()` helper — try `conversations.history` first (fast path for top-level messages), then fall back to `conversations.replies` with the reply's own `ts`, which returns the reply itself for threaded messages
- Full thread context, permalink, dedupe, and the `:inbox_tray:` confirmation all work unchanged for both message types

## Context
Follow-up to #131 / #132. Reported when a reaction on a threaded message in a channel failed to create a task even though the reaction event was delivered and the user token had channel access.

## Testing
- `7 passed` in `tests/test_slack_task_capture.py` (2 new: thread-reply fallback, unreadable-message error path)
- `37 passed` across all Slack test files
- Local closed-loop validation: booted the stack against a throwaway DB, simulated a `:loma-task:` reaction on a thread reply through the real `_capture_loma_task` path (with `conversations.history` returning empty, as real Slack does for thread replies) — the task was created in the Todo lane and the `:inbox_tray:` confirmation was posted

## Testing screenshot
Captured task (from a simulated thread-reply reaction) on the Tasks board:

![Thread-reply task captured on the Tasks board](https://cdn.plotline.so/loma-images/loma-pr-thread-reply-task-capture.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)