### PR TITLE
feat: drain in-flight agent runs before deploy, notify owners on interrupt

### DIFF
--- a/api/drain.py
+++ b/api/drain.py
@@ -1,0 +1,128 @@
+"""Drain mode — stop accepting new agent runs so a deploy can wait for the
+in-flight ones to finish instead of killing them.
+
+`scripts/deploy.sh` drives this: it builds the new images first, then flips
+drain on, polls the running count until it reaches zero (bounded), and only
+then recreates the containers. Without drain, `docker compose up` SIGTERMs
+the backend mid-run and every active task/chat dies silently.
+
+State is in-process (a restart clears it, which is exactly what we want).
+
+Routes live under the public `/health` prefix so the deploy script can call
+them without a dashboard session. The mutating verbs are loopback-only: the
+script reaches them via `docker compose exec loma-backend curl ...`, while
+traffic through nginx arrives from the proxy's container IP and is refused.
+"""
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from aiohttp import web
+
+from observability.db import get_db
+from observability.observer import HEARTBEAT_INTERVAL_SECONDS
+
+logger = logging.getLogger(__name__)
+
+# A conversation only counts as "running" if its heartbeat is fresh. Docs
+# stuck at status=running with a dead heartbeat (crashed worker, legacy rows)
+# must never block a deploy forever.
+RUNNING_HEARTBEAT_WINDOW_SECONDS = HEARTBEAT_INTERVAL_SECONDS * 2
+
+# What callers show the user when a new run is refused during drain.
+DRAIN_MESSAGE = "Loma is restarting for a deploy. Please try again in a minute."
+
+_LOOPBACK = ("127.0.0.1", "::1", "::ffff:127.0.0.1")
+
+_state: dict = {"draining": False, "since": None, "reason": ""}
+
+
+def is_draining() -> bool:
+    return bool(_state["draining"])
+
+
+def drain_reason() -> str:
+    """Free-text reason set by the drainer (e.g. "deploy abc1234"), or ""."""
+    return _state["reason"] if _state["draining"] else ""
+
+
+def set_draining(on: bool, reason: str = "") -> None:
+    _state["draining"] = bool(on)
+    _state["since"] = datetime.now(timezone.utc) if on else None
+    _state["reason"] = (reason or "").strip()[:200] if on else ""
+    logger.info("[DRAIN] %s%s", "enabled" if on else "disabled",
+                f" ({_state['reason']})" if _state["reason"] else "")
+
+
+def running_query(now: datetime | None = None) -> dict:
+    """Mongo filter for conversations that are genuinely running right now."""
+    now = now or datetime.now(timezone.utc)
+    cutoff = now - timedelta(seconds=RUNNING_HEARTBEAT_WINDOW_SECONDS)
+    return {"status": "running", "last_heartbeat": {"$gte": cutoff}}
+
+
+async def running_summary(db) -> dict:
+    """Count live runs and report the oldest one (for deploy logs)."""
+    if db is None:
+        return {"running": 0, "oldest_started_at": None}
+    query = running_query()
+    running = await db.conversations.count_documents(query)
+    oldest_started_at = None
+    if running:
+        oldest = await db.conversations.find(
+            query, {"started_at": 1},
+        ).sort("started_at", 1).limit(1).to_list(1)
+        if oldest and oldest[0].get("started_at"):
+            oldest_started_at = oldest[0]["started_at"].isoformat()
+    return {"running": running, "oldest_started_at": oldest_started_at}
+
+
+def _is_loopback(request: web.Request) -> bool:
+    return (request.remote or "") in _LOOPBACK
+
+
+async def handle_health(request: web.Request) -> web.Response:
+    """GET /health — liveness probe (public)."""
+    return web.json_response({"status": "ok", "draining": is_draining()})
+
+
+async def handle_get_drain(request: web.Request) -> web.Response:
+    """GET /health/drain — drain flag plus the live running count."""
+    summary = await running_summary(get_db())
+    since = _state["since"]
+    return web.json_response({
+        "draining": is_draining(),
+        "reason": drain_reason(),
+        "since": since.isoformat() if since else None,
+        **summary,
+    })
+
+
+async def handle_set_drain(request: web.Request) -> web.Response:
+    """POST /health/drain — start refusing new agent runs (loopback only)."""
+    if not _is_loopback(request):
+        return web.json_response({"error": "Forbidden"}, status=403)
+    reason = ""
+    if request.can_read_body:
+        try:
+            body = await request.json()
+            reason = str((body or {}).get("reason") or "")
+        except Exception:
+            pass
+    set_draining(True, reason)
+    return await handle_get_drain(request)
+
+
+async def handle_clear_drain(request: web.Request) -> web.Response:
+    """DELETE /health/drain — resume accepting runs (aborted deploy)."""
+    if not _is_loopback(request):
+        return web.json_response({"error": "Forbidden"}, status=403)
+    set_draining(False)
+    return await handle_get_drain(request)
+
+
+def setup_drain_routes(app: web.Application) -> None:
+    app.router.add_get("/health", handle_health)
+    app.router.add_get("/health/drain", handle_get_drain)
+    app.router.add_post("/health/drain", handle_set_drain)
+    app.router.add_delete("/health/drain", handle_clear_drain)

--- a/api/routes.py
+++ b/api/routes.py
@@ -26,6 +26,7 @@ from api.auth_helpers import (
     require_maintainer_or_above,
 )
 from api.dashboard_ingestion import ingest_dashboard_chat
