### PR TITLE
fix: new tasks never get an auto-generated title (stuck on "New task")

### DIFF
--- a/api/routes.py
+++ b/api/routes.py
@@ -771,6 +771,15 @@ async def handle_generate_titles(request: web.Request) -> web.Response:
     if db is None:
         return web.json_response({"error": "Observability not configured"}, status=503)
 
+    # Repair rows poisoned by the old side-drawer flow, which stored the
+    # "New task" placeholder as a user-edited title and locked out every
+    # auto-title path. Nobody names a task "New task" on purpose — a false
+    # positive just gets a fresh LLM title below.
+    repaired = (await db.conversations.update_many(
+        {"title": "New task", "title_edited": True, "source": "dashboard"},
+        {"$set": {"title": None, "title_edited": False}},
+    )).modified_count
+
     # Find conversations missing title or topic (skip unsent board drafts)
     missing = await db.conversations.find(
         {"$nor": [{"task_status": "todo", "status": None}],
@@ -780,7 +789,11 @@ async def handle_generate_titles(request: web.Request) -> web.Response:
     ).limit(200).to_list(200)
 
     if not missing:
-        return web.json_response({"processed": 0, "message": "All conversations already have titles and topics"})
+        return web.json_response({
+            "processed": 0,
+            "repaired": repaired,
+            "message": "All conversations already have titles and topics",
+        })
 
     processed = 0
     batch_size = 5
@@ -793,6 +806,7 @@ async def handle_generate_titles(request: web.Request) -> web.Response:
 
     return web.json_response({
         "processed": processed,
+        "repaired": repaired,
         "message": f"Generated titles/topics for {processed} conversations",
     })
 

--- a/api/task_routes.py
+++ b/api/task_routes.py
@@ -254,9 +254,10 @@ async def handle_create_task(request: web.Request) -> web.Response:
         return web.json_response({"error": "Invalid JSON"}, status=400)
 
     prompt = (body.get("prompt") or "").strip()
+    # Empty staged drafts are fine (the side drawer creates one on click and
+    # the user fills it in) — title stays None so finish-time enrichment can
+    # name the task from the first message. start=true still requires details.
     title = (body.get("title") or "").strip() or None
-    if not prompt and not title:
-        return web.json_response({"error": "A title or details are required"}, status=400)
 
     model = (body.get("model") or "").strip()
 
@@ -332,7 +333,8 @@ async def handle_create_task(request: web.Request) -> web.Response:
     await db.conversations.insert_one(doc)
 
     # Quick-added tasks (no explicit title) get an LLM title from the prompt.
-    if not title:
+    # Empty drafts skip this — enrichment titles them after the first run.
+    if not title and prompt:
         asyncio.create_task(_auto_title_task(db, doc["conversation_id"], prompt))
 
     if start:

--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -94,6 +94,18 @@ export default function TasksPage() {
       const data = await fetchTasksBoard(searchQuery);
       hasBoardRef.current = true;
       setBoard(data);
+      // Keep the open drawer's task in sync (e.g. the async-generated title).
+      // Only swap when title/prompt changed — a new object remounts the
+      // drawer's title editor, which would clobber an in-progress rename.
+      setChatTask((current) => {
+        if (!current) return current;
+        const next = data.tasks.find(
+          (t) => t.conversation_id === current.conversation_id,
+        );
+        return next && (next.title !== current.title || next.prompt !== current.prompt)
+          ? next
+          : current;
+      });
     } catch {
       // Transient poll failures are fine — keep showing the last board.
     }
@@ -156,8 +168,9 @@ export default function TasksPage() {
       const todoLane = board.lanes.find(
         (lane) => lane.id === "todo" || lane.name.trim().toLowerCase() === "todo",
       ) || board.lanes[0];
+      // No title: the backend leaves title_edited false so the first run's
+      // enrichment can name the task. "New task" is a display-only fallback.
       const { task } = await createTask({
-        title: "New task",
         prompt: "",
         lane: todoLane?.id || "todo",
       });

--- a/dashboard/src/components/tasks/MobileTaskCard.tsx
+++ b/dashboard/src/components/tasks/MobileTaskCard.tsx
@@ -69,7 +69,7 @@ export function MobileTaskCard({
         {dot && <span className={cn("mt-2 h-2 w-2 shrink-0 rounded-full", dot)} />}
         <div className="min-w-0 flex-1 py-0.5">
           <div className="line-clamp-2 break-words text-[13px]">
-            {task.title || task.prompt}
+            {task.title || task.prompt || "New task"}
           </div>
           <div className="mt-0.5 flex items-center gap-2 text-xs text-muted-foreground">
             <ClientTimestamp iso={timestamp} variant="short" placeholder="—" />

--- a/dashboard/src/components/tasks/TaskBoard.tsx
+++ b/dashboard/src/components/tasks/TaskBoard.tsx
@@ -154,7 +154,7 @@ export function TaskBoard({ board, onBoardChange, onRefresh, onEditDraft, onAddT
       <DragOverlay>
         {activeTask && (
           <div className="rounded-md border bg-card px-3 py-2 text-[13px] shadow-md">
-            <div className="line-clamp-2 break-words">{activeTask.title || activeTask.prompt}</div>
+            <div className="line-clamp-2 break-words">{activeTask.title || activeTask.prompt || "New task"}</div>
           </div>
         )}
       </DragOverlay>

--- a/dashboard/src/components/tasks/TaskCard.tsx
+++ b/dashboard/src/components/tasks/TaskCard.tsx
@@ -73,7 +73,7 @@ export function TaskCard({
         {dot && <span className={cn("mt-1.5 h-2 w-2 shrink-0 rounded-full", dot)} />}
         <div className="min-w-0 flex-1">
           <div className="line-clamp-2 break-words text-[13px]">
-            {task.title || task.prompt}
+            {task.title || task.prompt || "New task"}
           </div>
           <div className="mt-0.5 flex items-center gap-2 text-xs text-muted-foreground">
             <ClientTimestamp iso={timestamp} variant="short" placeholder="—" />

--- a/dashboard/src/components/tasks/TaskChatDrawer.tsx
+++ b/dashboard/src/components/tasks/TaskChatDrawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { RiExternalLinkLine, RiLoader4Line, RiPencilLine } from "@remixicon/react";
 import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet";
 import { Button } from "@/components/ui/button";
@@ -13,7 +13,13 @@ import { basePath, fetchConversation, updateTask, type ChatFile, type Task } fro
 
 /** Loads and renders one conversation inside the drawer. Keyed by
  * conversation_id from the parent so switching tasks resets all state. */
-function DrawerConversation({ conversationId }: { conversationId: string }) {
+function DrawerConversation({
+  conversationId,
+  onStreamComplete,
+}: {
+  conversationId: string;
+  onStreamComplete?: (conversationId: string) => void;
+}) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [initialItems, setInitialItems] = useState<ChatItem[] | undefined>();
@@ -93,6 +99,7 @@ function DrawerConversation({ conversationId }: { conversationId: string }) {
         initialModel={model || undefined}
         initialStatus={initialStatus}
         draftStorageKey={`loma-task-draft-${conversationId}`}
+        onStreamComplete={onStreamComplete}
       />
     </div>
   );
@@ -112,6 +119,38 @@ export function TaskChatDrawer({
   onOpenChange: (open: boolean) => void;
   onTaskChange?: (task: Task) => void;
 }) {
+  // Refs so the delayed title fetch below reads the latest task/callback, not
+  // the ones captured when the stream started.
+  const taskRef = useRef(task);
+  const onTaskChangeRef = useRef(onTaskChange);
+  useEffect(() => {
+    taskRef.current = task;
+    onTaskChangeRef.current = onTaskChange;
+  }, [task, onTaskChange]);
+
+  // After a run finishes, server-side enrichment generates a title
+  // asynchronously — poll once shortly after so the drawer header and board
+  // card pick it up (mirrors handleStreamComplete on the chat page).
+  const handleStreamComplete = useCallback((conversationId: string) => {
+    setTimeout(async () => {
+      try {
+        const data = await fetchConversation(conversationId);
+        const nextTitle = data.conversation?.title;
+        const current = taskRef.current;
+        if (
+          nextTitle &&
+          current &&
+          current.conversation_id === conversationId &&
+          nextTitle !== current.title
+        ) {
+          onTaskChangeRef.current?.({ ...current, title: nextTitle });
+        }
+      } catch {
+        // Board polling will pick the title up on its next pass.
+      }
+    }, 4000);
+  }, []);
+
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent
@@ -148,6 +187,7 @@ export function TaskChatDrawer({
           <DrawerConversation
             key={task.conversation_id}
             conversationId={task.conversation_id}
+            onStreamComplete={handleStreamComplete}
           />
         )}
       </SheetContent>
@@ -161,10 +201,16 @@ function EditableTaskTitle({ task, onTaskChange }: { task: Task; onTaskChange?: 
 
   const saveTitle = async () => {
     if (!task) return;
-    const nextTitle = title.trim() || "New task";
-    setTitle(nextTitle);
     setEditingTitle(false);
-    if (nextTitle === task.title) return;
+    const fallback = task.title || task.prompt || "New task";
+    const nextTitle = title.trim();
+    // Empty or unchanged input is a no-op — saving would store the display
+    // fallback as a real user title and lock out auto-titling (title_edited).
+    if (!nextTitle || nextTitle === fallback) {
+      setTitle(fallback);
+      return;
+    }
+    setTitle(nextTitle);
     try {
       const { task: updatedTask } = await updateTask(task.conversation_id, { title: nextTitle });
       onTaskChange?.(updatedTask || { ...task, title: nextTitle });

--- a/tests/test_task_create.py
+++ b/tests/test_task_create.py
@@ -1,0 +1,88 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from api import task_routes
+
+
+class FakeRequest:
+    def __init__(self, body=None):
+        self._body = body or {}
+
+    async def json(self):
+        return self._body
+
+
+def _setup(monkeypatch):
+    conversations = SimpleNamespace(insert_one=AsyncMock())
+    users = SimpleNamespace(find_one=AsyncMock(return_value={
+        "task_board": {
+            "lanes": [{"id": "todo", "name": "Todo", "order": 0}],
+            "tags": [],
+        },
+    }))
+    monkeypatch.setattr(task_routes, "get_db", lambda: SimpleNamespace(
+        conversations=conversations, users=users,
+    ))
+    monkeypatch.setattr(task_routes, "get_user_email", lambda _request: "owner@example.com")
+    scheduled = MagicMock()
+    monkeypatch.setattr(task_routes.asyncio, "create_task", scheduled)
+    return conversations, scheduled
+
+
+@pytest.mark.asyncio
+async def test_create_empty_draft_leaves_title_open_for_auto_naming(monkeypatch):
+    conversations, scheduled = _setup(monkeypatch)
+
+    response = await task_routes.handle_create_task(
+        FakeRequest({"prompt": "", "lane": "todo"}))
+    inserted = conversations.insert_one.await_args.args[0]
+
+    assert response.status == 201
+    assert inserted["title"] is None
+    assert inserted["title_edited"] is False
+    assert inserted["task_status"] == "todo"
+    # No prompt yet — finish-time enrichment names the task, not creation.
+    scheduled.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_quick_add_with_prompt_schedules_auto_title(monkeypatch):
+    conversations, scheduled = _setup(monkeypatch)
+
+    response = await task_routes.handle_create_task(
+        FakeRequest({"prompt": "Investigate the flaky deploy"}))
+    inserted = conversations.insert_one.await_args.args[0]
+
+    assert response.status == 201
+    assert inserted["title"] is None
+    assert inserted["title_edited"] is False
+    assert scheduled.called
+    for call in scheduled.call_args_list:
+        call.args[0].close()  # discard un-run coroutines from the mock
+
+
+@pytest.mark.asyncio
+async def test_user_supplied_title_is_marked_edited(monkeypatch):
+    conversations, scheduled = _setup(monkeypatch)
+
+    response = await task_routes.handle_create_task(
+        FakeRequest({"title": "Ship the release", "prompt": ""}))
+    inserted = conversations.insert_one.await_args.args[0]
+
+    assert response.status == 201
+    assert inserted["title"] == "Ship the release"
+    assert inserted["title_edited"] is True
+    scheduled.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_start_still_requires_prompt(monkeypatch):
+    conversations, _scheduled = _setup(monkeypatch)
+
+    response = await task_routes.handle_create_task(
+        FakeRequest({"prompt": "", "start": True}))
+
+    assert response.status == 400
+    conversations.insert_one.assert_not_called()


### PR DESCRIPTION
## Root cause

The "New task" drawer button poisoned every task at creation: it sent the literal `title: "New task"`, which `handle_create_task` stored with `title_edited: true` — the "user typed this, never overwrite" flag. Every auto-title path then *correctly* refused to touch the task:

- creation-time `_auto_title_task` skipped (a title exists)
- finish-time enrichment generated a good title from the first message but discarded it at the `title_edited` gate (`observer.py`)
- the `generate-titles` backfill excluded the row (title non-empty + `title_edited`)

All prior fixes (#63 clobber guard, #71 creation-time titling, #143 LLM fallback + chat-page refresh, #145 CLI auth) targeted other layers; the literal landed in #118 after the first two, so titling worked server-side and its output was thrown away. Separately, the drawer UI never re-read the title even when one was written (board poll updates `board.tasks` but not the open drawer's task; no `onStreamComplete`).

## Changes

- **`api/task_routes.py`** — allow empty staged drafts (`title: null, title_edited: false`) so finish-time enrichment can name the task; only schedule creation-time auto-titling when a prompt exists. `start=true` still requires details.
- **`tasks/page.tsx`** — drop the `title: "New task"` literal from drawer create; sync the open drawer's task from the 5s board poll (only when title/prompt changed, to avoid clobbering an in-progress rename).
- **`TaskCard` / `MobileTaskCard` / `TaskBoard` drag overlay** — "New task" becomes a display-only fallback.
- **`TaskChatDrawer.tsx`** — wire `onStreamComplete` (mirrors the chat page) so the header/card pick up the generated title ~4s after a run finishes; fix a re-poisoning edge where blurring the rename editor without typing PATCHed the fallback as a real user title.
- **`api/routes.py`** — `POST /api/conversations/generate-titles` now first repairs poisoned rows (`title: "New task"` + `title_edited: true` → reset) and titles them in the same call. Run it once after deploy to fix existing tasks.
- **`tests/test_task_create.py`** (new) — locks in creation semantics: empty draft → untitled/auto-namable, prompt → auto-title scheduled, user title → `title_edited: true`, `start` without prompt → 400.

## Testing

- Full backend suite: 362 passed
- `next build`: clean
- Post-deploy: create a task from the button, send a message — the title should replace "New task" within ~5s of the run finishing; then `curl -X POST .../api/conversations/generate-titles` to repair existing tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)