### PR TITLE
feat: send messages to agent mid-stream instead of queuing

### DIFF
--- a/agent/active_streams.py
+++ b/agent/active_streams.py
@@ -1,0 +1,57 @@
+"""
+Registry of active streaming sessions.
+
+Maps conversation_id -> active SDK client so that mid-stream endpoints
+(inject, interrupt) can find the right client while the agent is working.
+"""
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from time import monotonic
+
+from claude_agent_sdk import ClaudeSDKClient
+
+logger = logging.getLogger(__name__)
+
+_lock = asyncio.Lock()
+_streams: dict[str, "ActiveStream"] = {}
+
+
+@dataclass
+class ActiveStream:
+    conversation_id: str
+    client: ClaudeSDKClient
+    user_email: str
+    started_at: float = field(default_factory=monotonic)
+
+
+async def register(conversation_id: str, client: ClaudeSDKClient, user_email: str) -> None:
+    async with _lock:
+        _streams[conversation_id] = ActiveStream(
+            conversation_id=conversation_id,
+            client=client,
+            user_email=user_email,
+        )
+    logger.info("Registered active stream for conversation %s", conversation_id)
+
+
+async def unregister(conversation_id: str) -> None:
+    async with _lock:
+        removed = _streams.pop(conversation_id, None)
+    if removed:
+        logger.info("Unregistered active stream for conversation %s", conversation_id)
+
+
+async def get_for_user(conversation_id: str, user_email: str) -> ActiveStream | None:
+    async with _lock:
+        stream = _streams.get(conversation_id)
+    if stream is None:
+        return None
+    if stream.user_email and user_email and stream.user_email != user_email:
+        logger.warning(
+            "User %s attempted to access stream owned by %s",
+            user_email, stream.user_email,
+        )
+        return None
+    return stream

--- a/agent/client.py
+++ b/agent/client.py
@@ -1156,6 +1156,10 @@ async def stream_agent(
         try:
             await client.query(full_prompt)
 
+            if observer and observer.conversation_id:
+                from agent.active_streams import register
+                await register(observer.conversation_id, client, user_email or "")
+
             streamed_in_turn = False
             streamed_first_chunk = False
             # True after the final ResultMessage when Agent sub-agent results
@@ -1542,6 +1546,9 @@ async def stream_agent(
                 yield f"Sorry, I encountered an error: {e}"
             return
         finally:
+            if observer and observer.conversation_id:
+                from agent.active_streams import unregister
+                await unregister(observer.conversation_id)
             # Always release the client back to pool
             if client is not None:
                 await pool.release(client)

--- a/api/routes.py
+++ b/api/routes.py
@@ -797,6 +797,57 @@ async def handle_generate_titles(request: web.Request) -> web.Response:
     })
 
 