+from api.drain import DRAIN_MESSAGE, is_draining
 from api import skill_service
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
@@ -834,6 +835,11 @@ async def handle_chat(request: web.Request) -> web.Response:
     user_email = get_user_email(request)
     if not user_email:
         return web.json_response({"error": "Authentication required"}, status=401)
+
+    # A deploy is waiting for in-flight runs to finish; don't start a new one
+    # that would only get killed. The client surfaces the message as-is.
+    if is_draining():
+        return web.json_response({"error": DRAIN_MESSAGE, "draining": True}, status=503)
 
     # Set up observability — reuse existing conversation if conversation_id provided
     observer = None

--- a/api/task_routes.py
+++ b/api/task_routes.py
@@ -29,6 +29,7 @@ from aiohttp import web
 
 from observability.db import get_db
 from api.auth_helpers import get_system_role, get_user_email
+from api.drain import DRAIN_MESSAGE, is_draining
 
 logger = logging.getLogger(__name__)
 
@@ -273,6 +274,11 @@ async def handle_create_task(request: web.Request) -> web.Response:
         if total > MAX_DRAFT_FILES_BYTES:
             return web.json_response(
                 {"error": "Attachments too large (max 8MB total)"}, status=400)
+
+    # Quick-add fires an agent run immediately; refuse while a deploy drains.
+    # Plain drafts are fine — nothing runs until the user sends a message.
+    if body.get("start") and is_draining():
+        return web.json_response({"error": DRAIN_MESSAGE, "draining": True}, status=503)
 
     board = await _get_board_config_for(db, user_email)
     lane_ids = [lane["id"] for lane in board["lanes"]]

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+import signal
 from pathlib import Path
 
 from aiohttp import web
@@ -41,6 +42,7 @@ from api.file_routes import setup_file_routes
 from api.integration_routes import setup_integration_routes
 from api.prompt_settings_routes import setup_prompt_settings_routes
 from api.telegram_routes import setup_telegram_routes
+from api.drain import setup_drain_routes
 from recovery import start_recovery_loop, mark_all_running_interrupted
 from scheduler.engine import init_scheduler
 from agent.client import load_config, merge_db_integrations
@@ -141,24 +143,51 @@ async def main():
     setup_integration_routes(webhook_app)
     setup_prompt_settings_routes(webhook_app)
     setup_telegram_routes(webhook_app)
+    setup_drain_routes(webhook_app)
+
     async def on_shutdown(_app):
         await mark_all_running_interrupted()
 
     webhook_app.on_shutdown.append(on_shutdown)
-    runner = web.AppRunner(webhook_app)
+    # Short connection-drain: open SSE chats are already accounted for by
+    # on_shutdown, so don't sit on them for aiohttp's default 60s.
+    runner = web.AppRunner(webhook_app, shutdown_timeout=5.0)
     await runner.setup()
     port = int(os.environ.get("WEBHOOK_PORT", "3000"))
     site = web.TCPSite(runner, "0.0.0.0", port)
     await site.start()
     logger.info("Webhook server running on port %d", port)
 
+    # Graceful shutdown. Docker stops the container with SIGTERM; without a
+    # handler Python exits immediately and on_shutdown (which marks in-flight
+    # runs interrupted and notifies their owners) never gets to run.
+    stop = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        loop.add_signal_handler(sig, _request_stop, stop, sig)
+
     logger.info("%s is running!", APP_NAME)
     if handler:
-        await handler.start_async()
+        # connect_async runs Socket Mode in background tasks (start_async is
+        # just this plus an infinite sleep), so we can wait on `stop` instead.
+        await handler.connect_async()
     else:
         logger.info("Slack Socket Mode not started; keeping HTTP server alive")
-        # Keep the process alive for the HTTP server
-        await asyncio.Event().wait()
+    await stop.wait()
+
+    logger.info("Shutting down...")
+    if handler:
+        try:
+            await handler.close_async()
+        except Exception:
+            logger.warning("Failed to close Slack Socket Mode cleanly", exc_info=True)
+    await runner.cleanup()  # fires on_shutdown -> mark_all_running_interrupted
+    logger.info("Shutdown complete")
+
+
+def _request_stop(stop: asyncio.Event, sig: int) -> None:
+    logger.info("Received %s; starting graceful shutdown", signal.Signals(sig).name)
+    stop.set()
 
 
 if __name__ == "__main__":

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -953,7 +953,12 @@ export async function* streamChat(
     signal,
   });
 
-  if (!res.ok) throw new Error(`Chat request failed: ${res.status}`);
+  if (!res.ok) {
+    // Surface the backend's message (e.g. "restarting for a deploy") instead
+    // of a bare status code.
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.error || `Chat request failed: ${res.status}`);
+  }
   if (!res.body) throw new Error("No response body");
 
   const reader = res.body.getReader();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,10 @@ services:
       # side path so the container keeps a writable /root/.ssh for known_hosts.
       # Override LOMA_SSH_DIR if the key lives elsewhere on the host.
       - ${LOMA_SSH_DIR:-/home/ubuntu/.ssh}:/root/.ssh-host:ro
