### PR TITLE
fix: remove the 900s wall-clock cap on OpenCode chat turns

### DIFF
--- a/agent/opencode_runtime.py
+++ b/agent/opencode_runtime.py
@@ -29,7 +29,10 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_OPENCODE_HOST = "127.0.0.1"
 DEFAULT_OPENCODE_PORT = 4097
 OPENCODE_START_TIMEOUT_SECONDS = 20
-OPENCODE_REQUEST_TIMEOUT_SECONDS = int(os.environ.get("OPENCODE_REQUEST_TIMEOUT", "900"))
+# Wall-clock cap for a whole turn. Chat turns default to 0 (no cap) so long
+# implementation work (installs, builds, test runs) is only guarded by the idle
+# watchdog, matching the Claude/Codex runtimes. Flows keep a ceiling by default.
+OPENCODE_REQUEST_TIMEOUT_SECONDS = int(os.environ.get("OPENCODE_REQUEST_TIMEOUT", "0"))
 OPENCODE_FLOW_REQUEST_TIMEOUT_SECONDS = int(os.environ.get("OPENCODE_FLOW_REQUEST_TIMEOUT", "1800"))
 OPENCODE_EVENT_BUFFER_LIMIT_BYTES = int(
     os.environ.get("OPENCODE_EVENT_BUFFER_LIMIT_BYTES", str(64 * 1024 * 1024))
@@ -998,7 +1001,7 @@ async def _iter_opencode_turn_events(
     idle_timeout_seconds: int,
     request_timeout_seconds: int,
 ) -> AsyncGenerator[dict, None]:
-    timeout = aiohttp.ClientTimeout(total=request_timeout_seconds)
+    timeout = _turn_client_timeout(request_timeout_seconds)
     prompt_task: asyncio.Task | None = None
     async with aiohttp.ClientSession(timeout=timeout, auth=_auth()) as session:
         try:
@@ -1104,6 +1107,8 @@ async def _iter_opencode_turn_events(
                     event_session_id = _event_session_id(event.get("properties") or {}) if event is not None else None
                     if event is not None and event_session_id == session_id:
                         yield event
+        except asyncio.TimeoutError as exc:
+            raise OpenCodeError(_describe_turn_timeout(request_timeout_seconds)) from exc
         finally:
             if prompt_task is not None:
                 try:
@@ -1111,6 +1116,27 @@ async def _iter_opencode_turn_events(
                 except Exception:
                     logger.exception("OpenCode prompt_async request failed")
                     raise
+
+
+def _turn_client_timeout(request_timeout_seconds: int) -> aiohttp.ClientTimeout:
+    """aiohttp timeout for a turn's event stream.
+
+    A positive value is a hard wall-clock cap on the whole turn. Zero (the
+    chat default) disables the cap; the idle watchdog is then the only guard,
+    so a turn can run as long as OpenCode keeps producing events.
+    """
+    if request_timeout_seconds > 0:
+        return aiohttp.ClientTimeout(total=request_timeout_seconds)
+    return aiohttp.ClientTimeout(total=None, sock_connect=30)
+
+
+def _describe_turn_timeout(request_timeout_seconds: int) -> str:
+    if request_timeout_seconds > 0:
+        return (
+            f"OpenCode turn exceeded the {request_timeout_seconds}s wall-clock limit "
+            "(raise OPENCODE_REQUEST_TIMEOUT / OPENCODE_FLOW_REQUEST_TIMEOUT to allow longer turns)"
+        )
+    return "OpenCode event stream connection timed out"
 
 
 async def _post_prompt_async(
@@ -1242,7 +1268,8 @@ async def run_opencode_agent(
         if is_flow_run
         else OPENCODE_REQUEST_TIMEOUT_SECONDS
     )
-    request_timeout_seconds = max(request_timeout_seconds, idle_timeout_seconds + 30)
+    if request_timeout_seconds > 0:
+        request_timeout_seconds = max(request_timeout_seconds, idle_timeout_seconds + 30)
 
     server = await _ensure_server_instance(user_mcp_overrides=user_mcp_overrides)
     base_url = server.base_url

--- a/tests/test_opencode_runtime.py
+++ b/tests/test_opencode_runtime.py
@@ -457,3 +457,26 @@ async def test_run_opencode_agent_does_not_retry_model_errors(monkeypatch):
 
     assert attempts["count"] == 1
     assert server.active_turns == 0
+
+
+def test_chat_turn_has_no_wall_clock_cap_by_default():
+    import agent.opencode_runtime as ocr
+
+    assert ocr.OPENCODE_REQUEST_TIMEOUT_SECONDS == 0
+    timeout = ocr._turn_client_timeout(ocr.OPENCODE_REQUEST_TIMEOUT_SECONDS)
+    assert timeout.total is None
+    assert timeout.sock_connect == 30
+
+
+def test_flow_turn_keeps_wall_clock_cap():
+    import agent.opencode_runtime as ocr
+
+    timeout = ocr._turn_client_timeout(ocr.OPENCODE_FLOW_REQUEST_TIMEOUT_SECONDS)
+    assert timeout.total == ocr.OPENCODE_FLOW_REQUEST_TIMEOUT_SECONDS
+
+
+def test_turn_timeout_message_is_explicit():
+    import agent.opencode_runtime as ocr
+
+    assert "1800s wall-clock limit" in ocr._describe_turn_timeout(1800)
+    assert "connection timed out" in ocr._describe_turn_timeout(0)


### PR DESCRIPTION
## Problem

Conversation `4ca60297-7dea-4c67-a2d3-ffbfd2beb396` died at exactly 900s while OpenCode was still actively streaming events (mid `npm install` / `eslint`). The turn was not idle, and the server had not crashed; it hit the hard `aiohttp.ClientTimeout(total=900)` (`OPENCODE_REQUEST_TIMEOUT`) that wraps the whole SSE stream. The resulting `asyncio.TimeoutError` was stored as an empty error, so the UI just stopped.

Claude and Codex have no per-turn wall-clock cap, which is why long implementation tasks survive there.

## Fix (`agent/opencode_runtime.py`)

- `OPENCODE_REQUEST_TIMEOUT` now defaults to `0` = **no wall-clock cap for chat turns**. The 480s idle watchdog (from #138) is the only guard, same as the other runtimes. Setting the env var to a positive value re-enables a cap.
- Flows keep their `OPENCODE_FLOW_REQUEST_TIMEOUT` (1800s) ceiling.
- `_turn_client_timeout()` builds `ClientTimeout(total=None, sock_connect=30)` when uncapped.
- A wall-clock timeout is now raised as an explicit `OpenCodeError` ("OpenCode turn exceeded the Ns wall-clock limit ...") instead of a bare `asyncio.TimeoutError`, so it lands in `conversation.error` and the UI.

## Testing

- 3 new unit tests (`test_chat_turn_has_no_wall_clock_cap_by_default`, `test_flow_turn_keeps_wall_clock_cap`, `test_turn_timeout_message_is_explicit`).
- `pytest tests`: 356 passed, 2 failed. Both failures (`test_zip_with_only_directories`, `test_stream_agent_uses_opencode_runtime_by_default`) are pre-existing and fail identically on clean `main`.
- Live smoke test against the running OpenCode server with `opencode-go/glm-5.3-flash`:

```
OpenCode turn prepared model=opencode-go/glm-5.3-flash source=dashboard ... idle_timeout=480s request_timeout=0s
OpenCode turn completed model=opencode-go/glm-5.3-flash total=7.403s first_event=2.716s first_text=7.291s input_tokens=994 output_tokens=3
REPLY: OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)