### PR TITLE
feat: add Claude Fable 5.1 support in model picker + favorites

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -138,6 +138,7 @@ logger = logging.getLogger(__name__)
 SUPPORTED_CLAUDE_MODEL_IDS = (
     "claude-opus-5",
     "claude-opus-4-8",
+    "claude-fable-5-1",
     "claude-fable-5",
     "claude-opus-4-7",
     "claude-opus-4-6",
@@ -145,8 +146,8 @@ SUPPORTED_CLAUDE_MODEL_IDS = (
 
 FAVORITE_MODEL_IDS = (
     "codex/gpt-5.6-sol",
+    "anthropic/claude-fable-5-1",
     "opencode-go/glm-5.3-flash",
-    "anthropic/claude-fable-5",
 )
 
 FAVORITE_MODEL_TEMPLATES = {

--- a/dashboard/src/app/flows/[id]/page.tsx
+++ b/dashboard/src/app/flows/[id]/page.tsx
@@ -61,6 +61,7 @@ const LABEL_COLORS = [
 const FAVORITE_MODEL_IDS = [
   "anthropic/claude-opus-5",
   "anthropic/claude-opus-4-8",
+  "anthropic/claude-fable-5-1",
   "anthropic/claude-fable-5",
   "anthropic/claude-opus-4-7",
   "anthropic/claude-opus-4-6",

--- a/dashboard/src/components/composer/ModelPicker.tsx
+++ b/dashboard/src/components/composer/ModelPicker.tsx
@@ -19,7 +19,7 @@ import { favoriteModelRank, isFavoriteModel, type ModelLoadState } from "@/hooks
 const FAVORITE_LABELS: Record<string, string> = {
   "codex/gpt-5.6-sol": "GPT 5.6 Sol",
   "opencode-go/glm-5.3-flash": "GLM 5.3 Flash",
-  "anthropic/claude-fable-5": "Claude Fable 5",
+  "anthropic/claude-fable-5-1": "Claude Fable 5.1",
 };
 
 interface ModelPickerProps {

--- a/dashboard/src/hooks/useAgentModels.ts
+++ b/dashboard/src/hooks/useAgentModels.ts
@@ -7,8 +7,8 @@ const MODEL_STORAGE_KEY = "dashboard-chat-selected-model";
 
 export const FAVORITE_MODEL_IDS = [
   "codex/gpt-5.6-sol",
+  "anthropic/claude-fable-5-1",
   "opencode-go/glm-5.3-flash",
-  "anthropic/claude-fable-5",
 ] as const;
 
 export function favoriteModelRank(model: AgentModel): number | null {


### PR DESCRIPTION
## What

Adds **Claude Fable 5.1** (`claude-fable-5-1`) to the Loma model catalog and swaps it in for Fable 5 in the favorites picker.

- `api/routes.py`: add `claude-fable-5-1` to `SUPPORTED_CLAUDE_MODEL_IDS`; replace `anthropic/claude-fable-5` with `anthropic/claude-fable-5-1` in `FAVORITE_MODEL_IDS`
- `dashboard/src/hooks/useAgentModels.ts`: same favorites swap on the frontend
- `dashboard/src/components/composer/ModelPicker.tsx`: favorite label "Claude Fable 5.1"
- `dashboard/src/app/flows/[id]/page.tsx`: add `anthropic/claude-fable-5-1` to the flows favorites list (Fable 5 kept for existing flows)

Note: Opus 5.1 was originally in scope but `claude-opus-5-1` (and alternate ID formats) is rejected by the Anthropic Models API, so it was left out. Fable 5.1 was verified live against the API before shipping.

## Testing

Booted the full stack locally (isolated backend :13000 + dashboard :13001 against a throwaway DB), logged in, and verified in-browser:

**Favorites row — Fable 5.1 replaces Fable 5:**

![Model picker favorites](https://cdn.plotline.so/loma-images/loma-pr/fable51-picker-favorites.png)

**Search "fable" — `claude-fable-5-1` resolves in the catalog:**

![Model picker fable search](https://cdn.plotline.so/loma-images/loma-pr/fable51-picker-search.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)