+    # On SIGTERM the backend marks in-flight runs interrupted and notifies their
+    # owners (recovery.mark_all_running_interrupted); give it time to finish
+    # before Docker's SIGKILL (default grace is only 10s).
+    stop_grace_period: 30s
     restart: unless-stopped
 
   loma-dashboard:

--- a/docs/deploys.md
+++ b/docs/deploys.md
@@ -1,0 +1,57 @@
+# Deploys drain in-flight agent runs first
+
+`scripts/deploy.sh` (run by CI on every push to `main`) no longer restarts the
+backend under whatever tasks happen to be running. It builds the new images,
+puts the running backend into **drain mode**, waits for in-flight agent runs to
+finish, and only then swaps the containers.
+
+## What drain mode does
+
+- New dashboard chats and quick-added board tasks are refused with HTTP 503 and
+  the message *"Loma is restarting for a deploy. Please try again in a minute."*
+  Staged drafts are still allowed (nothing runs until they are sent).
+- Slack mentions/DMs get the same message as a thread reply instead of a run.
+- Scheduled flows that fire while draining are **deferred**, not skipped: the
+  new server runs them right after it boots (`flows.deferred_run_at`).
+- Webhook-triggered runs (GitHub, Linear, Pylon, incoming webhooks) are not
+  gated; the deploy simply waits for them like any other run.
+
+A run counts as "in flight" only while its heartbeat is fresh (60s), so a doc
+stuck at `status: running` from a crash can never block a deploy forever.
+
+## If runs are still going when the wait expires
+
+The backend now shuts down gracefully on SIGTERM. Anything still running is
+marked `interrupted` with the error `Interrupted by deploy <sha>`, and the
+owner is told: dashboard chats/tasks get an inbox notification (plus the
+existing "Task was interrupted" push for active board tasks), Slack threads
+get a reply asking them to continue in-thread.
+
+## Knobs
+
+| Env (deploy.sh) | Default | Meaning |
+|---|---|---|
+| `DRAIN_MAX_WAIT` | `600` | Seconds to wait for `running == 0`. `0` skips draining. |
+| `DRAIN_ON_TIMEOUT` | `proceed` | `fail` aborts the deploy (and clears drain) instead of restarting over live runs. |
+
+`docker-compose.yml` gives `loma-backend` a `stop_grace_period` of 30s so the
+shutdown notifications have time to land before Docker's SIGKILL.
+
+## Endpoints (public prefix, no dashboard session)
+
+```
+GET    /health                 -> {"status": "ok", "draining": false}
+GET    /health/drain           -> {"draining", "reason", "since", "running", "oldest_started_at"}
+POST   /health/drain {"reason": "deploy abc1234"}   # loopback only
+DELETE /health/drain                                # loopback only
+```
+
+The mutating verbs only accept loopback callers. From the host, go through the
+container, which is exactly what `deploy.sh` does:
+
+```bash
+docker compose exec -T loma-backend curl -s -X POST -H 'Content-Type: application/json' \
+  -d '{"reason":"manual maintenance"}' http://127.0.0.1:3000/health/drain
+docker compose exec -T loma-backend curl -s http://127.0.0.1:3000/health/drain
+docker compose exec -T loma-backend curl -s -X DELETE http://127.0.0.1:3000/health/drain
+```

--- a/recovery.py
+++ b/recovery.py
@@ -13,7 +13,10 @@ from datetime import datetime, timedelta, timezone
 from agent.client import stream_agent
 from observability.db import get_db
 from observability.observer import ConversationObserver, HEARTBEAT_INTERVAL_SECONDS
-from recovery_handlers import post_recovery_response
+from observability.notifications import create_notification
+from observability.push import send_task_needs_input_push
+from api.drain import drain_reason
+from recovery_handlers import post_recovery_response, _post_to_slack
 
 logger = logging.getLogger(__name__)
 
@@ -24,34 +27,95 @@ RECOVERY_WINDOW_MINUTES = int(os.environ.get("RECOVERY_WINDOW_MINUTES", "10"))
 # A heartbeat is considered stale after 2x the interval (missed at least one beat).
 HEARTBEAT_STALE_SECONDS = HEARTBEAT_INTERVAL_SECONDS * 2
 
+# Cap on how long shutdown waits to notify owners of interrupted runs. Must fit
+# inside the container's stop_grace_period (docker-compose.yml) with room for
+# the Mongo writes that precede it.
+SHUTDOWN_NOTIFY_TIMEOUT_SECONDS = 8
+
 
 async def mark_all_running_interrupted():
-    """Mark all currently-running conversations as interrupted.
+    """Mark all currently-running conversations as interrupted and tell their owners.
 
     Called during graceful shutdown so the next server instance doesn't
