### PR TITLE
fix: replace retired Ox Alpha favorite with GLM 5.3 Flash

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -145,16 +145,16 @@ SUPPORTED_CLAUDE_MODEL_IDS = (
 
 FAVORITE_MODEL_IDS = (
     "codex/gpt-5.6-sol",
-    "opencode/x-preview-f-free",
+    "opencode-go/glm-5.3-flash",
     "anthropic/claude-fable-5",
 )
 
 FAVORITE_MODEL_TEMPLATES = {
-    "opencode/x-preview-f-free": {
-        "id": "opencode/x-preview-f-free",
-        "provider_id": "opencode",
-        "model_id": "x-preview-f-free",
-        "label": "OpenCode Zen · Ox Alpha Free",
+    "opencode-go/glm-5.3-flash": {
+        "id": "opencode-go/glm-5.3-flash",
+        "provider_id": "opencode-go",
+        "model_id": "glm-5.3-flash",
+        "label": "OpenCode Go · GLM 5.3 Flash",
         "context_limit": None,
         "supports_attachments": True,
         "supports_reasoning": True,
@@ -178,8 +178,8 @@ FAVORITE_MODEL_TEMPLATES = {
 def _ensure_favorite_models(models: list[dict]) -> list[dict]:
     """Ensure configured favorite provider/model aliases are available."""
     by_id = {model.get("id"): model for model in models}
-    if os.environ.get("OPENCODE_API_KEY") and "opencode/x-preview-f-free" not in by_id:
-        models.append(FAVORITE_MODEL_TEMPLATES["opencode/x-preview-f-free"])
+    if os.environ.get("OPENCODE_API_KEY") and "opencode-go/glm-5.3-flash" not in by_id:
+        models.append(FAVORITE_MODEL_TEMPLATES["opencode-go/glm-5.3-flash"])
     if os.environ.get("OPENAI_API_KEY") and "openai/gpt-5.5" not in by_id:
         models.append(FAVORITE_MODEL_TEMPLATES["openai/gpt-5.5"])
     return models

--- a/dashboard/src/app/flows/[id]/page.tsx
+++ b/dashboard/src/app/flows/[id]/page.tsx
@@ -64,7 +64,7 @@ const FAVORITE_MODEL_IDS = [
   "anthropic/claude-fable-5",
   "anthropic/claude-opus-4-7",
   "anthropic/claude-opus-4-6",
-  "opencode/x-preview-f-free",
+  "opencode-go/glm-5.3-flash",
   "openai/gpt-5.5",
 ] as const;
 

--- a/dashboard/src/components/composer/ModelPicker.tsx
+++ b/dashboard/src/components/composer/ModelPicker.tsx
@@ -18,7 +18,7 @@ import { favoriteModelRank, isFavoriteModel, type ModelLoadState } from "@/hooks
 
 const FAVORITE_LABELS: Record<string, string> = {
   "codex/gpt-5.6-sol": "GPT 5.6 Sol",
-  "opencode/x-preview-f-free": "Ox Alpha",
+  "opencode-go/glm-5.3-flash": "GLM 5.3 Flash",
   "anthropic/claude-fable-5": "Claude Fable 5",
 };
 

--- a/dashboard/src/hooks/useAgentModels.ts
+++ b/dashboard/src/hooks/useAgentModels.ts
@@ -7,7 +7,7 @@ const MODEL_STORAGE_KEY = "dashboard-chat-selected-model";
 
 export const FAVORITE_MODEL_IDS = [
   "codex/gpt-5.6-sol",
-  "opencode/x-preview-f-free",
+  "opencode-go/glm-5.3-flash",
   "anthropic/claude-fable-5",
 ] as const;
 


### PR DESCRIPTION
## Problem

OpenCode retired `x-preview-f-free` (Ox Alpha Free). The model picker's Favorites section still pointed at `opencode/x-preview-f-free`, so the entry rendered as "Ox Alpha" and errored when selected — the model ID no longer exists in the live OpenCode catalog (GLM 5.3 Flash now ships as `opencode-go/glm-5.3-flash`).

## Fix

Swap the retired favorite for `opencode-go/glm-5.3-flash` everywhere the favorites list is defined:

- `api/routes.py` — `FAVORITE_MODEL_IDS` ordering + `FAVORITE_MODEL_TEMPLATES` fallback template (relabeled `OpenCode Go · GLM 5.3 Flash`) + `_ensure_favorite_models` gate
- `dashboard/src/hooks/useAgentModels.ts` — `FAVORITE_MODEL_IDS`
- `dashboard/src/components/composer/ModelPicker.tsx` — `FAVORITE_LABELS` → "GLM 5.3 Flash"
- `dashboard/src/app/flows/[id]/page.tsx` — `FAVORITE_MODEL_IDS`

## Verification (local boot, logged-in browser)

Favorites now shows GLM 5.3 Flash; selecting it and sending a message works end-to-end (model replied "pong"):

![Favorites with GLM 5.3 Flash](https://cdn.plotline.so/loma-images/loma-pr-glm-favorites/favorites-open.png)

![GLM 5.3 Flash replies without error](https://cdn.plotline.so/loma-images/loma-pr-glm-favorites/glm-reply.png)