### PR TITLE
fix: replace Ox Alpha favorite with GLM 5.3 Flash

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -145,16 +145,16 @@ SUPPORTED_CLAUDE_MODEL_IDS = (
 
 FAVORITE_MODEL_IDS = (
     "codex/gpt-5.6-sol",
-    "opencode/x-preview-f-free",
+    "opencode-go/glm-5.3-flash",
     "anthropic/claude-fable-5",
 )
 
 FAVORITE_MODEL_TEMPLATES = {
-    "opencode/x-preview-f-free": {
-        "id": "opencode/x-preview-f-free",
-        "provider_id": "opencode",
-        "model_id": "x-preview-f-free",
-        "label": "OpenCode Zen · Ox Alpha Free",
+    "opencode-go/glm-5.3-flash": {
+        "id": "opencode-go/glm-5.3-flash",
+        "provider_id": "opencode-go",
+        "model_id": "glm-5.3-flash",
+        "label": "OpenCode Go · GLM 5.3 Flash",
         "context_limit": None,
         "supports_attachments": True,
         "supports_reasoning": True,
@@ -178,8 +178,8 @@ FAVORITE_MODEL_TEMPLATES = {
 def _ensure_favorite_models(models: list[dict]) -> list[dict]:
     """Ensure configured favorite provider/model aliases are available."""
     by_id = {model.get("id"): model for model in models}
-    if os.environ.get("OPENCODE_API_KEY") and "opencode/x-preview-f-free" not in by_id:
-        models.append(FAVORITE_MODEL_TEMPLATES["opencode/x-preview-f-free"])
+    if os.environ.get("OPENCODE_API_KEY") and "opencode-go/glm-5.3-flash" not in by_id:
+        models.append(FAVORITE_MODEL_TEMPLATES["opencode-go/glm-5.3-flash"])
     if os.environ.get("OPENAI_API_KEY") and "openai/gpt-5.5" not in by_id:
         models.append(FAVORITE_MODEL_TEMPLATES["openai/gpt-5.5"])
     return models

--- a/dashboard/src/app/flows/[id]/page.tsx
+++ b/dashboard/src/app/flows/[id]/page.tsx
@@ -64,7 +64,7 @@ const FAVORITE_MODEL_IDS = [
   "anthropic/claude-fable-5",
   "anthropic/claude-opus-4-7",
   "anthropic/claude-opus-4-6",
-  "opencode/x-preview-f-free",
+  "opencode-go/glm-5.3-flash",
   "openai/gpt-5.5",
 ] as const;
 

--- a/dashboard/src/components/composer/ModelPicker.tsx
+++ b/dashboard/src/components/composer/ModelPicker.tsx
@@ -18,7 +18,7 @@ import { favoriteModelRank, isFavoriteModel, type ModelLoadState } from "@/hooks
 
 const FAVORITE_LABELS: Record<string, string> = {
   "codex/gpt-5.6-sol": "GPT 5.6 Sol",
-  "opencode/x-preview-f-free": "Ox Alpha",
+  "opencode-go/glm-5.3-flash": "GLM 5.3 Flash",
   "anthropic/claude-fable-5": "Claude Fable 5",
 };
 

--- a/dashboard/src/hooks/useAgentModels.ts
+++ b/dashboard/src/hooks/useAgentModels.ts
@@ -7,7 +7,7 @@ const MODEL_STORAGE_KEY = "dashboard-chat-selected-model";
 
 export const FAVORITE_MODEL_IDS = [
   "codex/gpt-5.6-sol",
-  "opencode/x-preview-f-free",
+  "opencode-go/glm-5.3-flash",
   "anthropic/claude-fable-5",
 ] as const;
 


### PR DESCRIPTION
## Summary
- replaces the retired Ox Alpha favorite with GLM 5.3 Flash
- updates the backend fallback model metadata to the current OpenCode Go model ID
- updates favorites in chat and flow model pickers

## Verification
- Python compilation passed
- targeted ESLint passed with one pre-existing hook warning
- production Next.js build passed
- local Loma backend and dashboard booted successfully against an isolated database

## Notes
- This PR was generated by Loma based on Adarsh's request