-    have to wait for heartbeats to go stale.
+    have to wait for heartbeats to go stale. A drain-aware deploy (see
+    api/drain.py) waits for runs to finish first, so anything still running
+    here overran the drain window; make sure its owner hears about it instead
+    of finding a task that silently stopped moving.
     """
     db = get_db()
     if db is None:
         return
     now = datetime.now(timezone.utc)
+    reason = drain_reason()
+    error = f"Interrupted by {reason}" if reason else "Server shutting down"
     try:
+        affected = await db.conversations.find(
+            {"status": "running"},
+            {"conversation_id": 1, "source": 1, "metadata": 1, "task_status": 1,
+             "title": 1, "prompt": 1},
+        ).to_list(length=500)
         result = await db.conversations.update_many(
             {"status": "running"},
             {"$set": {
                 "status": "interrupted",
                 "finished_at": now,
-                "error": "Server shutting down",
+                "error": error,
             }},
         )
         if result.modified_count > 0:
             logger.info(
-                "[RECOVERY] Graceful shutdown: marked %d running conversation(s) as interrupted",
-                result.modified_count,
+                "[RECOVERY] Graceful shutdown: marked %d running conversation(s) as interrupted (%s)",
+                result.modified_count, error,
             )
     except Exception:
         logger.exception("[RECOVERY] Failed to mark conversations during shutdown")
+        return
 
+    if not affected:
+        return
+    try:
+        await asyncio.wait_for(
+            asyncio.gather(
+                *(_notify_interrupted(db, convo, error) for convo in affected),
+                return_exceptions=True,
+            ),
+            timeout=SHUTDOWN_NOTIFY_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError:
+        logger.warning("[RECOVERY] Timed out notifying owners of interrupted conversations")
+
+
+async def _notify_interrupted(db, convo: dict, error: str):
+    """Best-effort: tell one conversation's owner the restart cut their run short."""
+    conversation_id = convo.get("conversation_id", "")
+    source = convo.get("source") or ""
+    metadata = convo.get("metadata") or {}
+    try:
+        if source == "dashboard":
+            owner = metadata.get("user_name") or ""
+            if owner and "@" in owner:
+                is_task = convo.get("task_status") == "active"
+                label = (convo.get("title") or convo.get("prompt") or "")[:200]
+                # Inbox entry persists until dismissed; push is handled below.
+                await create_notification(
+                    db,
+                    user_email=owner,
+                    title=("Task" if is_task else "Chat") + " interrupted by a restart",
+                    body=f"{error}. Open the conversation and send a message to continue.\n\n{label}".strip(),
+                    conversation_id=conversation_id,
+                    source="system",
+                    fire_push=False,
+                )
+                if is_task:
+                    # Existing "Task was interrupted" push, deep-linked to the task.
+                    await send_task_needs_input_push(db, conversation_id)
+        elif source in ("slack_mention", "slack_dm") or source.startswith("slack_channel_"):
+            await _post_to_slack(
+                metadata,
+                f":warning: {error}. This request was cut short; reply in this thread to continue.",
+            )
+    except Exception as e:
+        logger.warning("[RECOVERY] Failed to notify owner of %s: %s", conversation_id, e)
 
 def start_recovery_loop():
     """Start a background task that periodically checks for interrupted conversations.

--- a/scheduler/engine.py
+++ b/scheduler/engine.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
@@ -63,6 +64,7 @@ async def init_scheduler():
     }).to_list(None)
     for flow in flows:
         _add_job_for_flow(flow)
+    await _run_deferred_flows(db, flows)
 
     # --- Usage monitoring (hourly) ---
     _scheduler.add_job(
@@ -87,6 +89,27 @@ async def init_scheduler():
     logger.info("Skill auto-organize job registered (daily at 03:00 UTC)")
 
     logger.info("Scheduler initialized with %d active flow(s)", len(flows))
+
+
+async def _run_deferred_flows(db, flows: list[dict]):
+    """Fire flows the previous server deferred while draining for a deploy.
+
+    executor.execute_flow sets `deferred_run_at` instead of running when the
+    server is draining; the trigger has already fired, so without this the run
+    would simply be lost.
+    """
+    deferred = [f for f in flows if f.get("deferred_run_at")]
+    if not deferred:
+        return
+    from scheduler.executor import execute_flow
+
+    await db.flows.update_many(
+        {"flow_id": {"$in": [f["flow_id"] for f in deferred]}},
+        {"$unset": {"deferred_run_at": ""}},
+    )
+    for flow in deferred:
+        logger.info("[SCHEDULER] Running flow %s deferred by the previous deploy", flow["flow_id"])
+        asyncio.create_task(execute_flow(flow["flow_id"]))
 
 
 def _add_job_for_flow(flow: dict):

--- a/scheduler/executor.py
+++ b/scheduler/executor.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 
 from agent.client import stream_agent
 from agent.pool import ClientPool
+from api.drain import is_draining
 from observability.db import get_db
 from observability.observer import ConversationObserver
 from scheduler.engine import get_next_run_time, remove_flow_from_scheduler
@@ -45,6 +46,16 @@ async def execute_flow(flow_id: str):
     flow = await db.flows.find_one({"flow_id": flow_id})
     if flow is None or flow["status"] != "active":
         logger.info("[SCHEDULER] Flow %s not active or not found, skipping", flow_id)
+        return
+
+    # A deploy is draining: don't start a run the restart would kill. Flag the
+    # flow so the new server runs it on boot (see engine._run_deferred_flows).
+    if is_draining():
+        logger.info("[SCHEDULER] Draining for a deploy; deferring flow %s to next startup", flow_id)
+        await db.flows.update_one(
+            {"flow_id": flow_id},
+            {"$set": {"deferred_run_at": datetime.now(timezone.utc)}},
+        )
         return
 
     logger.info("[SCHEDULER] Executing flow: %s (%s)", flow["name"], flow_id)

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,12 +2,69 @@
 # Build and (re)start the Loma stack, then verify both services respond.
 # Generic by design: contains no host/URL/secrets. Invoked by CI after the repo
 # has been fast-forwarded to origin/main on the server.
+#
+# Deploys drain first (see api/drain.py): the running backend stops accepting
+# new agent runs and we wait, bounded, for in-flight ones to finish, so the
+# container swap doesn't kill someone's task or chat halfway through.
+#   DRAIN_MAX_WAIT    seconds to wait for running=0 (default 600; 0 skips drain)
+#   DRAIN_ON_TIMEOUT  "proceed" (default) or "fail" if runs are still active
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
-echo "Deploying $(git rev-parse --short HEAD)"
+SHA=$(git rev-parse --short HEAD)
+echo "Deploying $SHA"
 
-docker compose up -d --build
+# Build while the old stack keeps serving so the swap below is quick.
+docker compose build
+
+DRAIN_MAX_WAIT="${DRAIN_MAX_WAIT:-600}"
+DRAIN_ON_TIMEOUT="${DRAIN_ON_TIMEOUT:-proceed}"
+
+# Talk to the running backend from inside its container: the drain toggles are
+# loopback-only, and this works whether or not :3000 is published on the host.
+drain_api() {
+  docker compose exec -T loma-backend curl -sf --max-time 5 -X "$1" \
+    -H 'Content-Type: application/json' "${@:2}" http://127.0.0.1:3000/health/drain
+}
+# Pull N out of {"running": N, ...} without needing jq/python on the host.
+running_count() {
+  printf '%s' "$1" | grep -o '"running": *[0-9]*' | grep -o '[0-9]*$' || true
+}
+
+running=""
+if [ "$DRAIN_MAX_WAIT" -gt 0 ] && drain_api POST -d "{\"reason\":\"deploy $SHA\"}" >/dev/null 2>&1; then
+  echo "Draining: waiting up to ${DRAIN_MAX_WAIT}s for in-flight agent runs to finish"
+  deadline=$((SECONDS + DRAIN_MAX_WAIT))
+  drained=0
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    status=$(drain_api GET 2>/dev/null || true)
+    running=$(running_count "$status")
+    if [ -z "$running" ]; then
+      echo "  drain status unavailable; not waiting"
+      drained=1
+      break
+    fi
+    if [ "$running" -eq 0 ]; then
+      drained=1
+      break
+    fi
+    echo "  $running run(s) still active ($((deadline - SECONDS))s left)"
+    sleep 10
+  done
+  if [ "$drained" = 1 ]; then
+    echo "Drained: no agent runs in flight"
+  elif [ "$DRAIN_ON_TIMEOUT" = "fail" ]; then
+    echo "Drain timed out with $running run(s) still active; aborting (DRAIN_ON_TIMEOUT=fail)"
+    drain_api DELETE >/dev/null 2>&1 || true
+    exit 1
+  else
+    echo "Drain timed out with $running run(s) still active; proceeding (owners are notified on shutdown)"
+  fi
+else
+  echo "Backend not reachable for drain (first deploy, stack down, or DRAIN_MAX_WAIT=0); proceeding"
+fi
+
+docker compose up -d
 
 # The nginx reverse-proxy config is bind-mounted. In TLS mode the nginx image
 # renders /etc/nginx/templates/*.template into /etc/nginx/conf.d/ at container

--- a/slack_app/handlers.py
+++ b/slack_app/handlers.py
@@ -6,6 +6,7 @@ import re as re_module
 
 from agent.client import stream_agent
 from api.dashboard_ingestion import ingest_dashboard_chat
+from api.drain import DRAIN_MESSAGE, is_draining
 from observability.db import get_db
 from observability.observer import ConversationObserver
 from slack_app.channels import get_channel_config
@@ -113,6 +114,16 @@ async def _handle_agent_request(
     Used by app_mention, DM, monitored-channel, and Slack-flow handlers to avoid
     duplication. When ``flow_id`` is set, the run is attributed to that flow.
     """
