### PR TITLE
feat: activity tab filters, skills folders & delete, conversation title fixes

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -271,11 +271,22 @@ async def _ensure_search_index(db) -> bool:
         return False
 
 
+def _fallback_title(prompt: str) -> str:
+    """Extract first few meaningful words from the prompt as a fallback title."""
+    words = prompt.strip().split()[:6]
+    if not words:
+        return "Untitled conversation"
+    title = " ".join(words)
+    if len(title) > 50:
+        title = title[:47] + "..."
+    return title
+
+
 async def _generate_title_llm(prompt: str, response_snippet: str = "") -> str:
     """Generate a short 5-word conversation title using Claude Haiku.
 
     Uses the claude CLI (same pattern as observability/confidence.py).
-    Returns 'Untitled conversation' on any failure.
+    Falls back to extracting words from the prompt on any failure.
     """
     context = prompt[:500]
     if response_snippet:
@@ -301,7 +312,7 @@ async def _generate_title_llm(prompt: str, response_snippet: str = "") -> str:
 
         if proc.returncode != 0:
             logger.warning("Title generation CLI failed (rc=%d): %s", proc.returncode, stderr.decode()[:500])
-            return "Untitled conversation"
+            return _fallback_title(prompt)
 
         output = stdout.decode().strip()
         try:
@@ -315,14 +326,14 @@ async def _generate_title_llm(prompt: str, response_snippet: str = "") -> str:
         words = title.split()
         if len(words) > 8:
             title = " ".join(words[:8])
-        return title or "Untitled conversation"
+        return title or _fallback_title(prompt)
 
     except asyncio.TimeoutError:
         logger.warning("Title generation timed out")
-        return "Untitled conversation"
+        return _fallback_title(prompt)
     except Exception as e:
         logger.warning("Title generation failed: %s", e)
-        return "Untitled conversation"
+        return _fallback_title(prompt)
 
 
 async def _classify_topic_llm(prompt: str, response_snippet: str = "") -> str:
@@ -1256,19 +1267,74 @@ async def handle_update_skill_scope(request: web.Request) -> web.Response:
 
 
 async def handle_delete_skill(request: web.Request) -> web.Response:
+    require_analyst_or_above(request)
+    db = get_db()
+    if db is None:
+        return web.json_response({"error": "MongoDB is not configured"}, status=503)
+    name = request.match_info["name"]
+    skill = await db.skills.find_one(
+        {"slug": skill_service.slugify(name), "enabled": {"$ne": False}},
+    )
+    if not skill:
+        return web.json_response({"error": "Skill not found"}, status=404)
+    scope = skill.get("scope", "personal")
+    if scope == "system":
+        return web.json_response({"error": "System skills cannot be deleted"}, status=403)
+    user_email = get_user_email(request)
+    if scope == "workspace":
+        require_admin(request)
+    elif skill.get("created_by", "") != user_email:
+        raise web.HTTPForbidden(
+            text='{"error": "You can only delete your own personal skills"}',
+            content_type="application/json",
+        )
+    try:
+        await skill_service.delete_skill(db, slug=name, actor=user_email, source="dashboard")
+        await _refresh_skill_prompt_cache()
+        return web.json_response({"ok": True})
+    except skill_service.SkillError as exc:
+        return _skill_error_response(exc)
+
+
+async def handle_update_skill_folder(request: web.Request) -> web.Response:
+    """PUT /api/skills/{name}/folder — move a skill to a folder."""
+    require_analyst_or_above(request)
+    db = get_db()
+    if db is None:
+        return web.json_response({"error": "MongoDB is not configured"}, status=503)
+    try:
+        body = await request.json()
+        skill = await skill_service.update_skill_folder(
+            db,
+            slug=request.match_info["name"],
+            folder=body.get("folder"),
+            actor=get_user_email(request),
+            folder_source="manual",
+        )
+        return web.json_response(skill)
+    except skill_service.SkillError as exc:
+        return _skill_error_response(exc)
+
+
+async def handle_list_skill_folders(request: web.Request) -> web.Response:
+    """GET /api/skills-folders — list distinct folder names."""
+    require_analyst_or_above(request)
+    db = get_db()
+    if db is None:
+        return web.json_response({"error": "MongoDB is not configured"}, status=503)
+    folders = await skill_service.list_folders(db)
+    return web.json_response({"folders": folders})
+
+
+async def handle_auto_organize_skills(request: web.Request) -> web.Response:
+    """POST /api/skills-organize — trigger AI auto-organization of unfoldered skills."""
     require_maintainer_or_above(request)
     db = get_db()
     if db is None:
         return web.json_response({"error": "MongoDB is not configured"}, status=503)
     try:
-        await skill_service.delete_skill(
-            db,
-            slug=request.match_info["name"],
-            actor=get_user_email(request),
-            source="dashboard",
-        )
-        await _refresh_skill_prompt_cache()
-        return web.json_response({"ok": True})
+        result = await skill_service.auto_organize_skills(db)
+        return web.json_response(result)
     except skill_service.SkillError as exc:
         return _skill_error_response(exc)
 
@@ -1812,6 +1878,9 @@ def setup_api_routes(app: web.Application):
     app.router.add_put("/api/skills/{name}", handle_update_skill)
     app.router.add_delete("/api/skills/{name}", handle_delete_skill)
     app.router.add_put("/api/skills/{name}/scope", handle_update_skill_scope)