+async def handle_inject_message(request: web.Request) -> web.Response:
+    """POST /api/conversations/{id}/inject — send a message to an active agent mid-stream."""
+    from agent.active_streams import get_for_user
+
+    cid = request.match_info["conversation_id"]
+    user_email = get_user_email(request)
+    if not user_email:
+        return web.json_response({"error": "Authentication required"}, status=401)
+
+    body = await request.json()
+    message = body.get("message", "")
+    if not message:
+        return web.json_response({"error": "Missing message"}, status=400)
+
+    stream = await get_for_user(cid, user_email)
+    if not stream:
+        return web.json_response({"error": "No active stream for this conversation"}, status=404)
+
+    try:
+        await stream.client.query(message)
+        db = request.app["db"]
+        from observability.observer import ConversationObserver
+        observer = ConversationObserver(db, {}, conversation_id=cid)
+        await observer.record_injected_message(message)
+        return web.json_response({"injected": True, "conversation_id": cid})
+    except Exception as e:
+        logger.exception("Failed to inject message into conversation %s", cid)
+        return web.json_response({"error": str(e)}, status=500)
+
+
+async def handle_interrupt_agent(request: web.Request) -> web.Response:
+    """POST /api/conversations/{id}/interrupt — interrupt the active agent."""
+    from agent.active_streams import get_for_user
+
+    cid = request.match_info["conversation_id"]
+    user_email = get_user_email(request)
+    if not user_email:
+        return web.json_response({"error": "Authentication required"}, status=401)
+
+    stream = await get_for_user(cid, user_email)
+    if not stream:
+        return web.json_response({"error": "No active stream for this conversation"}, status=404)
+
+    try:
+        await stream.client.interrupt()
+        return web.json_response({"interrupted": True, "conversation_id": cid})
+    except Exception as e:
+        logger.exception("Failed to interrupt conversation %s", cid)
+        return web.json_response({"error": str(e)}, status=500)
+
+
 async def handle_chat(request: web.Request) -> web.Response:
     """POST /api/chat — SSE stream for dashboard chat.
 
@@ -1872,6 +1923,8 @@ def setup_api_routes(app: web.Application):
     app.router.add_post("/api/conversations/{conversation_id}/pin", handle_pin_conversation)
     app.router.add_delete("/api/conversations/{conversation_id}/pin", handle_unpin_conversation)
     app.router.add_put("/api/conversations/{conversation_id}/share", handle_share_conversation)
+    app.router.add_post("/api/conversations/{conversation_id}/inject", handle_inject_message)
+    app.router.add_post("/api/conversations/{conversation_id}/interrupt", handle_interrupt_agent)
     app.router.add_get("/api/stats", handle_get_stats)
     app.router.add_get("/api/cost-stats", handle_cost_stats)
     app.router.add_get("/api/token-usage", handle_token_usage)

--- a/dashboard/src/components/ChatPanel.tsx
+++ b/dashboard/src/components/ChatPanel.tsx
@@ -8,7 +8,7 @@ import { filesToChatFiles } from "@/lib/chatFiles";
 import { ModelPicker } from "./composer/ModelPicker";
 import { PendingFilesStrip } from "./composer/PendingFilesStrip";
 import { DictationButton, appendDictation } from "./composer/DictationButton";
-import { streamChat, fetchConversation, basePath } from "../lib/api";
+import { streamChat, fetchConversation, injectMessage, interruptAgent, basePath } from "../lib/api";
 import type { ChatEvent, ChatFile, ChatMessage, ClarifyQuestion, Turn, PersistedArtifact } from "../lib/api";
 import MarkdownContent from "./MarkdownContent";
 import ArtifactCard from "./ArtifactCard";
@@ -757,6 +757,9 @@ export default function ChatPanel({
   }, []);
 
   const handleStop = useCallback(() => {
+    if (conversationId) {
+      interruptAgent(conversationId).catch(() => {});
+    }
     if (abortControllerRef.current) {
       abortControllerRef.current.abort();
       abortControllerRef.current = null;
@@ -765,7 +768,7 @@ export default function ChatPanel({
       setIsStreaming(false);
       setStreamStartedAt(null);
     }
-  }, [isRecovering]);
+  }, [isRecovering, conversationId]);
 
   useEffect(() => {
     const handleEscapeKey = (e: KeyboardEvent) => {
@@ -866,11 +869,12 @@ export default function ChatPanel({
       const isOverride = overrideMessage !== undefined;
       const filesToQueue = !isOverride && pendingFiles.length > 0 ? [...pendingFiles] : undefined;
       const fileNames = filesToQueue?.map((f) => f.name);
-      queuedMessagesRef.current.push({ text: displayText, files: filesToQueue });
-      setQueuedCount(queuedMessagesRef.current.length);
+      const hasFiles = filesToQueue && filesToQueue.length > 0;
+
+      // Show message immediately
       setItems((prev) => [
         ...prev,
-        { role: "user", content: displayText, fileNames, files: filesToQueue, queued: true },
+        { role: "user", content: displayText, fileNames, files: filesToQueue, queued: !conversationId || hasFiles },
       ]);
       if (!isOverride) {
         setInput("");
@@ -879,9 +883,26 @@ export default function ChatPanel({
           if (inputRef.current) inputRef.current.style.height = "auto";
         });
       }
-      // User sent a message — always snap down and resume following the stream.
       isAtBottomRef.current = true;
       scrollToBottom({ force: true });
+
+      // Try mid-stream injection (text-only; files fall back to queue)
+      if (conversationId && !hasFiles) {
+        try {
+          await injectMessage(conversationId, displayText);
+          return;
+        } catch {
+          // Stream likely ended — fall back to queue-and-send
+        }
+      }
+      // Fallback: queue for delivery after current stream ends
+      queuedMessagesRef.current.push({ text: displayText, files: filesToQueue });
+      setQueuedCount(queuedMessagesRef.current.length);
+      setItems((prev) =>
+        prev.map((item, i) =>
+          i === prev.length - 1 && !item.queued ? { ...item, queued: true } : item
+        )
+      );
       return;
     }
     const message = systemContext && overrideMessage

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -930,6 +930,36 @@ export interface ChatMessage {
   content: string;
 }
 
+export async function injectMessage(
+  conversationId: string,
+  message: string,
+): Promise<{ injected: boolean }> {
+  const res = await fetch(`${API_BASE}/api/conversations/${conversationId}/inject`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ message }),
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.error || `Injection failed: ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function interruptAgent(
+  conversationId: string,
+): Promise<{ interrupted: boolean }> {
+  const res = await fetch(`${API_BASE}/api/conversations/${conversationId}/interrupt`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+  });
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.error || `Interrupt failed: ${res.status}`);
+  }
+  return res.json();
+}
+
 export async function* streamChat(
   message: string,
   conversationHistory?: ChatMessage[],

--- a/observability/observer.py
+++ b/observability/observer.py
@@ -369,6 +369,22 @@ class ConversationObserver:
         from observability.push import fire_task_push
         fire_task_push(self.db, self.conversation_id)
 
+    async def record_injected_message(self, content: str):
+        """Record a user message injected mid-stream."""
+        now = datetime.now(timezone.utc)
+        try:
+            await self.db.conversations.update_one(
+                {"conversation_id": self.conversation_id},
+                {"$push": {"messages": {
+                    "role": "user",
+                    "content": content[:5000],
+                    "timestamp": now,
+                    "injected": True,
+                }}},
+            )
+        except Exception as e:
+            logger.warning("Observability: failed to record injected message: %s", e)
+
     async def record_error(self, error: str):
         """Mark conversation as errored."""
         self._stop_heartbeat()


### PR DESCRIPTION
## Summary

- Messages sent while the agent is working are now injected directly via `client.query()` on the active SDK client, so the agent receives them immediately instead of being queued until the turn ends.
- Falls back to the existing queue-and-send behavior if the stream has already ended (race condition) or the message has file attachments.
- Stop button now calls `client.interrupt()` to actually halt the agent server-side, not just abort the browser SSE fetch.

## Test plan

- [ ] Start a long-running agent task, send a follow-up message while it's streaming — verify it appears immediately (no "Queued" badge) and the agent incorporates it
- [ ] Send a message right as the agent finishes — verify graceful fallback to queue-then-send
- [ ] Send a message with file attachments while streaming — verify it queues (injection is text-only)
- [ ] Press Stop while agent is working — verify the agent actually halts (not just the browser stream)

🤖 Generated with [Claude Code](https://claude.com/claude-code)