+    # A deploy is waiting for in-flight runs to finish; tell the user to retry
+    # rather than start a run that the restart would cut short.
+    if is_draining():
+        logger.info("[SLACK] Draining for a deploy; refusing new run in %s/%s", channel, thread_ts)
+        try:
+            await client.chat_postMessage(channel=channel, text=DRAIN_MESSAGE, thread_ts=thread_ts)
+        except Exception as e:
+            logger.warning("[SLACK] Failed to post drain notice: %s", e)
+        return
+
     # Add hourglass reaction as acknowledgement
     logger.info("[SLACK] Adding hourglass reaction to message...")
     try:

--- a/tests/test_drain.py
+++ b/tests/test_drain.py
@@ -1,0 +1,257 @@
+"""Tests for drain-before-deploy: api/drain.py, the run gates, scheduler
+deferral, and the shutdown notification path in recovery.py."""
+
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import api.drain as drain
+import recovery
+import scheduler.engine as engine
+import scheduler.executor as executor
+from api.drain import (
+    DRAIN_MESSAGE,
+    RUNNING_HEARTBEAT_WINDOW_SECONDS,
+    handle_clear_drain,
+    handle_get_drain,
+    handle_set_drain,
+    running_query,
+)
+from api.routes import handle_chat
+from api.task_routes import handle_create_task
+
+
+class FakeRequest(dict):
+    def __init__(self, *, remote="127.0.0.1", body=None, user_email="", role="chatter"):
+        super().__init__(user_email=user_email, system_role=role)
+        self.remote = remote
+        self._body = body
+        self.can_read_body = body is not None
+
+    async def json(self):
+        if self._body is None:
+            raise ValueError("no body")
+        return self._body
+
+
+def response_json(response):
+    return json.loads(response.body)
+
+
+def _db_with_running(count, oldest=None):
+    db = MagicMock()
+    db.conversations.count_documents = AsyncMock(return_value=count)
+    cursor = MagicMock()
+    cursor.sort.return_value = cursor
+    cursor.limit.return_value = cursor
+    cursor.to_list = AsyncMock(return_value=[{"started_at": oldest}] if oldest else [])
+    db.conversations.find.return_value = cursor
+    return db
+
+
+@pytest.fixture(autouse=True)
+def _reset_drain():
+    drain.set_draining(False)
+    yield
+    drain.set_draining(False)
+
+
+# ── api/drain.py ──────────────────────────────────────────────────────────
+
+
+def test_running_query_only_counts_fresh_heartbeats():
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    query = running_query(now)
+    assert query["status"] == "running"
+    assert query["last_heartbeat"] == {
+        "$gte": now - timedelta(seconds=RUNNING_HEARTBEAT_WINDOW_SECONDS)}
+
+
+@pytest.mark.asyncio
+async def test_set_drain_rejects_non_loopback():
+    response = await handle_set_drain(FakeRequest(remote="172.18.0.5", body={}))
+    assert response.status == 403
+    assert drain.is_draining() is False
+
+
+@pytest.mark.asyncio
+async def test_set_and_clear_drain_roundtrip():
+    oldest = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+    db = _db_with_running(2, oldest=oldest)
+    with patch.object(drain, "get_db", return_value=db):
+        response = await handle_set_drain(
+            FakeRequest(body={"reason": "deploy abc1234"}))
+        assert response.status == 200
+        body = response_json(response)
+        assert body["draining"] is True
+        assert body["reason"] == "deploy abc1234"
+        assert body["running"] == 2
+        assert body["oldest_started_at"] == oldest.isoformat()
+        assert drain.drain_reason() == "deploy abc1234"
+
+        response = await handle_clear_drain(FakeRequest())
+        body = response_json(response)
+        assert body["draining"] is False
+        assert body["reason"] == ""
+        assert drain.is_draining() is False
+
+
+@pytest.mark.asyncio
+async def test_get_drain_is_readable_from_anywhere_and_tolerates_no_db():
+    with patch.object(drain, "get_db", return_value=None):
+        response = await handle_get_drain(FakeRequest(remote="172.18.0.5"))
+    assert response.status == 200
+    assert response_json(response) == {
+        "draining": False, "reason": "", "since": None,
+        "running": 0, "oldest_started_at": None,
+    }
+
+
+# ── run gates ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_chat_refused_while_draining():
+    drain.set_draining(True, "deploy abc1234")
+    request = FakeRequest(body={"message": "hi"}, user_email="user@example.com")
+    response = await handle_chat(request)
+    assert response.status == 503
+    body = response_json(response)
+    assert body["error"] == DRAIN_MESSAGE
+    assert body["draining"] is True
+
+
+@pytest.mark.asyncio
+async def test_quick_add_task_refused_while_draining_but_drafts_allowed():
+    drain.set_draining(True)
+    db = MagicMock()
+    with patch("api.task_routes.get_db", return_value=db):
+        response = await handle_create_task(
+            FakeRequest(body={"prompt": "do it", "start": True}, user_email="user@example.com"))
+        assert response.status == 503
+        assert response_json(response)["error"] == DRAIN_MESSAGE
+
+        # A staged draft doesn't run anything, so it must get past the gate
+        # (it then fails on the mocked board lookup, which is fine here).
+        board = {"lanes": [{"id": "todo", "name": "Todo", "order": 0}], "prompt": "", "tags": []}
+        db.conversations.insert_one = AsyncMock()
+        with patch("api.task_routes._get_board_config_for", new=AsyncMock(return_value=board)), \
+             patch("api.task_routes._auto_title_task", new=AsyncMock()):
+            response = await handle_create_task(
+                FakeRequest(body={"prompt": "later", "title": "Draft"}, user_email="user@example.com"))
+        assert response.status == 201
+
+
+@pytest.mark.asyncio
+async def test_scheduled_flow_deferred_while_draining():
+    drain.set_draining(True)
+    flow = {"flow_id": "flow-1", "name": "Nightly", "status": "active", "prompt": "go"}
+    db = MagicMock()
+    db.flows.find_one = AsyncMock(return_value=flow)
+    db.flows.update_one = AsyncMock()
+    with patch.object(executor, "get_db", return_value=db), \
+         patch.object(executor, "stream_agent") as stream_agent:
+        await executor.execute_flow("flow-1")
+    stream_agent.assert_not_called()
+    update = db.flows.update_one.call_args[0]
+    assert update[0] == {"flow_id": "flow-1"}
+    assert "deferred_run_at" in update[1]["$set"]
+
+
+@pytest.mark.asyncio
+async def test_deferred_flows_run_on_startup_and_are_cleared():
+    flows = [
+        {"flow_id": "flow-1", "deferred_run_at": datetime.now(timezone.utc)},
+        {"flow_id": "flow-2"},
+    ]
+    db = MagicMock()
+    db.flows.update_many = AsyncMock()
+    executed = []
+
+    async def fake_execute(flow_id):
+        executed.append(flow_id)
+
+    with patch("scheduler.executor.execute_flow", new=fake_execute):
+        await engine._run_deferred_flows(db, flows)
+        # Let the fire-and-forget task run.
+        import asyncio
+        await asyncio.sleep(0)
+    assert executed == ["flow-1"]
+    unset = db.flows.update_many.call_args[0]
+    assert unset[0] == {"flow_id": {"$in": ["flow-1"]}}
+    assert unset[1] == {"$unset": {"deferred_run_at": ""}}
+
+
+# ── shutdown: mark interrupted + notify owners ────────────────────────────
+
+
+def _shutdown_db(running_docs):
+    db = MagicMock()
+    cursor = MagicMock()
+    cursor.to_list = AsyncMock(return_value=running_docs)
+    db.conversations.find.return_value = cursor
+    db.conversations.update_many = AsyncMock(return_value=MagicMock(modified_count=len(running_docs)))
+    return db
+
+
+@pytest.mark.asyncio
+async def test_shutdown_marks_interrupted_with_deploy_reason_and_notifies():
+    drain.set_draining(True, "deploy abc1234")
+    docs = [
+        {"conversation_id": "task-1", "source": "dashboard", "task_status": "active",
+         "title": "Ship the thing", "metadata": {"user_name": "owner@example.com"}},
+        {"conversation_id": "chat-1", "source": "dashboard", "task_status": None,
+         "prompt": "quick question", "metadata": {"user_name": "owner@example.com"}},
+        {"conversation_id": "slack-1", "source": "slack_mention",
+         "metadata": {"slack_channel_id": "C1", "slack_thread_ts": "1.0"}},
+    ]
+    db = _shutdown_db(docs)
+    with patch.object(recovery, "get_db", return_value=db), \
+         patch.object(recovery, "create_notification", new=AsyncMock()) as notify, \
+         patch.object(recovery, "send_task_needs_input_push", new=AsyncMock()) as push, \
+         patch.object(recovery, "_post_to_slack", new=AsyncMock()) as slack:
+        await recovery.mark_all_running_interrupted()
+
+    update = db.conversations.update_many.call_args[0]
+    assert update[0] == {"status": "running"}
+    assert update[1]["$set"]["status"] == "interrupted"
+    assert update[1]["$set"]["error"] == "Interrupted by deploy abc1234"
+
+    # Both dashboard conversations get an inbox entry; only the board task
+    # gets the deep-linked task push.
+    assert notify.await_count == 2
+    titles = {c.kwargs["title"] for c in notify.await_args_list}
+    assert titles == {"Task interrupted by a restart", "Chat interrupted by a restart"}
+    for call in notify.await_args_list:
+        assert call.kwargs["user_email"] == "owner@example.com"
+        assert "Interrupted by deploy abc1234" in call.kwargs["body"]
+        assert call.kwargs["fire_push"] is False
+    push.assert_awaited_once_with(db, "task-1")
+
+    slack.assert_awaited_once()
+    metadata, text = slack.await_args[0]
+    assert metadata["slack_channel_id"] == "C1"
+    assert "Interrupted by deploy abc1234" in text
+
+
+@pytest.mark.asyncio
+async def test_shutdown_without_drain_keeps_generic_error_and_skips_when_idle():
+    db = _shutdown_db([])
+    with patch.object(recovery, "get_db", return_value=db), \
+         patch.object(recovery, "create_notification", new=AsyncMock()) as notify:
+        await recovery.mark_all_running_interrupted()
+    assert db.conversations.update_many.call_args[0][1]["$set"]["error"] == "Server shutting down"
+    notify.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_notification_failure_does_not_raise():
+    docs = [{"conversation_id": "task-1", "source": "dashboard", "task_status": "active",
+             "metadata": {"user_name": "owner@example.com"}}]
+    db = _shutdown_db(docs)
+    with patch.object(recovery, "get_db", return_value=db), \
+         patch.object(recovery, "create_notification", new=AsyncMock(side_effect=RuntimeError("boom"))), \
+         patch.object(recovery, "send_task_needs_input_push", new=AsyncMock()):
+        await recovery.mark_all_running_interrupted()  # must not raise