+    app.router.add_put("/api/skills/{name}/folder", handle_update_skill_folder)
+    app.router.add_get("/api/skills-folders", handle_list_skill_folders)
+    app.router.add_post("/api/skills-organize", handle_auto_organize_skills)
     app.router.add_put("/api/skills/{name}/files", handle_update_skill_file)
     app.router.add_delete("/api/skills/{name}/files", handle_delete_skill_file)
     app.router.add_post("/api/skills/{name}/assets", handle_upload_skill_asset)

--- a/api/skill_service.py
+++ b/api/skill_service.py
@@ -227,6 +227,7 @@ async def ensure_skill_indexes(db) -> None:
     await db.skills.create_index("slug", unique=True)
     await db.skills.create_index("enabled")
     await db.skills.create_index("scope")
+    await db.skills.create_index("folder")
     await db.skills.create_index([("updated_at", -1)])
     await db.skill_files.create_index([("skill_slug", 1), ("path", 1)], unique=True)
     await db.skill_files.create_index("content_hash")
@@ -250,6 +251,8 @@ async def get_skill(db, slug: str) -> dict[str, Any]:
     files = await _load_files(db, slug)
     skill_doc = serialize_doc(skill) or {}
     skill_doc["scope"] = skill_doc.get("scope") or ("system" if skill_doc.get("created_by") in ("system", "import") else "personal")
+    skill_doc["folder"] = skill_doc.get("folder") or None
+    skill_doc["folder_source"] = skill_doc.get("folder_source") or None
     skill_doc["files"] = files
     skill_md = next((f for f in files if f["path"] == "SKILL.md"), None)
     skill_doc["content"] = skill_md.get("content", "") if skill_md else ""
@@ -284,6 +287,8 @@ async def list_skills(db) -> list[dict[str, Any]]:
         doc["has_extra_files"] = bool(doc["files"])
         doc["name"] = doc.get("name") or doc["slug"]
         doc["scope"] = doc.get("scope") or ("system" if doc.get("created_by") in ("system", "import") else "personal")
+        doc["folder"] = doc.get("folder") or None
+        doc["folder_source"] = doc.get("folder_source") or None
     return docs
 
 
@@ -472,6 +477,130 @@ async def delete_skill(db, *, slug: str, actor: str, source: str = "dashboard") 
     if result.matched_count == 0:
         raise SkillError("Skill not found", status=404)
     await _record_version(db, slug, actor, source, "Disabled skill")
+
+
+async def update_skill_folder(
+    db, *, slug: str, folder: str | None, actor: str, folder_source: str = "manual",
+) -> dict[str, Any]:
+    slug = slugify(slug)
+    skill = await db.skills.find_one({"slug": slug, "enabled": {"$ne": False}})
+    if not skill:
+        raise SkillError("Skill not found", status=404)
+    if skill.get("scope") == "system":
+        raise SkillError("Cannot organize system skills into folders", status=403)
+    folder = folder.strip() if folder else None
+    await db.skills.update_one(
+        {"slug": slug},
+        {"$set": {
+            "folder": folder,
+            "folder_source": folder_source,
+            "updated_at": now_utc(),
+            "updated_by": actor,
+        }},
+    )
+    msg = f"Moved to folder '{folder}'" if folder else "Removed from folder"
+    await _record_version(db, slug, actor, "dashboard", msg)
+    return await get_skill(db, slug)
+
+
+async def list_folders(db) -> list[str]:
+    folders = await db.skills.distinct(
+        "folder", {"enabled": {"$ne": False}, "folder": {"$ne": None}},
+    )
+    return sorted([f for f in folders if f])
+
+
+async def auto_organize_skills(db) -> dict[str, Any]:
+    """Categorize unorganized skills into business-function folders using LLM."""
+    import asyncio
+    import json as json_module
+    import logging
+
+    logger = logging.getLogger("loma.skill_organize")
+
+    unorganized = await db.skills.find({
+        "enabled": {"$ne": False},
+        "scope": {"$ne": "system"},
+        "$or": [{"folder": {"$exists": False}}, {"folder": None}],
+    }).to_list(500)
+
+    if not unorganized:
+        return {"organized": 0, "total": 0, "message": "No unorganized skills found"}
+
+    creator_emails = list({s.get("created_by", "") for s in unorganized if s.get("created_by")})
+    teams = await db.teams.find({"members": {"$in": creator_emails}}).to_list(50) if creator_emails else []
+    email_to_teams: dict[str, list[str]] = {}
+    for team in teams:
+        for member in team.get("members", []):
+            email_to_teams.setdefault(member, []).append(team.get("name", ""))
+
+    skill_lines = []
+    for skill in unorganized:
+        slug = skill.get("slug", "")
+        name = skill.get("name", slug)
+        desc = skill.get("description", "")
+        tags = ", ".join(skill.get("tags") or [])
+        creator_teams = ", ".join(email_to_teams.get(skill.get("created_by", ""), []))
+        skill_lines.append(
+            f"- slug: {slug} | name: {name} | description: {desc} | tags: {tags} | creator_teams: {creator_teams}"
+        )
+
+    BATCH_SIZE = 40
+    total_organized = 0
+    timestamp = now_utc()
+
+    for i in range(0, len(skill_lines), BATCH_SIZE):
+        batch = skill_lines[i:i + BATCH_SIZE]
+        batch_skills = unorganized[i:i + BATCH_SIZE]
+
+        message = (
+            "Categorize these skills into business-function folders. "
+            "Choose from: Sales, CSM, Engineering, Legal, Account Receivables, "
+            "Product, Marketing, Operations, HR, Finance, General.\n"
+            "Return ONLY a JSON object mapping each slug to its folder name.\n"
+            "Example: {\"my-skill\": \"Sales\", \"other-skill\": \"Engineering\"}\n\n"
+            "Skills:\n" + "\n".join(batch)
+        )
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "claude", "-p", message,
+                "--model", "claude-haiku-4-5-20251001",
+                "--max-turns", "1",
+                "--output-format", "json",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=60)
+            if proc.returncode != 0:
+                logger.warning("Skill organize CLI failed (rc=%d): %s", proc.returncode, stderr.decode()[:500])
+                continue
+
+            output = stdout.decode().strip()
+            try:
+                envelope = json_module.loads(output)
+                raw = envelope.get("result", output)
+                mapping = json_module.loads(raw) if isinstance(raw, str) else raw
+            except (json_module.JSONDecodeError, TypeError):
+                logger.warning("Failed to parse LLM response for skill organize batch")
+                continue
+
+            for skill in batch_skills:
+                slug = skill.get("slug", "")
+                folder = mapping.get(slug)
+                if folder and isinstance(folder, str):
+                    await db.skills.update_one(
+                        {"slug": slug, "folder": None},
+                        {"$set": {"folder": folder.strip(), "folder_source": "auto", "updated_at": timestamp}},
+                    )
+                    total_organized += 1
+
+        except asyncio.TimeoutError:
+            logger.warning("Skill organize batch timed out")
+        except Exception as e:
+            logger.warning("Skill organize batch failed: %s", e)
+
+    return {"organized": total_organized, "total": len(unorganized), "message": f"Organized {total_organized} of {len(unorganized)} skills"}
 
 
 async def get_skill_file(db, slug: str, path: str) -> dict[str, Any]:

