### PR TITLE
feat: per-chat skills & tools picker in composer toolbar

### DIFF
--- a/agent/client.py
+++ b/agent/client.py
@@ -776,6 +776,7 @@ async def stream_agent(
     user_email: str | None = None,
     selected_model: str | None = None,
     raise_on_opencode_error: bool = False,
+    tool_config: dict | None = None,
 ) -> AsyncGenerator[str | dict, None]:
     """
     Run the Claude agent and yield text blocks as they arrive.
@@ -805,6 +806,15 @@ async def stream_agent(
     """
     # Build text portion of the prompt with source marker for the pooled system prompt
     text_parts = [f"[Source: {source}]"]
+
+    # Per-chat skill restriction
+    if tool_config and tool_config.get("enabled_skills") is not None:
+        slugs = ", ".join(tool_config["enabled_skills"])
+        text_parts.append(
+            f"[Skill Restriction: For this conversation, only use these Loma skills: "
+            f"{slugs}. Do not read or apply other skills even if they appear in the "
+            f"skill index.]"
+        )
 
     # Inject authenticated user identity and auth token for personal tools
     if user_email:
@@ -1046,8 +1056,13 @@ async def stream_agent(
     client = None
     account_email: str | None = None
 
-    if (user_mcp_overrides or excluded_integrations) and selected_claude_model:
-        # Per-user MCP overrides / sharing exclusions: ephemeral client with merged config
+    needs_ephemeral = bool(
+        (user_mcp_overrides or excluded_integrations)
+        or (tool_config and tool_config.get("enabled_tools") is not None)
+    )
+
+    if needs_ephemeral and selected_claude_model:
+        # Per-user MCP overrides / sharing exclusions / per-chat tool filtering
         account = pool._next_account()
         if account is None:
             yield "No Claude accounts are currently available."
@@ -1064,6 +1079,12 @@ async def stream_agent(
                 tool_name = f"mcp__{server_name}"
                 if tool_name not in allowed_tools:
                     allowed_tools.append(tool_name)
+            # Per-chat tool filtering
+            if tool_config and tool_config.get("enabled_tools") is not None:
+                enabled_set = set(tool_config["enabled_tools"])
+                # Always keep Skill (internal plumbing for loma_skills CLI)
+                enabled_set.add("Skill")
+                allowed_tools = [t for t in allowed_tools if t in enabled_set]
             options.allowed_tools = allowed_tools
             options.env = {"CLAUDE_CONFIG_DIR": account["config_dir"]}
             client = ClaudeSDKClient(options=options)

--- a/api/routes.py
+++ b/api/routes.py
@@ -882,6 +882,18 @@ async def handle_chat(request: web.Request) -> web.Response:
     if selected_model is not None and not isinstance(selected_model, str):
         return web.json_response({"error": "model must be a provider/model string"}, status=400)
 
+    # Per-chat tool/skill restrictions
+    tool_config = body.get("tool_config")
+    if tool_config is not None:
+        if not isinstance(tool_config, dict):
+            return web.json_response({"error": "tool_config must be an object"}, status=400)
+        for key in ("enabled_skills", "enabled_tools"):
+            val = tool_config.get(key)
+            if val is not None and not isinstance(val, list):
+                return web.json_response(
+                    {"error": f"tool_config.{key} must be an array or null"}, status=400,
+                )
+
     # Build conversation context from history
     history = body.get("conversation_history", [])
     context_parts: list[str] = []
@@ -924,7 +936,7 @@ async def handle_chat(request: web.Request) -> web.Response:
             # Check if conversation already exists (resume) or is client-generated (start)
             existing = await db.conversations.find_one(
                 {"conversation_id": existing_conversation_id},
-                {"_id": 1, "task_status": 1, "started_at": 1, "metadata": 1, "source": 1},
+                {"_id": 1, "task_status": 1, "started_at": 1, "metadata": 1, "source": 1, "tool_config": 1},
             )
             if existing and not _check_conversation_access(
                 existing, user_email, get_system_role(request)
@@ -980,11 +992,21 @@ async def handle_chat(request: web.Request) -> web.Response:
                         {"$set": flip, "$unset": {"draft_files": ""}},
                     )
                 await observer.resume()
+                # Use stored tool_config from existing conversation if not in request
+                if tool_config is None and existing.get("tool_config"):
+                    tool_config = existing["tool_config"]
             else:
                 await observer.start()
         else:
             observer = ConversationObserver(db, metadata=metadata)
             await observer.start()
+
+        # Persist tool_config on the conversation document
+        if tool_config and observer:
+            await db.conversations.update_one(
+                {"conversation_id": observer.conversation_id},
+                {"$set": {"tool_config": tool_config}},
+            )
 
         # Board tasks carry the owner's personal working context on every turn.
         if existing and existing.get("task_status"):
@@ -1057,6 +1079,7 @@ async def handle_chat(request: web.Request) -> web.Response:
             source="dashboard",
             user_email=user_email,
             selected_model=selected_model,
+            tool_config=tool_config,
         ):
             # If the client already disconnected, keep consuming events so the
             # agent runs to completion (observability still records everything)
@@ -1687,6 +1710,83 @@ async def handle_list_mcp_servers(request: web.Request) -> web.Response:
     return web.json_response({"servers": servers})
 
 
+_BUILTIN_TOOLS = [
+    {"id": "Bash", "name": "Bash", "group": "built-in", "description": "Run shell commands"},
+    {"id": "Read", "name": "Read", "group": "built-in", "description": "Read files"},
+    {"id": "WebSearch", "name": "Web Search", "group": "built-in", "description": "Search the web"},
+    {"id": "Agent", "name": "Agent", "group": "built-in", "description": "Spawn sub-agents"},
+]
+
+
+async def handle_available_tools(request: web.Request) -> web.Response:
+    """GET /api/available-tools — catalog of tools and skills for the picker."""
+    tools = list(_BUILTIN_TOOLS)
+
+    # MCP tools from config.yaml
+    if CONFIG_PATH.exists():
+        try:
+            with open(CONFIG_PATH) as f:
+                config = yaml.safe_load(f) or {}
+            for name in config.get("mcp_servers", {}):
+                tools.append({
+                    "id": f"mcp__{name}",
+                    "name": name.replace("_", " ").title(),
+                    "group": "integrations",
+                    "description": _MCP_DESCRIPTIONS.get(name, ""),
+                })
+        except Exception as e:
+            logger.warning("Failed to read config.yaml for available tools: %s", e)
+
+    # MCP tools from DB integrations
+    db = get_db()
+    if db is not None:
+        try:
+            from integrations.registry import PROVIDER_CATALOG
+            async for integration in db.integrations.find({"status": "active"}):
+                provider = integration["provider"]
+                if integration.get("is_custom"):
+                    tool_id = f"mcp__{provider}"
+                    if not any(t["id"] == tool_id for t in tools):
+                        tools.append({
+                            "id": tool_id,
+                            "name": provider.replace("_", " ").title(),
+                            "group": "integrations",
+                            "description": "",
+                        })
+                    continue
+                catalog_entry = PROVIDER_CATALOG.get(provider)
+                if not catalog_entry or not catalog_entry.get("mcp_config_template"):
+                    continue
+                server_name = catalog_entry["mcp_server_name"]
+                tool_id = f"mcp__{server_name}"
+                if not any(t["id"] == tool_id for t in tools):
+                    tools.append({
+                        "id": tool_id,
+                        "name": catalog_entry.get("display_name", server_name),
+                        "group": "integrations",
+                        "description": catalog_entry.get("description", ""),
+                    })
+        except Exception as e:
+            logger.warning("Failed to read DB integrations for available tools: %s", e)
+
+    # Skills from DB
+    skills = []
+    if db is not None:
+        try:
+            raw = await skill_service.list_skills(db)
+            for s in raw:
+                skills.append({
+                    "slug": s["slug"],
+                    "name": s.get("name") or s["slug"],
+                    "description": s.get("description", ""),
+                    "tags": s.get("tags", []),
+                })
+        except Exception as e:
+            logger.warning("Failed to read skills for available tools: %s", e)
+
+    return web.json_response({"tools": tools, "skills": skills})
+
+
 async def handle_pool_status(request):
     """Return agent pool status (available/in_use/queued)."""
     from agent.pool import get_pool
@@ -2008,6 +2108,7 @@ def setup_api_routes(app: web.Application):
     app.router.add_get("/api/skills/{name}", handle_get_skill)
     app.router.add_get("/api/memory/recent", handle_memory_recent)
     app.router.add_get("/api/mcp-servers", handle_list_mcp_servers)
+    app.router.add_get("/api/available-tools", handle_available_tools)
     app.router.add_get("/api/pool-status", handle_pool_status)
     app.router.add_get("/api/files/{file_id}", handle_serve_file)
 

--- a/api/task_routes.py
+++ b/api/task_routes.py
@@ -35,7 +35,8 @@ logger = logging.getLogger(__name__)
 
 
 async def _run_task_headless(db, conversation_id: str, prompt: str,
-                             model: str, files: list, owner: str):
+                             model: str, files: list, owner: str,
+                             tool_config: dict | None = None):
     """Run a task's first agent turn in the background — no client stream.
 
     Powers quick-add: the task fires immediately and keeps running even if
@@ -76,6 +77,7 @@ async def _run_task_headless(db, conversation_id: str, prompt: str,
             source="dashboard",
             user_email=owner,
             selected_model=model or None,
+            tool_config=tool_config,
         ):
             pass  # observer records; nobody is watching the stream
     except Exception as e:
@@ -262,6 +264,17 @@ async def handle_create_task(request: web.Request) -> web.Response:
 
     model = (body.get("model") or "").strip()
 
+    tool_config = body.get("tool_config")
+    if tool_config is not None:
+        if not isinstance(tool_config, dict):
+            return web.json_response({"error": "tool_config must be an object"}, status=400)
+        for key in ("enabled_skills", "enabled_tools"):
+            val = tool_config.get(key)
+            if val is not None and not isinstance(val, list):
+                return web.json_response(
+                    {"error": f"tool_config.{key} must be an array or null"}, status=400,
+                )
+
     files = body.get("files") or []
     if files:
         if not isinstance(files, list) or len(files) > MAX_DRAFT_FILES:
@@ -335,6 +348,7 @@ async def handle_create_task(request: web.Request) -> web.Response:
         "task_tag_ids": [],
         "task_priority": None,
         "task_deadline": None,
+        **({"tool_config": tool_config} if tool_config else {}),
     }
     await db.conversations.insert_one(doc)
 
@@ -346,6 +360,7 @@ async def handle_create_task(request: web.Request) -> web.Response:
     if start:
         asyncio.create_task(_run_task_headless(
             db, doc["conversation_id"], prompt, model, files, user_email,
+            tool_config=tool_config,
         ))
 
     return web.json_response({"task": _task_view(doc, lane_ids)}, status=201)
@@ -675,6 +690,21 @@ async def handle_update_task(request: web.Request) -> web.Response:
         title = (body["title"] or "").strip() or None
         updates["title"] = title
         updates["title_edited"] = bool(title)
+
+    if "tool_config" in body:
+        if conversation.get("status") == "running":
+            return web.json_response(
+                {"error": "tool_config cannot be changed while a task is running"}, status=400)
+        tc = body["tool_config"]
+        if tc is not None:
+            if not isinstance(tc, dict):
+                return web.json_response({"error": "tool_config must be an object or null"}, status=400)
+            for key in ("enabled_skills", "enabled_tools"):
+                val = tc.get(key)
+                if val is not None and not isinstance(val, list):
+                    return web.json_response(
+                        {"error": f"tool_config.{key} must be an array or null"}, status=400)
+        updates["tool_config"] = tc
 
     if not updates:
         return web.json_response({"error": "Nothing to update"}, status=400)

--- a/dashboard/src/app/chat/page.tsx
+++ b/dashboard/src/app/chat/page.tsx
@@ -16,7 +16,7 @@ import { cn } from "@/lib/utils";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import type { ChatItem } from "../../components/ChatPanel";
 import type { Artifact } from "../../components/ArtifactViewer";
-import type { ChatFile } from "../../lib/api";
+import type { ChatFile, ToolConfig } from "../../lib/api";
 import { rebuildItemsFromConversation } from "../../components/ChatPanel";
 import ChatContextMenu from "../../components/ChatContextMenu";
 import { CostChip } from "../../components/CostChip";
@@ -54,6 +54,7 @@ function ChatPageContent() {
   const [taskDraftFiles, setTaskDraftFiles] = useState<ChatFile[] | null>(null);
   const [taskModel, setTaskModel] = useState<string | null>(null);
   const [pinnedAgentId, setPinnedAgentId] = useState<string | null>(null);
+  const [taskToolConfig, setTaskToolConfig] = useState<ToolConfig | null>(null);
   const [taskStatus, setTaskStatus] = useState<"todo" | "active" | "done" | null>(null);
   const [conversationOwner, setConversationOwner] = useState<string | null>(null);
   const [conversationShared, setConversationShared] = useState(false);
@@ -135,6 +136,7 @@ function ChatPageContent() {
           setTaskDraftPrompt(data.conversation.prompt);
           setTaskDraftFiles(data.conversation.draft_files || null);
           setTaskModel(data.conversation.model || null);
+          setTaskToolConfig(data.conversation.tool_config || null);
           setConversationTitle(data.conversation.title || null);
           setPromptPreview(
             data.conversation.prompt.length > 80
@@ -432,6 +434,7 @@ function ChatPageContent() {
         initialFiles={taskDraftFiles || undefined}
         initialModel={taskModel || undefined}
         initialAgentId={continueId ? pinnedAgentId : undefined}
+        initialToolConfig={taskToolConfig}
         autoSend={autoSendParam || (startParam && !!taskDraftPrompt)}
         systemContext={skillContextParam || undefined}
         initialStatus={initialStatus}

--- a/dashboard/src/components/ChatPanel.tsx
+++ b/dashboard/src/components/ChatPanel.tsx
@@ -6,8 +6,10 @@ import { useStandalone } from "@/hooks/useStandalone";
 import { useAgentModels } from "@/hooks/useAgentModels";
 import { useAgentIdentities } from "@/hooks/useAgentIdentities";
 import { AgentPicker } from "@/components/composer/AgentPicker";
+import { useToolsPicker } from "@/hooks/useToolsPicker";
 import { filesToChatFiles } from "@/lib/chatFiles";
 import { ModelPicker } from "./composer/ModelPicker";
+import { ToolsPicker } from "./composer/ToolsPicker";
 import { PendingFilesStrip } from "./composer/PendingFilesStrip";
 import { DictationButton, appendDictation } from "./composer/DictationButton";
 import { streamChat, fetchConversation, injectMessage, interruptAgent, basePath } from "../lib/api";
@@ -544,6 +546,7 @@ export default function ChatPanel({
   initialFiles,
   initialModel,
   initialAgentId,
+  initialToolConfig,
   autoSend,
   systemContext,
   initialStatus,
@@ -566,6 +569,8 @@ export default function ChatPanel({
   initialModel?: string;
   /** Agent pinned on the conversation being resumed — wins over the saved preference */
   initialAgentId?: string | null;
+  /** Tool/skill restrictions to preselect (e.g. from a board task's stored config) */
+  initialToolConfig?: import("@/lib/api").ToolConfig | null;
   autoSend?: boolean;
   systemContext?: string;
   initialStatus?: string;
@@ -621,6 +626,20 @@ export default function ChatPanel({
     selectAgent,
     loadState: agentLoadState,
   } = useAgentIdentities(initialAgentId);
+  const {
+    tools: availableTools,
+    skills: availableSkills,
+    selection: toolsSelection,
+    loadState: toolsLoadState,
+    loadCatalog: loadToolsCatalog,
+    toggleTool,
+    toggleSkill,
+    enableAll: enableAllTools,
+    isAllEnabled: allToolsEnabled,
+    disabledCount: toolsDisabledCount,
+    toolConfig,
+    isAlwaysEnabled,
+  } = useToolsPicker(initialToolConfig);
   /** Internal artifact store — synced to parent via callbacks */
   const [internalArtifacts, setInternalArtifacts] = useState<Artifact[]>(initialArtifacts || []);
   // Use external artifacts if they have entries, otherwise fall back to internal.
@@ -979,6 +998,7 @@ export default function ChatPanel({
         abortController.signal,
         selectedModel || undefined,
         selectedAgentId || undefined,
+        toolConfig,
       )) {
         if (event.type === "account_info") {
           setAccountInfo(event);
@@ -1413,6 +1433,7 @@ export default function ChatPanel({
                   <div className="flex min-w-0 items-center gap-0.5">
                     <AgentPicker agents={agentIdentities} selectedAgentId={selectedAgentId} onSelect={selectAgent} loadState={agentLoadState} disabled={isStreaming} />
                     <ModelPicker models={agentModels} selectedModel={selectedModel} onSelect={selectModel} loadState={modelLoadState} disabled={isStreaming} />
+                    <ToolsPicker tools={availableTools} skills={availableSkills} selection={toolsSelection} onToggleTool={toggleTool} onToggleSkill={toggleSkill} onEnableAll={enableAllTools} onOpen={loadToolsCatalog} isAllEnabled={allToolsEnabled} disabledCount={toolsDisabledCount} loadState={toolsLoadState} disabled={isStreaming} isAlwaysEnabled={isAlwaysEnabled} />
                   </div>
                   <div className="flex items-center gap-1 max-md:gap-2 shrink-0">
                     <DictationButton
@@ -1734,6 +1755,7 @@ export default function ChatPanel({
                   <div className="flex min-w-0 items-center gap-0.5">
                     <AgentPicker agents={agentIdentities} selectedAgentId={selectedAgentId} onSelect={selectAgent} loadState={agentLoadState} disabled={isStreaming} />
                     <ModelPicker models={agentModels} selectedModel={selectedModel} onSelect={selectModel} loadState={modelLoadState} disabled={isStreaming} />
+                    <ToolsPicker tools={availableTools} skills={availableSkills} selection={toolsSelection} onToggleTool={toggleTool} onToggleSkill={toggleSkill} onEnableAll={enableAllTools} onOpen={loadToolsCatalog} isAllEnabled={allToolsEnabled} disabledCount={toolsDisabledCount} loadState={toolsLoadState} disabled={isStreaming} isAlwaysEnabled={isAlwaysEnabled} />
                   </div>
                   <div className="flex items-center gap-1 max-md:gap-2 shrink-0">
                     <DictationButton

--- a/dashboard/src/components/ChatWithArtifacts.tsx
+++ b/dashboard/src/components/ChatWithArtifacts.tsx
@@ -79,6 +79,7 @@ export default function ChatWithArtifacts({
   initialFiles,
   initialModel,
   initialAgentId,
+  initialToolConfig,
   autoSend,
   systemContext,
   initialStatus,
@@ -93,6 +94,7 @@ export default function ChatWithArtifacts({
   initialFiles?: ChatFile[];
   initialModel?: string;
   initialAgentId?: string | null;
+  initialToolConfig?: import("@/lib/api").ToolConfig | null;
   autoSend?: boolean;
   systemContext?: string;
   initialStatus?: string;
@@ -165,6 +167,7 @@ export default function ChatWithArtifacts({
           initialFiles={initialFiles}
           initialModel={initialModel}
           initialAgentId={initialAgentId}
+          initialToolConfig={initialToolConfig}
           autoSend={autoSend}
           systemContext={systemContext}
           initialStatus={initialStatus}

--- a/dashboard/src/components/composer/ToolsPicker.tsx
+++ b/dashboard/src/components/composer/ToolsPicker.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { RiArrowDownSLine, RiEqualizerLine } from "@remixicon/react";
+import { cn } from "@/lib/utils";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Switch } from "@/components/ui/switch";
+import type { AvailableTool, AvailableSkill } from "@/lib/api";
+import type { ToolsLoadState, ToolsSelection } from "@/hooks/useToolsPicker";
+
+interface ToolsPickerProps {
+  tools: AvailableTool[];
+  skills: AvailableSkill[];
+  selection: ToolsSelection;
+  onToggleTool: (id: string) => void;
+  onToggleSkill: (slug: string) => void;
+  onEnableAll: () => void;
+  onOpen: () => void;
+  isAllEnabled: boolean;
+  disabledCount: number;
+  loadState: ToolsLoadState;
+  disabled?: boolean;
+  isAlwaysEnabled: (toolId: string) => boolean;
+}
+
+export function ToolsPicker({
+  tools,
+  skills,
+  selection,
+  onToggleTool,
+  onToggleSkill,
+  onEnableAll,
+  onOpen,
+  isAllEnabled,
+  disabledCount,
+  loadState,
+  disabled,
+  isAlwaysEnabled,
+}: ToolsPickerProps) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState("");
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    if (nextOpen) {
+      onOpen();
+      setSearch("");
+    }
+  };
+
+  const isToolEnabled = (id: string) =>
+    selection.enabledTools === null || selection.enabledTools.includes(id);
+
+  const isSkillEnabled = (slug: string) =>
+    selection.enabledSkills === null || selection.enabledSkills.includes(slug);
+
+  const filteredTools = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    if (!query) return tools;
+    return tools.filter(
+      (t) =>
+        t.name.toLowerCase().includes(query) ||
+        t.id.toLowerCase().includes(query) ||
+        (t.description || "").toLowerCase().includes(query),
+    );
+  }, [tools, search]);
+
+  const filteredSkills = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    if (!query) return skills;
+    return skills.filter(
+      (s) =>
+        s.name.toLowerCase().includes(query) ||
+        s.slug.toLowerCase().includes(query) ||
+        s.description.toLowerCase().includes(query) ||
+        (s.tags || []).some((tag) => tag.toLowerCase().includes(query)),
+    );
+  }, [skills, search]);
+
+  const isDisabled = disabled;
+  const isLoading = loadState === "loading" || loadState === "idle";
+
+  const label = isAllEnabled
+    ? "All tools"
+    : disabledCount === 1
+      ? "1 disabled"
+      : `${disabledCount} disabled`;
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          disabled={isDisabled}
+          title="Configure available tools & skills"
+          className="group inline-flex h-7 max-w-full items-center gap-1.5 rounded-md px-1.5 text-left text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus:outline-none disabled:cursor-not-allowed disabled:opacity-55"
+        >
+          <RiEqualizerLine size={13} className="shrink-0" />
+          <span className={cn(
+            "min-w-0 truncate text-xs",
+            isAllEnabled ? "text-muted-foreground" : "text-amber-600 dark:text-amber-400",
+          )}>
+            {label}
+          </span>
+          <RiArrowDownSLine
+            size={14}
+            className={cn(
+              "shrink-0 text-gray-400 transition-transform",
+              open && "rotate-180",
+            )}
+          />
+        </button>
+      </PopoverTrigger>
+
+      <PopoverContent
+        side="top"
+        align="start"
+        className="w-[min(85vw,320px)] p-0 overflow-hidden rounded-xl"
+      >
+        <Command shouldFilter={false}>
+          {/* Enable all toggle */}
+          <div className="border-b border-border p-2.5">
+            <button
+              type="button"
+              onClick={onEnableAll}
+              className={cn(
+                "flex w-full items-center justify-between rounded-lg px-2.5 py-2 text-[13px] transition-colors",
+                isAllEnabled
+                  ? "bg-muted/60 text-foreground"
+                  : "bg-muted/30 text-muted-foreground hover:bg-muted/60",
+              )}
+            >
+              <span className="font-medium">All tools & skills</span>
+              <Switch
+                size="sm"
+                checked={isAllEnabled}
+                onCheckedChange={() => {
+                  if (!isAllEnabled) onEnableAll();
+                }}
+              />
+            </button>
+          </div>
+
+          <div className="border-b border-border p-1.5">
+            <CommandInput
+              value={search}
+              onValueChange={setSearch}
+              placeholder="Search tools & skills"
+            />
+          </div>
+
+          <CommandList>
+            <ScrollArea className="max-h-72">
+              {isLoading ? (
+                <div className="px-3 py-6 text-center text-[13px] text-muted-foreground">
+                  Loading tools...
+                </div>
+              ) : (
+                <>
+                  <CommandEmpty className="px-3 py-6 text-center text-[13px] text-muted-foreground">
+                    No matches.
+                  </CommandEmpty>
+
+                  {filteredTools.length > 0 && (
+                    <CommandGroup heading="Tools">
+                      {filteredTools.map((tool) => {
+                        const enabled = isToolEnabled(tool.id);
+                        const locked = isAlwaysEnabled(tool.id);
+                        return (
+                          <CommandItem
+                            key={tool.id}
+                            value={tool.id}
+                            onSelect={() => !locked && onToggleTool(tool.id)}
+                            className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-[13px]"
+                          >
+                            <span className="min-w-0 flex-1">
+                              <span className={cn(
+                                "truncate",
+                                enabled ? "text-foreground" : "text-muted-foreground line-through",
+                              )}>
+                                {tool.name}
+                              </span>
+                              {tool.group === "integrations" && (
+                                <span className="ml-1.5 text-[11px] text-muted-foreground">
+                                  integration
+                                </span>
+                              )}
+                            </span>
+                            <Switch
+                              size="sm"
+                              checked={enabled}
+                              disabled={locked}
+                              onCheckedChange={() => !locked && onToggleTool(tool.id)}
+                              onClick={(e) => e.stopPropagation()}
+                            />
+                          </CommandItem>
+                        );
+                      })}
+                    </CommandGroup>
+                  )}
+
+                  {filteredSkills.length > 0 && (
+                    <CommandGroup heading="Skills">
+                      {filteredSkills.map((skill) => {
+                        const enabled = isSkillEnabled(skill.slug);
+                        return (
+                          <CommandItem
+                            key={skill.slug}
+                            value={skill.slug}
+                            onSelect={() => onToggleSkill(skill.slug)}
+                            className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-[13px]"
+                          >
+                            <span className="min-w-0 flex-1">
+                              <span className={cn(
+                                "truncate",
+                                enabled ? "text-foreground" : "text-muted-foreground line-through",
+                              )}>
+                                {skill.name}
+                              </span>
+                            </span>
+                            <Switch
+                              size="sm"
+                              checked={enabled}
+                              onCheckedChange={() => onToggleSkill(skill.slug)}
+                              onClick={(e) => e.stopPropagation()}
+                            />
+                          </CommandItem>
+                        );
+                      })}
+                    </CommandGroup>
+                  )}
+                </>
+              )}
+            </ScrollArea>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/dashboard/src/components/tasks/QuickAddTask.tsx
+++ b/dashboard/src/components/tasks/QuickAddTask.tsx
@@ -7,7 +7,9 @@ import { Textarea } from "@/components/ui/textarea";
 import { createTask, type ChatFile } from "@/lib/api";
 import { filesToChatFiles } from "@/lib/chatFiles";
 import { useAgentModels } from "@/hooks/useAgentModels";
+import { useToolsPicker } from "@/hooks/useToolsPicker";
 import { ModelPicker } from "@/components/composer/ModelPicker";
+import { ToolsPicker } from "@/components/composer/ToolsPicker";
 import { PendingFilesStrip } from "@/components/composer/PendingFilesStrip";
 import { DictationButton, appendDictation } from "@/components/composer/DictationButton";
 import { cn } from "@/lib/utils";
@@ -28,6 +30,20 @@ export function QuickAddTask({ onAdded }: QuickAddTaskProps) {
   const [error, setError] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { models, selectedModel, selectModel, loadState } = useAgentModels();
+  const {
+    tools: availableTools,
+    skills: availableSkills,
+    selection: toolsSelection,
+    loadState: toolsLoadState,
+    loadCatalog: loadToolsCatalog,
+    toggleTool,
+    toggleSkill,
+    enableAll: enableAllTools,
+    isAllEnabled: allToolsEnabled,
+    disabledCount: toolsDisabledCount,
+    toolConfig,
+    isAlwaysEnabled,
+  } = useToolsPicker();
 
   const addFiles = async (fileList: FileList | File[]) => {
     const { files: chatFiles, rejected } = await filesToChatFiles(fileList);
@@ -46,6 +62,7 @@ export function QuickAddTask({ onAdded }: QuickAddTaskProps) {
         model: selectedModel || undefined,
         files: files.length > 0 ? files : undefined,
         start: true,
+        tool_config: toolConfig,
       });
       setValue("");
       setFiles([]);
@@ -100,13 +117,14 @@ export function QuickAddTask({ onAdded }: QuickAddTaskProps) {
           style={{ maxHeight: "120px" }}
         />
         <div className="flex items-center justify-between gap-2 px-2 pb-2">
-          <div className="flex min-w-0 items-center">
+          <div className="flex min-w-0 items-center gap-1">
             <ModelPicker
               models={models}
               selectedModel={selectedModel}
               onSelect={selectModel}
               loadState={loadState}
             />
+            <ToolsPicker tools={availableTools} skills={availableSkills} selection={toolsSelection} onToggleTool={toggleTool} onToggleSkill={toggleSkill} onEnableAll={enableAllTools} onOpen={loadToolsCatalog} isAllEnabled={allToolsEnabled} disabledCount={toolsDisabledCount} loadState={toolsLoadState} isAlwaysEnabled={isAlwaysEnabled} />
           </div>
           <div className="flex items-center gap-1 max-md:gap-2 shrink-0">
             <DictationButton

--- a/dashboard/src/components/tasks/TaskChatDrawer.tsx
+++ b/dashboard/src/components/tasks/TaskChatDrawer.tsx
@@ -28,6 +28,7 @@ function DrawerConversation({
   const [draftPrompt, setDraftPrompt] = useState<string | null>(null);
   const [draftFiles, setDraftFiles] = useState<ChatFile[] | null>(null);
   const [model, setModel] = useState<string | null>(null);
+  const [toolConfig, setToolConfig] = useState<import("@/lib/api").ToolConfig | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -36,6 +37,7 @@ function DrawerConversation({
         const data = await fetchConversation(conversationId);
         if (cancelled) return;
         setModel(data.conversation.model || null);
+        setToolConfig(data.conversation.tool_config || null);
         if (data.conversation.task_status === "todo" && !data.conversation.status) {
           // Unstarted board draft: nothing has been sent yet — put the staged
           // prompt in the composer instead of rendering it as a sent message
@@ -97,6 +99,7 @@ function DrawerConversation({
         initialPrompt={draftPrompt || undefined}
         initialFiles={draftFiles || undefined}
         initialModel={model || undefined}
+        initialToolConfig={toolConfig}
         initialStatus={initialStatus}
         draftStorageKey={`loma-task-draft-${conversationId}`}
         onStreamComplete={onStreamComplete}

--- a/dashboard/src/hooks/useToolsPicker.ts
+++ b/dashboard/src/hooks/useToolsPicker.ts
@@ -1,0 +1,133 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  fetchAvailableTools,
+  type AvailableTool,
+  type AvailableSkill,
+  type ToolConfig,
+} from "@/lib/api";
+
+export type ToolsLoadState = "idle" | "loading" | "ready" | "error";
+
+export interface ToolsSelection {
+  enabledSkills: string[] | null; // null = all
+  enabledTools: string[] | null; // null = all
+}
+
+const ALWAYS_ENABLED_TOOLS = new Set(["Bash", "Read"]);
+
+export function useToolsPicker(initial?: ToolConfig | null) {
+  const [tools, setTools] = useState<AvailableTool[]>([]);
+  const [skills, setSkills] = useState<AvailableSkill[]>([]);
+  const [loadState, setLoadState] = useState<ToolsLoadState>("idle");
+  const [selection, setSelection] = useState<ToolsSelection>({
+    enabledSkills: initial?.enabled_skills ?? null,
+    enabledTools: initial?.enabled_tools ?? null,
+  });
+  const fetchedRef = useRef(false);
+  const toolsRef = useRef<AvailableTool[]>([]);
+  const skillsRef = useRef<AvailableSkill[]>([]);
+
+  // Keep refs in sync with state
+  toolsRef.current = tools;
+  skillsRef.current = skills;
+
+  // Sync with external initial value (e.g. when loading an existing conversation)
+  useEffect(() => {
+    if (initial) {
+      setSelection({
+        enabledSkills: initial.enabled_skills ?? null,
+        enabledTools: initial.enabled_tools ?? null,
+      });
+    }
+  }, [initial]);
+
+  const loadCatalog = useCallback(async () => {
+    if (fetchedRef.current) return;
+    fetchedRef.current = true;
+    setLoadState("loading");
+    try {
+      const data = await fetchAvailableTools();
+      setTools(data.tools);
+      setSkills(data.skills);
+      toolsRef.current = data.tools;
+      skillsRef.current = data.skills;
+      setLoadState("ready");
+    } catch (e) {
+      console.warn("Failed to load available tools", e);
+      setLoadState("error");
+    }
+  }, []);
+
+  const toggleTool = useCallback((toolId: string) => {
+    if (ALWAYS_ENABLED_TOOLS.has(toolId)) return;
+    setSelection((prev) => {
+      if (prev.enabledTools === null) {
+        const allIds = toolsRef.current.map((t) => t.id);
+        return { ...prev, enabledTools: allIds.filter((id) => id !== toolId) };
+      }
+      const isEnabled = prev.enabledTools.includes(toolId);
+      return {
+        ...prev,
+        enabledTools: isEnabled
+          ? prev.enabledTools.filter((id) => id !== toolId)
+          : [...prev.enabledTools, toolId],
+      };
+    });
+  }, []);
+
+  const toggleSkill = useCallback((slug: string) => {
+    setSelection((prev) => {
+      if (prev.enabledSkills === null) {
+        const allSlugs = skillsRef.current.map((s) => s.slug);
+        return { ...prev, enabledSkills: allSlugs.filter((s) => s !== slug) };
+      }
+      const isEnabled = prev.enabledSkills.includes(slug);
+      return {
+        ...prev,
+        enabledSkills: isEnabled
+          ? prev.enabledSkills.filter((s) => s !== slug)
+          : [...prev.enabledSkills, slug],
+      };
+    });
+  }, []);
+
+  const enableAll = useCallback(() => {
+    setSelection({ enabledSkills: null, enabledTools: null });
+  }, []);
+
+  const isAllEnabled = selection.enabledSkills === null && selection.enabledTools === null;
+
+  const disabledCount = (() => {
+    let count = 0;
+    if (selection.enabledTools !== null) {
+      count += tools.filter((t) => !selection.enabledTools!.includes(t.id)).length;
+    }
+    if (selection.enabledSkills !== null) {
+      count += skills.filter((s) => !selection.enabledSkills!.includes(s.slug)).length;
+    }
+    return count;
+  })();
+
+  const toolConfig: ToolConfig | undefined =
+    isAllEnabled ? undefined : {
+      enabled_skills: selection.enabledSkills,
+      enabled_tools: selection.enabledTools,
+    };
+
+  return {
+    tools,
+    skills,
+    selection,
+    loadState,
+    loadCatalog,
+    toggleTool,
+    toggleSkill,
+    enableAll,
+    isAllEnabled,
+    disabledCount,
+    toolConfig,
+    isAlwaysEnabled: (toolId: string) => ALWAYS_ENABLED_TOOLS.has(toolId),
+  };
+}

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -48,6 +48,7 @@ export interface Conversation {
   task_status?: "todo" | "active" | "done" | null;
   /** Attachments staged with a board-task draft (cleared once started) */
   draft_files?: ChatFile[];
+  tool_config?: ToolConfig | null;
   messages?: Array<{
     role: "user" | "assistant";
     content: string;
@@ -266,6 +267,38 @@ export interface SkillDetailResponse {
   scope?: "system" | "personal" | "workspace";
   folder?: string | null;
   folder_source?: "manual" | "auto" | null;
+}
+
+// ── Tool/Skill picker catalog ──────────────────────────────────────────────
+
+export interface ToolConfig {
+  enabled_skills?: string[] | null;
+  enabled_tools?: string[] | null;
+}
+
+export interface AvailableTool {
+  id: string;
+  name: string;
+  group: "built-in" | "integrations";
+  description?: string;
+}
+
+export interface AvailableSkill {
+  slug: string;
+  name: string;
+  description: string;
+  tags?: string[];
+}
+
+export interface AvailableToolsResponse {
+  tools: AvailableTool[];
+  skills: AvailableSkill[];
+}
+
+export async function fetchAvailableTools(): Promise<AvailableToolsResponse> {
+  const res = await fetch(`${API_BASE}/api/available-tools`);
+  if (!res.ok) throw new Error(`Failed to fetch available tools: ${res.status}`);
+  return res.json();
 }
 
 export async function fetchSkills(): Promise<{ skills: Skill[] }> {
@@ -969,6 +1002,7 @@ export async function* streamChat(
   signal?: AbortSignal,
   selectedModel?: string,
   agentId?: string,
+  toolConfig?: ToolConfig,
 ): AsyncGenerator<ChatEvent, void, unknown> {
   const body: Record<string, unknown> = { message };
   if (conversationHistory?.length) body.conversation_history = conversationHistory;
@@ -977,6 +1011,7 @@ export async function* streamChat(
   if (userEmail) body.user_email = userEmail;
   if (selectedModel) body.model = selectedModel;
   if (agentId) body.agent_id = agentId;
+  if (toolConfig) body.tool_config = toolConfig;
 
   const res = await fetch(`${API_BASE}/api/chat`, {
     method: "POST",
@@ -1115,6 +1150,7 @@ export async function createTask(params: {
   files?: ChatFile[];
   /** Fire immediately: the agent starts running in the background */
   start?: boolean;
+  tool_config?: ToolConfig;
 }): Promise<{ task: Task }> {
   const res = await fetch(`${API_BASE}/api/tasks`, {
     method: "POST",


### PR DESCRIPTION
## Summary

- Adds a **ToolsPicker** dropdown next to the ModelPicker in all composer toolbars (chat empty state, active chat, task quick-add, task drawer)
- Users can toggle which tools (Bash, Read, WebSearch, Agent, MCP integrations) and skills the agent has access to per-conversation
- Default: everything enabled (zero overhead — no `tool_config` sent to backend). First toggle transitions to explicit allowlist
- Bash and Read are locked as always-enabled (minimum required tools)

### Backend
- New `GET /api/available-tools` endpoint returns combined catalog of built-in tools, MCP integrations (from config.yaml + DB), and DB-backed skills
- `tool_config` field stored on conversation documents, validated and persisted through `handle_chat()`, `handle_create_task()`, and `handle_update_task()`
- `stream_agent()` enforces restrictions: filters `allowed_tools` on ephemeral Claude clients, injects prompt-level skill restriction directive
- Existing conversations restore their `tool_config` on resume

### Frontend
- New `useToolsPicker` hook (mirrors `useAgentModels` pattern) with lazy catalog loading, ref-based toggle state, and `null` = all enabled semantics
- New `ToolsPicker` component (Popover + cmdk, mirrors `ModelPicker` structure) with grouped tools/skills list, Switch toggles, and master "All tools & skills" toggle
- Wired into `ChatPanel`, `QuickAddTask`, `ChatWithArtifacts`, `TaskChatDrawer`, and chat page

## Test plan

- [ ] Open a new chat — verify ToolsPicker appears next to ModelPicker showing "All tools"
- [ ] Click the picker — verify tools and skills load and are all toggled on
- [ ] Toggle off WebSearch, send a message — verify the agent cannot use web search
- [ ] Toggle off a skill, send a message — verify the agent doesn't use that skill
- [ ] Open an existing conversation that had tool_config — verify the picker restores the previous selection
- [ ] Create a task via quick-add with tools disabled — verify headless agent respects the restriction
- [ ] Verify default behavior (no toggles changed) works identically to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)