### PR DESCRIPTION
## Summary
- Deploys no longer kill in-flight agent runs. `scripts/deploy.sh` now builds first, puts the running backend into **drain mode**, waits (bounded) for `running == 0`, then swaps containers.
- New runs are refused while draining with a clear retry message (dashboard chat, quick-add tasks, Slack); scheduled flows are **deferred to the next boot** instead of being lost.
- Anything that still overruns the wait is marked `Interrupted by deploy <sha>` and its **owner is told** (inbox notification + task push for dashboard, thread reply for Slack). This path was previously dead code: nothing installed a SIGTERM handler, so `on_shutdown` never ran under Docker.

## Context
Every push to `main` ran `docker compose up -d --build` straight over the live backend. The Claude subprocess died with the container, the conversation got flipped to `interrupted` with "Server shutting down" (in theory; in practice the process was SIGKILLed before that ran), nobody was notified, and board tasks silently stopped moving. Discussed in the Loma taskboard thread; this implements the agreed "drain, then deploy" approach plus the notification fix for the timeout edge case.

## Changes
- `api/drain.py` (new): in-process drain flag + live running count (heartbeat within 60s, so zombie `running` docs can never block a deploy). Routes under the public `/health` prefix: `GET /health`, `GET /health/drain`, `POST /health/drain {"reason"}`, `DELETE /health/drain`. Mutating verbs are loopback-only; `deploy.sh` reaches them via `docker compose exec loma-backend curl`.
- `api/routes.py` `/api/chat`: 503 `{"error": "Loma is restarting for a deploy. Please try again in a minute.", "draining": true}` while draining.
- `api/task_routes.py`: same 503 for quick-add (`start: true`); staged drafts still allowed (nothing runs).
- `slack_app/handlers.py`: mentions/DMs get the same message as a thread reply instead of starting a run.
- `scheduler/executor.py` + `scheduler/engine.py`: scheduled flows firing during drain set `flows.deferred_run_at`; `init_scheduler` runs them on boot and clears the flag.
- `scripts/deploy.sh`: `docker compose build` → drain → poll (`DRAIN_MAX_WAIT`, default 600s; `DRAIN_ON_TIMEOUT=proceed|fail`) → `docker compose up -d`. Gracefully skips drain when the backend isn't reachable (first deploy / stack down).
- `app.py`: graceful shutdown on SIGTERM/SIGINT (`loop.add_signal_handler` → stop event → `runner.cleanup()` which fires `on_shutdown`). Slack Socket Mode now uses `connect_async()` instead of the blocking `start_async()`. `AppRunner(shutdown_timeout=5.0)` so open SSE chats don't hold shutdown for 60s.
- `recovery.py` `mark_all_running_interrupted`: collects affected conversations first, error is `Interrupted by <drain reason>` (falls back to "Server shutting down"), then notifies owners within an 8s cap: dashboard → inbox notification via `create_notification` (+ existing `send_task_needs_input_push` for active board tasks), Slack → `_post_to_slack` thread reply.
- `docker-compose.yml`: `stop_grace_period: 30s` on `loma-backend` so the above completes before Docker's SIGKILL (default is 10s).
- `dashboard/src/lib/api.ts`: `streamChat` surfaces the backend's JSON `error` on non-2xx instead of "Chat request failed: 503".
- `docs/deploys.md` (new): behaviour, knobs, manual curl commands.
- `tests/test_drain.py` (new, 11 tests): heartbeat-window query, loopback enforcement, drain roundtrip, chat/quick-add gates (drafts allowed), scheduler deferral + startup catch-up, shutdown marking + notifications (reason, per-source fan-out, failure isolation).