--- a/dashboard/src/app/chat/page.tsx
+++ b/dashboard/src/app/chat/page.tsx
@@ -72,6 +72,19 @@ function ChatPageContent() {
     setConversationOwner(user?.email || null);
   }, [user?.email]);
 
+  // After stream completes, poll for the async-generated title
+  const handleStreamComplete = useCallback((convId: string) => {
+    setTimeout(async () => {
+      try {
+        const data = await fetchConversation(convId);
+        if (data.conversation?.title) {
+          setConversationTitle(data.conversation.title);
+        }
+        window.dispatchEvent(new Event("conversations-updated"));
+      } catch {}
+    }, 4000);
+  }, []);
+
   useEffect(() => {
     if (flowId) {
       loadFlow();
@@ -420,6 +433,7 @@ function ChatPageContent() {
         systemContext={skillContextParam || undefined}
         initialStatus={initialStatus}
         onConversationCreated={handleConversationCreated}
+        onStreamComplete={handleStreamComplete}
       />
     </div>
   );

--- a/dashboard/src/app/conversations/page.tsx
+++ b/dashboard/src/app/conversations/page.tsx
@@ -7,6 +7,8 @@ import { useSession } from "next-auth/react";
 import { fetchConversations, fetchStats } from "../../lib/api";
 import type { Conversation, StatsResponse } from "../../lib/api";
 import { useUser } from "../../lib/UserContext";
+import { fetchUsers } from "../../lib/governance-api";
+import type { User } from "../../lib/governance-api";
 import ChatContextMenu from "../../components/ChatContextMenu";
 import ClientTimestamp from "../../components/ClientTimestamp";
 import { Button } from "@/components/ui/button";
@@ -19,7 +21,8 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   RiSearchLine, RiCloseLine, RiRefreshLine, RiChat1Line,
-  RiAtLine, RiChat3Line, RiLinksLine, RiComputerLine, RiGitBranchLine, RiTaskLine
+  RiAtLine, RiChat3Line, RiLinksLine, RiComputerLine, RiGitBranchLine, RiTaskLine,
+  RiUserLine
 } from "@remixicon/react";
 import { cn } from "@/lib/utils";
 import { EmptyState } from "@/components/EmptyState";
@@ -132,7 +135,7 @@ function MobileSkeletonCard() {
 export default function ConversationsPage() {
   const router = useRouter();
   const { data: session } = useSession();
-  const { isPinned, togglePin, projects, renameConversation, removeConversation, assignToProject, unassignFromProject, addProject, refreshProjects } = useUser();
+  const { isAdmin, isPinned, togglePin, projects, renameConversation, removeConversation, assignToProject, unassignFromProject, addProject, refreshProjects } = useUser();
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [stats, setStats] = useState<StatsResponse | null>(null);
   const [page, setPage] = useState(1);
@@ -144,6 +147,8 @@ export default function ConversationsPage() {
   const [personFilter, setPersonFilter] = useState("");
   const [topicFilter, setTopicFilter] = useState("");
   const [loading, setLoading] = useState(true);
+  const [teamUsers, setTeamUsers] = useState<User[]>([]);
+  const [personFilterReady, setPersonFilterReady] = useState(false);
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -156,14 +161,21 @@ export default function ConversationsPage() {
   useEffect(() => {
     if (session?.user?.email) {
       setPersonFilter(session.user.email);
+      setPersonFilterReady(true);
       setPage(1);
     }
   }, [session?.user?.email]);
 
   useEffect(() => {
-    if (!personFilter) return;
+    if (isAdmin) {
+      fetchUsers().then(setTeamUsers).catch(() => {});
+    }
+  }, [isAdmin]);
+
+  useEffect(() => {
+    if (!personFilterReady) return;
     loadData();
-  }, [page, sourceFilter, categoryFilter, debouncedSearch, personFilter, topicFilter]);
+  }, [page, sourceFilter, categoryFilter, debouncedSearch, personFilter, topicFilter, personFilterReady]);
 
   async function loadData() {
     setLoading(true);
@@ -189,7 +201,7 @@ export default function ConversationsPage() {
     }
   }
 
-  const hasActiveFilters = sourceFilter || categoryFilter || debouncedSearch || topicFilter;
+  const hasActiveFilters = sourceFilter || categoryFilter || debouncedSearch || topicFilter || (isAdmin && personFilter !== session?.user?.email);
 
   const clearFilters = useCallback(() => {
     setSourceFilter("");
@@ -197,8 +209,9 @@ export default function ConversationsPage() {
     setSearchQuery("");
     setDebouncedSearch("");
     setTopicFilter("");
+    if (session?.user?.email) setPersonFilter(session.user.email);
     setPage(1);
-  }, []);
+  }, [session?.user?.email]);
 
   function formatDuration(ms: number | null | undefined) {
     if (!ms) return null;
@@ -226,6 +239,30 @@ export default function ConversationsPage() {
             />
           </div>
           <div className="flex flex-wrap items-center gap-2 flex-1">
+            {isAdmin && (
+              <Select
+                value={personFilter || "__all__"}
+                onValueChange={(val) => { setPersonFilter(val === "__all__" ? "" : val); setPage(1); }}
+              >
+                <SelectTrigger className="w-auto min-w-[140px] bg-card border-border text-[13px] text-foreground">
+                  <div className="flex items-center gap-1.5">
+                    <RiUserLine size={14} className="text-muted-foreground shrink-0" />
+                    <SelectValue placeholder="My Chats" />
+                  </div>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={session?.user?.email || "__me__"}>My Chats</SelectItem>
+                  <SelectItem value="__all__">All Users</SelectItem>
+                  {teamUsers
+                    .filter((u) => u.email !== session?.user?.email)
+                    .map((u) => (
+                      <SelectItem key={u.email} value={u.email}>
+                        {u.name || u.email}
+                      </SelectItem>
+                    ))}
+                </SelectContent>
+              </Select>
+            )}
             <Select
               value={sourceFilter || "__all__"}
               onValueChange={(val) => { setSourceFilter(val === "__all__" ? "" : val); setPage(1); }}

--- a/dashboard/src/app/skills/components/SkillTreeSidebar.tsx
+++ b/dashboard/src/app/skills/components/SkillTreeSidebar.tsx
@@ -1,16 +1,22 @@
 "use client";
 
+import { useState, useRef, useEffect } from "react";
 import Link from "next/link";
 import type { Skill, SkillFile } from "../../../lib/api";
-import { updateSkillScope } from "../../../lib/api";
+import { updateSkillScope, updateSkillFolder, deleteSkill, autoOrganizeSkills } from "../../../lib/api";
+import { useUser } from "../../../lib/UserContext";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import {
@@ -23,6 +29,12 @@ import {
   RiGroupLine,
   RiUserLine,
   RiMoreLine,
+  RiFolderLine,
+  RiFolderOpenLine,
+  RiDeleteBinLine,
+  RiSparklingLine,
+  RiCloseLine,
+  RiCheckLine,
 } from "@remixicon/react";
 
 type ScopeKey = "workspace" | "personal" | "system";
@@ -60,13 +72,38 @@ export default function SkillTreeSidebar({
   width?: number;
   onSkillsChanged?: () => void;
 }) {
-  const grouped: Record<ScopeKey, Skill[]> = { workspace: [], personal: [], system: [] };
+  const { user, isAdmin, hasRole } = useUser();
+  const userEmail = user?.email || "";
+  const isMaintainer = hasRole("maintainer");
+
+  const [showNewFolder, setShowNewFolder] = useState<string | null>(null);
+  const [newFolderName, setNewFolderName] = useState("");
+  const [organizing, setOrganizing] = useState(false);
+  const folderInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (showNewFolder && folderInputRef.current) {
+      folderInputRef.current.focus();
+    }
+  }, [showNewFolder]);
+
+  // Group skills: Scope → Folder → Skills
+  const allFolders = new Set<string>();
+  const grouped: Record<ScopeKey, { ungrouped: Skill[]; folders: Map<string, Skill[]> }> = {
+    workspace: { ungrouped: [], folders: new Map() },
+    personal: { ungrouped: [], folders: new Map() },
+    system: { ungrouped: [], folders: new Map() },
+  };
+
   for (const skill of skills) {
-    const scope = skill.scope || "personal";
-    if (scope in grouped) {
-      grouped[scope as ScopeKey].push(skill);
+    const scope = (skill.scope || "personal") as ScopeKey;
+    const target = grouped[scope] || grouped.personal;
+    if (skill.folder) {
+      allFolders.add(skill.folder);
+      if (!target.folders.has(skill.folder)) target.folders.set(skill.folder, []);
+      target.folders.get(skill.folder)!.push(skill);
     } else {
-      grouped.personal.push(skill);
+      target.ungrouped.push(skill);
     }
   }
 
@@ -74,9 +111,207 @@ export default function SkillTreeSidebar({
     try {
       await updateSkillScope(slug, newScope);
       onSkillsChanged?.();
-    } catch {
-      // silent
+    } catch {}
+  }
+
+  async function handleMoveFolder(slug: string, folder: string | null) {
+    try {
+      await updateSkillFolder(slug, folder);
+      onSkillsChanged?.();
+    } catch {}
+  }
+
+  async function handleDelete(slug: string, name: string) {
+    if (!confirm(`Delete skill "${name}"? This cannot be undone.`)) return;
+    try {
+      await deleteSkill(slug);
+      onSkillsChanged?.();
+    } catch {}
+  }
+
+  async function handleAutoOrganize() {
+    setOrganizing(true);
+    try {
+      await autoOrganizeSkills();
+      onSkillsChanged?.();
+    } catch {} finally {
+      setOrganizing(false);
     }
+  }
+
+  function handleCreateFolder(slug: string) {
+    const trimmed = newFolderName.trim();
+    if (trimmed) {
+      handleMoveFolder(slug, trimmed);
+    }
+    setShowNewFolder(null);
+    setNewFolderName("");
+  }
+
+  function canDelete(skill: Skill, scopeKey: ScopeKey): boolean {
+    if (scopeKey === "system") return false;
+    if (scopeKey === "workspace") return isAdmin;
+    return skill.created_by === userEmail;
+  }
+
+  function renderSkillRow(skill: Skill, scopeKey: ScopeKey) {
+    const slug = skill.slug || skill.name;
+    const isSelected = selectedSkillSlug === slug;
+    const isSkillExpanded = expandedSkills.has(slug);
+    const files = skillFiles[slug] || skill.file_details || [];
+    const extraFiles = files.filter((f) => f.path !== "SKILL.md");
+    const hasExtraFiles = extraFiles.length > 0;
+    const isMovable = scopeKey !== "system";
+    const deletable = canDelete(skill, scopeKey);
+
+    return (
+      <div key={slug}>
+        <div
+          className={cn(
+            "group flex items-center gap-1 px-3 py-1.5 rounded-md mx-1 cursor-pointer transition-colors",
+            isSelected && !selectedFilePath
+              ? "bg-accent text-accent-foreground"
+              : "text-foreground/80 hover:bg-muted"
+          )}
+        >
+          {hasExtraFiles ? (
+            <button
+              onClick={(e) => { e.stopPropagation(); onToggleSkill(slug); }}
+              className="p-0.5 flex-shrink-0"
+            >
+              <RiArrowRightSLine
+                size={14}
+                className={cn(
+                  "text-muted-foreground transition-transform duration-150",
+                  isSkillExpanded && "rotate-90"
+                )}
+              />
+            </button>
+          ) : (
+            <span className="w-[18px] flex-shrink-0" />
+          )}
+          <button
+            onClick={() => onSelectSkill(slug)}
+            className="flex-1 text-left text-[13px] truncate"
+          >
+            {skill.name || slug}
+          </button>
+          {(isMovable || deletable) && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  onClick={(e) => e.stopPropagation()}
+                  className="p-0.5 rounded flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground hover:text-foreground"
+                >
+                  <RiMoreLine size={14} />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="min-w-[180px]">
+                {isMovable && (
+                  <>
+                    {scopeKey === "personal" ? (
+                      <DropdownMenuItem onClick={() => handleMoveScope(slug, "workspace")}>
+                        <RiGroupLine size={14} className="text-muted-foreground" />
+                        Move to Workspace
+                      </DropdownMenuItem>
+                    ) : scopeKey === "workspace" ? (
+                      <DropdownMenuItem onClick={() => handleMoveScope(slug, "personal")}>
+                        <RiUserLine size={14} className="text-muted-foreground" />
+                        Move to Personal
+                      </DropdownMenuItem>
+                    ) : null}
+
+                    <DropdownMenuSub>
+                      <DropdownMenuSubTrigger onClick={(e) => e.stopPropagation()}>
+                        <RiFolderLine size={14} className="text-muted-foreground" />
+                        {skill.folder ? "Change folder" : "Move to folder"}
+                      </DropdownMenuSubTrigger>
+                      <DropdownMenuSubContent className="w-48">
+                        {skill.folder && (
+                          <DropdownMenuItem onClick={() => handleMoveFolder(slug, null)}>
+                            <RiCloseLine size={14} />
+                            Remove from folder
+                          </DropdownMenuItem>
+                        )}
+                        {[...allFolders].sort().map((f) => (
+                          <DropdownMenuItem
+                            key={f}
+                            onClick={() => handleMoveFolder(slug, f)}
+                            className={f === skill.folder ? "text-brand-600 font-medium" : ""}
+                          >
+                            <RiFolderLine size={14} className="text-muted-foreground" />
+                            <span className="truncate">{f}</span>
+                            {f === skill.folder && (
+                              <RiCheckLine size={14} className="text-brand-600 ml-auto flex-shrink-0" />
+                            )}
+                          </DropdownMenuItem>
+                        ))}
+                        {showNewFolder === slug ? (
+                          <div className="px-2 py-1.5">
+                            <Input
+                              ref={folderInputRef}
+                              type="text"
+                              value={newFolderName}
+                              onChange={(e) => setNewFolderName(e.target.value)}
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter") handleCreateFolder(slug);
+                                if (e.key === "Escape") { setShowNewFolder(null); setNewFolderName(""); }
+                              }}
+                              placeholder="Folder name..."
+                              className="h-7 text-xs"
+                            />
+                          </div>
+                        ) : (
+                          <DropdownMenuItem onClick={(e) => { e.preventDefault(); setShowNewFolder(slug); setNewFolderName(""); }}>
+                            <RiAddLine size={14} className="text-muted-foreground" />
+                            New folder
+                          </DropdownMenuItem>
+                        )}
+                      </DropdownMenuSubContent>
+                    </DropdownMenuSub>
+                  </>
+                )}
+                {deletable && (
+                  <>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      variant="destructive"
+                      onClick={() => handleDelete(slug, skill.name || slug)}
+                    >
+                      <RiDeleteBinLine size={14} />
+                      Delete
+                    </DropdownMenuItem>
+                  </>
+                )}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+        </div>
+
+        {hasExtraFiles && isSkillExpanded && (
+          <div className="ml-6">
+            {files.map((file) => {
+              const isFileSelected = isSelected && selectedFilePath === file.path;
+              return (
+                <button
+                  key={file.path}
+                  onClick={() => onSelectSkill(slug, file.path)}
+                  className={cn(
+                    "w-full flex items-center gap-1.5 px-3 py-1 rounded-md mx-1 text-left transition-colors",
+                    isFileSelected
+                      ? "bg-accent text-accent-foreground"
+                      : "text-muted-foreground hover:bg-muted hover:text-foreground"
+                  )}
+                >
+                  <RiFileLine size={14} className="flex-shrink-0" />
+                  <span className="text-xs truncate">{file.path}</span>
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    );
   }
 
   return (
@@ -101,6 +336,15 @@ export default function SkillTreeSidebar({
               <RiGlobalLine size={16} className="text-muted-foreground" />
               Explore
             </DropdownMenuItem>
+            {isMaintainer && (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={handleAutoOrganize} disabled={organizing}>
+                  <RiSparklingLine size={16} className="text-muted-foreground" />
+                  {organizing ? "Organizing..." : "Auto-organize"}
+                </DropdownMenuItem>
+              </>
+            )}
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
@@ -109,7 +353,8 @@ export default function SkillTreeSidebar({
       <ScrollArea className="flex-1 min-h-0">
         <div className="py-2">
           {SECTIONS.map(({ key, label, showInfo }) => {
-            const sectionSkills = grouped[key];
+            const { ungrouped, folders } = grouped[key];
+            const totalCount = ungrouped.length + [...folders.values()].reduce((n, s) => n + s.length, 0);
             const isOpen = expandedSections.has(key);
 
             return (
@@ -123,110 +368,45 @@ export default function SkillTreeSidebar({
                     className={cn("transition-transform duration-150", isOpen && "rotate-90")}
                   />
                   <span>{label}</span>
+                  <span className="text-muted-foreground/50 font-normal normal-case">({totalCount})</span>
                   {showInfo && <RiInformationLine size={12} className="text-muted-foreground/50" />}
                 </button>
 
                 {isOpen && (
                   <div className="ml-2">
-                    {sectionSkills.length === 0 ? (
+                    {totalCount === 0 ? (
                       <div className="px-4 py-1.5 text-xs text-muted-foreground">No skills</div>
                     ) : (
-                      sectionSkills.map((skill) => {
-                        const slug = skill.slug || skill.name;
-                        const isSelected = selectedSkillSlug === slug;
-                        const isSkillExpanded = expandedSkills.has(slug);
-                        const files = skillFiles[slug] || skill.file_details || [];
-                        const extraFiles = files.filter((f) => f.path !== "SKILL.md");
-                        const hasExtraFiles = extraFiles.length > 0;
-                        const isMovable = key !== "system";
-
-                        return (
-                          <div key={slug}>
-                            <div
-                              className={cn(
-                                "group flex items-center gap-1 px-3 py-1.5 rounded-md mx-1 cursor-pointer transition-colors",
-                                isSelected && !selectedFilePath
-                                  ? "bg-accent text-accent-foreground"
-                                  : "text-foreground/80 hover:bg-muted"
-                              )}
-                            >
-                              {hasExtraFiles ? (
-                                <button
-                                  onClick={(e) => {
-                                    e.stopPropagation();
-                                    onToggleSkill(slug);
-                                  }}
-                                  className="p-0.5 flex-shrink-0"
-                                >
-                                  <RiArrowRightSLine
-                                    size={14}
-                                    className={cn(
-                                      "text-muted-foreground transition-transform duration-150",
-                                      isSkillExpanded && "rotate-90"
-                                    )}
-                                  />
-                                </button>
-                              ) : (
-                                <span className="w-[18px] flex-shrink-0" />
-                              )}
+                      <>
+                        {/* Folders */}
+                        {[...folders.entries()].sort(([a], [b]) => a.localeCompare(b)).map(([folderName, folderSkills]) => {
+                          const folderKey = `folder:${key}:${folderName}`;
+                          const isFolderOpen = expandedSections.has(folderKey);
+                          return (
+                            <div key={folderKey}>
                               <button
-                                onClick={() => onSelectSkill(slug)}
-                                className="flex-1 text-left text-[13px] truncate"
+                                onClick={() => onToggleSection(folderKey)}
+                                className="w-full flex items-center gap-1.5 px-3 py-1.5 rounded-md mx-1 text-[12px] text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
                               >
-                                {skill.name || slug}
+                                {isFolderOpen ? (
+                                  <RiFolderOpenLine size={14} className="flex-shrink-0 text-amber-500" />
+                                ) : (
+                                  <RiFolderLine size={14} className="flex-shrink-0 text-amber-500" />
+                                )}
+                                <span className="truncate font-medium">{folderName}</span>
+                                <span className="text-muted-foreground/50 text-[11px] ml-auto">{folderSkills.length}</span>
                               </button>
-                              {isMovable && (
-                                <DropdownMenu>
-                                  <DropdownMenuTrigger asChild>
-                                    <button
-                                      onClick={(e) => e.stopPropagation()}
-                                      className="p-0.5 rounded flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity text-muted-foreground hover:text-foreground"
-                                    >
-                                      <RiMoreLine size={14} />
-                                    </button>
-                                  </DropdownMenuTrigger>
-                                  <DropdownMenuContent align="end" className="min-w-[160px]">
-                                    {key === "personal" ? (
-                                      <DropdownMenuItem onClick={() => handleMoveScope(slug, "workspace")}>
-                                        <RiGroupLine size={14} className="text-muted-foreground" />
-                                        Move to Workspace
-                                      </DropdownMenuItem>
-                                    ) : (
-                                      <DropdownMenuItem onClick={() => handleMoveScope(slug, "personal")}>
-                                        <RiUserLine size={14} className="text-muted-foreground" />
-                                        Move to Personal
-                                      </DropdownMenuItem>
-                                    )}
-                                  </DropdownMenuContent>
-                                </DropdownMenu>
+                              {isFolderOpen && (
+                                <div className="ml-3">
+                                  {folderSkills.map((skill) => renderSkillRow(skill, key))}
+                                </div>
                               )}
                             </div>
-
-                            {hasExtraFiles && isSkillExpanded && (
-                              <div className="ml-6">
-                                {files.map((file) => {
-                                  const isFileSelected = isSelected && selectedFilePath === file.path;
-                                  return (
-                                    <button
-                                      key={file.path}
-                                      onClick={() => onSelectSkill(slug, file.path)}
-                                      className={cn(
-                                        "w-full flex items-center gap-1.5 px-3 py-1 rounded-md mx-1 text-left transition-colors",
-                                        isFileSelected
-                                          ? "bg-accent text-accent-foreground"
-                                          : "text-muted-foreground hover:bg-muted hover:text-foreground"
-                                      )}
-                                    >
-                                      <RiFileLine size={14} className="flex-shrink-0" />
-                                      <span className="text-xs truncate">{file.path}</span>
-                                    </button>
-                                  );
-                                })}
-                              </div>
-                            )}
-                          </div>
-                        );
-                      })
+                          );
+                        })}
+                        {/* Ungrouped skills */}
+                        {ungrouped.map((skill) => renderSkillRow(skill, key))}
+                      </>
                     )}
                   </div>
                 )}

--- a/dashboard/src/app/skills/page.tsx
+++ b/dashboard/src/app/skills/page.tsx
@@ -171,7 +171,10 @@ function SkillsPageInner() {
     if (selectedSkillSlug) {
       fetchSkill(selectedSkillSlug)
         .then(setSkillDetail)
-        .catch(() => {});
+        .catch(() => {
+          setSkillDetail(null);
+          updateUrl(null);
+        });
     }
     loadSkills();
   }

--- a/dashboard/src/components/ChatPanel.tsx
+++ b/dashboard/src/components/ChatPanel.tsx
@@ -550,6 +550,7 @@ export default function ChatPanel({
   onArtifactClose,
   artifacts: externalArtifacts,
   onConversationCreated,
+  onStreamComplete,
 }: {
   initialItems?: ChatItem[];
   /** Artifacts restored from history (persisted in MongoDB) */
@@ -576,6 +577,8 @@ export default function ChatPanel({
   artifacts?: Artifact[];
   /** Called when a new conversation is created (ID available) */
   onConversationCreated?: (conversationId: string) => void;
+  /** Called when the agent stream finishes (for post-stream title refresh) */
+  onStreamComplete?: (conversationId: string) => void;
 } = {}) {
   const { data: session } = useSession();
   const standalone = useStandalone();
@@ -1128,6 +1131,9 @@ export default function ChatPanel({
       if (!enteredRecovery) {
         setIsStreaming(false);
         setStreamStartedAt(null);
+        if (activeConversationId && onStreamComplete) {
+          onStreamComplete(activeConversationId);
+        }
       }
       abortControllerRef.current = null;
       scrollToBottom();

--- a/dashboard/src/components/ChatWithArtifacts.tsx
+++ b/dashboard/src/components/ChatWithArtifacts.tsx
@@ -82,6 +82,7 @@ export default function ChatWithArtifacts({
   systemContext,
   initialStatus,
   onConversationCreated,
+  onStreamComplete,
   draftStorageKey,
 }: {
   initialItems?: ChatItem[];
@@ -94,6 +95,7 @@ export default function ChatWithArtifacts({
   systemContext?: string;
   initialStatus?: string;
   onConversationCreated?: (conversationId: string) => void;
+  onStreamComplete?: (conversationId: string) => void;
   /** localStorage key for persisting unsent composer text (see ChatPanel) */
   draftStorageKey?: string;
 }) {
@@ -169,6 +171,7 @@ export default function ChatWithArtifacts({
           onArtifactClose={handleArtifactClose}
           artifacts={artifacts}
           onConversationCreated={onConversationCreated}
+          onStreamComplete={onStreamComplete}
         />
       </div>
 

--- a/dashboard/src/components/Sidebar.tsx
+++ b/dashboard/src/components/Sidebar.tsx
@@ -380,6 +380,13 @@ export default function Sidebar({
     }
   }, [status, session?.user?.email, pinnedIds.size]);
 
+  // Refresh sidebar conversations when a stream completes (title may have been generated)
+  useEffect(() => {
+    const handler = () => reloadConversations();
+    window.addEventListener("conversations-updated", handler);
+    return () => window.removeEventListener("conversations-updated", handler);
+  }, [reloadConversations]);
+
   // Close sidebar on route change (mobile)
   useEffect(() => {
     onClose();

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -239,6 +239,8 @@ export interface Skill {
   updated_at?: string;
   created_by?: string;
   scope?: "system" | "personal" | "workspace";
+  folder?: string | null;
+  folder_source?: "manual" | "auto" | null;
 }
 
 export interface SkillFile {
@@ -262,6 +264,8 @@ export interface SkillDetailResponse {
   updated_at?: string;
   created_by?: string;
   scope?: "system" | "personal" | "workspace";
+  folder?: string | null;
+  folder_source?: "manual" | "auto" | null;
 }
 
 export async function fetchSkills(): Promise<{ skills: Skill[] }> {
@@ -361,6 +365,28 @@ export async function deleteSkill(name: string): Promise<{ ok: boolean }> {
   if (!res.ok) {
     const err = await res.json().catch(() => ({}));
     throw new Error(err.error || `Failed to delete skill: ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function updateSkillFolder(name: string, folder: string | null): Promise<SkillDetailResponse> {
+  const res = await fetch(`${API_BASE}/api/skills/${encodeURIComponent(name)}/folder`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ folder }),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.error || `Failed to update skill folder: ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function autoOrganizeSkills(): Promise<{ organized: number; total: number; message: string }> {
+  const res = await fetch(`${API_BASE}/api/skills-organize`, { method: "POST" });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.error || `Failed to auto-organize skills: ${res.status}`);
   }
   return res.json();
 }

--- a/scheduler/engine.py
+++ b/scheduler/engine.py
@@ -75,6 +75,17 @@ async def init_scheduler():
     )
     logger.info("Usage check job registered (hourly at :00)")
 
+    # --- Skill auto-organization (daily at 03:00 UTC) ---
+    _scheduler.add_job(
+        _run_skill_auto_organize,
+        CronTrigger(hour=3, minute=0, timezone="UTC"),
+        id="skill_auto_organize",
+        replace_existing=True,
+        misfire_grace_time=3600,
+        max_instances=1,
+    )
+    logger.info("Skill auto-organize job registered (daily at 03:00 UTC)")
+
     logger.info("Scheduler initialized with %d active flow(s)", len(flows))
 
 
@@ -148,6 +159,21 @@ async def _run_usage_check():
         await run_usage_check()
     except Exception:
         logger.exception("[USAGE_CHECK] Hourly check failed")
+
+
+async def _run_skill_auto_organize():
+    """Wrapper for the daily skill auto-organization job."""
+    try:
+        from api.skill_service import auto_organize_skills
+        from observability.db import get_db
+        db = get_db()
+        if db is None:
+            logger.warning("[SKILL_ORGANIZE] DB not available")
+            return
+        result = await auto_organize_skills(db)
+        logger.info("[SKILL_ORGANIZE] %s", result.get("message", ""))
+    except Exception:
+        logger.exception("[SKILL_ORGANIZE] Auto-organize failed")
 
 
 async def shutdown_scheduler():


### PR DESCRIPTION
## Summary

- **Activity tab**: Fix race condition where admins see all users' chats on first render. Add person filter dropdown for admins to view specific users' conversations, defaulting to "My Chats".
- **Conversation titles**: Fix "Untitled conversation" bug by falling back to prompt excerpt when LLM title generation fails. Add post-stream delayed fetch so chat page and sidebar pick up asynchronously generated titles.
- **Skills delete**: Wire up existing delete API to the UI. Users can delete their own personal skills; admins can delete workspace skills; system skills are protected. Backend permission relaxed from maintainer-only to role-aware checks.
- **Skills folders**: Add folder organization system with `folder` and `folder_source` fields on skills. Sidebar renders a two-level tree (Scope → Folder → Skills) with collapsible folder groups, a "Move to folder" submenu with inline folder creation, and folder count badges.
- **Skills auto-organize**: Background AI job (daily cron at 03:00 UTC + on-demand button for maintainers) categorizes unfoldered skills into business-function folders (Sales, CSM, Engineering, Legal, etc.) using Claude Haiku, with team membership context for better accuracy.

## Test plan
- [ ] Admin activity tab: verify first render shows only own chats (no flash of all users)
- [ ] Admin activity tab: verify person filter dropdown works (My Chats / All Users / specific user)
- [ ] Start a new chat and verify title updates from "Untitled" after agent finishes
- [ ] Skills: delete own personal skill, verify confirm dialog and removal
- [ ] Skills: verify non-owner cannot delete another user's personal skill
- [ ] Skills: admin can delete workspace skill
- [ ] Skills: move skill into a folder, create new folder inline, remove from folder
- [ ] Skills: trigger auto-organize and verify unfoldered skills get categorized

🤖 Generated with [Claude Code](https://claude.com/claude-code)