**Not gated (by design):** webhook-triggered runs (GitHub/Linear/Pylon/incoming). External systems mostly don't retry a 503, and the drain wait is bounded anyway; a webhook run that starts mid-drain just extends the wait.

## Testing

**Unit:** `pytest -q` → 378 passed (11 new). The 2 failures on this branch (`test_zip_with_only_directories`, `test_stream_agent_uses_opencode_runtime_by_default`) fail identically on `main`. `python -m compileall` clean, `tsc --noEmit` clean, `check_public_content.py` / `check_secrets.py` clean.

**Live, on an isolated local stack** (throwaway Mongo DB, ports 13000/13001, Slack + scheduler off), scripted end to end:

```
GET  /health                 -> {"status": "ok", "draining": false}
POST /health/drain {"reason":"deploy test1234"}
                             -> {"draining": true, "reason": "deploy test1234", "running": 0, ...}
POST /api/chat               -> HTTP 503 {"error": "Loma is restarting for a deploy. Please try again in a minute.", "draining": true}
POST /api/tasks start=true   -> HTTP 503 (same body)
POST /api/tasks (draft)      -> HTTP 201
<seed a running board task with a fresh heartbeat>
GET  /health/drain           -> {"draining": true, "running": 1, "oldest_started_at": "2026-09-02T03:13:32..."}
kill -TERM <python pid>      -> exited in ~2s:
  [INFO] __main__: Received SIGTERM; starting graceful shutdown
  [INFO] recovery: [RECOVERY] Graceful shutdown: marked 1 running conversation(s) as interrupted (Interrupted by deploy test1234)
  [INFO] __main__: Shutdown complete
Mongo after shutdown:
  conversation: status=interrupted, error="Interrupted by deploy test1234", finished_at set
  notifications: 1 x "Task interrupted by a restart" for the owner, source=system
restart backend
GET  /health/drain           -> {"draining": false, "running": 0, ...}
POST /api/chat               -> past the gate again (400 on empty message)
```

**Screenshots (logged-in dashboard):**

Chat refused while draining:
![chat refused](https://cdn.plotline.so/loma-images/loma-pr/drain-chat-refused-1788318855.png)

Inbox after the SIGTERM with a task still in flight:
![notification](https://cdn.plotline.so/loma-images/loma-pr/drain-notification-1788318857.png)

Board after restart: the interrupted task lands in Needs Input instead of silently stalling in Working:
![tasks](https://cdn.plotline.so/loma-images/loma-pr/drain-tasks-1788318858.png)

**Not exercised locally:** the `deploy.sh` `docker compose` path itself (no Docker daemon in the test container). It passed `bash -n`; the drain endpoints it calls are the ones verified above. First real deploy after merge will still use the *old* `deploy.sh` semantics for the outgoing container (no drain endpoint there yet), so expect one last un-drained restart.

## Notes
- This PR was generated by Loma based on the taskboard request above
- Please review carefully before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)
