### PR TITLE
feat: grouped skill/tool pickers and specific people/team sharing for agents

### DIFF
--- a/api/agent_identity_routes.py
+++ b/api/agent_identity_routes.py
@@ -38,6 +38,7 @@ MAX_DESCRIPTION_LEN = 200
 MAX_PROMPT_LEN = 8000
 MAX_SKILLS = 50
 MAX_TOOLS = 50
+MAX_SHARES = 100
 
 
 def _serialize(doc):
@@ -63,15 +64,22 @@ def _serialize(doc):
     return doc
 
 
-def _visible_query(user_email: str) -> dict:
-    """Agents this user can see and chat with: their own plus workspace-shared."""
-    return {
-        "deleted": {"$ne": True},
-        "$or": [
-            {"created_by": user_email},
-            {"visibility": "workspace"},
-        ],
-    }
+def _visible_query(user_email: str, team_ids: list[str]) -> dict:
+    """Agents this user can see and chat with: their own, workspace-shared,
+    shared with them directly, or shared with a team they belong to."""
+    ors: list[dict] = [
+        {"created_by": user_email},
+        {"visibility": "workspace"},
+        {"shared_with.users": user_email},
+    ]
+    if team_ids:
+        ors.append({"shared_with.teams": {"$in": team_ids}})
+    return {"deleted": {"$ne": True}, "$or": ors}
+
+
+async def _user_team_ids(db, user_email: str) -> list[str]:
+    teams = await db.teams.find({"members": user_email}, {"team_id": 1}).to_list(100)
+    return [t["team_id"] for t in teams if t.get("team_id")]
 
 
 def _can_manage(agent: dict, user_email: str, system_role: str) -> bool:
@@ -148,6 +156,34 @@ async def _validate_body(db, body: dict, *, partial: bool) -> tuple[dict, str | 
             return {}, f"visibility must be one of: {', '.join(VISIBILITIES)}"
         fields["visibility"] = visibility
 
+    if "shared_with" in body:
+        shared = body.get("shared_with") or {}
+        if not isinstance(shared, dict):
+            return {}, "shared_with must be an object with users and teams lists"
+        users = shared.get("users") or []
+        teams = shared.get("teams") or []
+        if not isinstance(users, list) or not all(isinstance(u, str) for u in users):
+            return {}, "shared_with.users must be a list of emails"
+        if not isinstance(teams, list) or not all(isinstance(t, str) for t in teams):
+            return {}, "shared_with.teams must be a list of team ids"
+        users = sorted({u.strip() for u in users if u.strip()})[:MAX_SHARES]
+        teams = sorted({t.strip() for t in teams if t.strip()})[:MAX_SHARES]
+        if users:
+            known = await db.users.find(
+                {"email": {"$in": users}}, {"email": 1},
+            ).to_list(MAX_SHARES)
+            unknown = set(users) - {doc["email"] for doc in known}
+            if unknown:
+                return {}, f"Unknown users: {', '.join(sorted(unknown)[:5])}"
+        if teams:
+            known = await db.teams.find(
+                {"team_id": {"$in": teams}}, {"team_id": 1},
+            ).to_list(MAX_SHARES)
+            unknown = set(teams) - {doc["team_id"] for doc in known}
+            if unknown:
+                return {}, f"Unknown teams: {', '.join(sorted(unknown)[:5])}"
+        fields["shared_with"] = {"users": users, "teams": teams}
+
     if "auth_mode" in body:
         auth_mode = body.get("auth_mode")
         if auth_mode not in AUTH_MODES:
@@ -202,6 +238,7 @@ async def handle_create_agent(request: web.Request) -> web.Response:
         "tools": fields.get("tools", []),
         "auth_mode": fields.get("auth_mode", "requester"),
         "visibility": visibility,
+        "shared_with": fields.get("shared_with", {"users": [], "teams": []}),
         "default_model": fields.get("default_model"),
         "avatar": fields.get("avatar", _validate_avatar(None)),
         "status": "active",
@@ -224,7 +261,8 @@ async def handle_list_agents(request: web.Request) -> web.Response:
     if not user_email:
         return web.json_response({"error": "Authentication required"}, status=401)
 
-    agents = await db.agent_identities.find(_visible_query(user_email)).sort(
+    team_ids = await _user_team_ids(db, user_email)
+    agents = await db.agent_identities.find(_visible_query(user_email, team_ids)).sort(
         [("visibility", -1), ("created_at", -1)],
     ).to_list(200)
 
@@ -244,6 +282,35 @@ async def handle_list_agents(request: web.Request) -> web.Response:
     return web.json_response({"agents": serialized})
 
 
+async def handle_share_directory(request: web.Request) -> web.Response:
+    """GET /api/agent-identities/directory — people and teams available as share
+    targets. Deliberately minimal fields (no roles, no tool assignments) so it's
+    safe to expose to every authenticated user, unlike the governance lists.
+    """
+    db = get_db()
+    if db is None:
+        return web.json_response({"error": "Observability not configured"}, status=503)
+
+    if not get_user_email(request):
+        return web.json_response({"error": "Authentication required"}, status=401)
+
+    users = await db.users.find(
+        {"status": {"$nin": ["rejected", "pending"]}},
+        {"email": 1, "name": 1, "avatar": 1},
+    ).sort("email", 1).to_list(300)
+    teams = await db.teams.find(
+        {}, {"team_id": 1, "name": 1, "color": 1, "bg_color": 1},
+    ).sort("name", 1).to_list(100)
+
+    return web.json_response({
+        "users": [
+            {"email": u["email"], "name": u.get("name", ""), "avatar": u.get("avatar", "")}
+            for u in users
+        ],
+        "teams": _serialize([{k: t.get(k) for k in ("team_id", "name", "color", "bg_color")} for t in teams]),
+    })
+
+
 async def handle_get_agent(request: web.Request) -> web.Response:
     """GET /api/agent-identities/{agent_id}."""
     db = get_db()
@@ -254,9 +321,10 @@ async def handle_get_agent(request: web.Request) -> web.Response:
     if not user_email:
         return web.json_response({"error": "Authentication required"}, status=401)
 
+    team_ids = await _user_team_ids(db, user_email)
     agent = await db.agent_identities.find_one({
         "agent_id": request.match_info["agent_id"],
-        **_visible_query(user_email),
+        **_visible_query(user_email, team_ids),
     })
     if not agent:
         return web.json_response({"error": "Not found"}, status=404)
@@ -351,10 +419,11 @@ async def resolve_agent_for_chat(db, agent_id: str, user_email: str) -> dict | N
     """Load an active agent the user is allowed to chat with, or None."""
     if not agent_id:
         return None
+    team_ids = await _user_team_ids(db, user_email)
     return await db.agent_identities.find_one({
         "agent_id": agent_id,
         "status": {"$ne": "disabled"},
-        **_visible_query(user_email),
+        **_visible_query(user_email, team_ids),
     })
 
 
@@ -407,6 +476,8 @@ def setup_agent_identity_routes(app: web.Application):
     """Register agent identity routes on the aiohttp app."""
     app.router.add_post("/api/agent-identities", handle_create_agent)
     app.router.add_get("/api/agent-identities", handle_list_agents)
+    # Static route must precede the {agent_id} wildcard
+    app.router.add_get("/api/agent-identities/directory", handle_share_directory)
     app.router.add_get("/api/agent-identities/{agent_id}", handle_get_agent)
     app.router.add_patch("/api/agent-identities/{agent_id}", handle_update_agent)
     app.router.add_delete("/api/agent-identities/{agent_id}", handle_delete_agent)

--- a/dashboard/src/app/agents/page.tsx
+++ b/dashboard/src/app/agents/page.tsx
@@ -9,10 +9,14 @@ import {
   createAgentIdentity,
   deleteAgentIdentity,
   fetchAgentIdentities,
+  fetchShareDirectory,
   updateAgentIdentity,
   type AgentIdentity,
   type AgentIdentityInput,
   type AgentMotif,
+  type AgentSharedWith,
+  type DirectoryTeam,
+  type DirectoryUser,
 } from "@/lib/agents-api";
 import { AgentAvatar, randomAvatarSpec } from "@/components/AgentAvatar";
 import { cn } from "@/lib/utils";
@@ -33,6 +37,7 @@ import {
 import {
   RiAddLine,
   RiChat1Line,
+  RiCloseLine,
   RiDeleteBinLine,
   RiPencilLine,
   RiRefreshLine,
@@ -53,14 +58,20 @@ const PERSONAL_TOOLS = [
   "telegram",
 ];
 
+type ShareMode = "private" | "specific" | "workspace";
+
 interface EditorState {
   agent: AgentIdentity | null; // null = creating
-  input: Required<Pick<AgentIdentityInput, "name" | "description" | "identity_prompt" | "skills" | "tools" | "visibility" | "avatar">>;
+  shareMode: ShareMode;
+  input: Required<Pick<AgentIdentityInput, "name" | "description" | "identity_prompt" | "skills" | "tools" | "visibility" | "avatar">> & {
+    shared_with: AgentSharedWith;
+  };
 }
 
 function emptyEditor(): EditorState {
   return {
     agent: null,
+    shareMode: "private",
     input: {
       name: "",
       description: "",
@@ -68,14 +79,22 @@ function emptyEditor(): EditorState {
       skills: [],
       tools: [],
       visibility: "private",
+      shared_with: { users: [], teams: [] },
       avatar: randomAvatarSpec(),
     },
   };
 }
 
 function editorFor(agent: AgentIdentity): EditorState {
+  const shared = agent.shared_with || { users: [], teams: [] };
   return {
     agent,
+    shareMode:
+      agent.visibility === "workspace"
+        ? "workspace"
+        : shared.users.length || shared.teams.length
+          ? "specific"
+          : "private",
     input: {
       name: agent.name,
       description: agent.description,
@@ -83,6 +102,7 @@ function editorFor(agent: AgentIdentity): EditorState {
       skills: agent.skills || [],
       tools: agent.tools || [],
       visibility: agent.visibility,
+      shared_with: { users: shared.users || [], teams: shared.teams || [] },
       avatar: agent.avatar || randomAvatarSpec(),
     },
   };
@@ -93,11 +113,13 @@ function ChipToggle({
   active,
   onToggle,
   title,
+  dotColor,
 }: {
   label: string;
   active: boolean;
   onToggle: () => void;
   title?: string;
+  dotColor?: string;
 }) {
   return (
     <button
@@ -105,15 +127,42 @@ function ChipToggle({
       onClick={onToggle}
       title={title}
       className={cn(
-        "rounded-full px-2.5 py-1 text-xs transition-colors",
+        "inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs transition-colors",
         active
           ? "bg-brand-800 text-brand-50 dark:bg-brand-200 dark:text-brand-900"
           : "bg-muted text-muted-foreground hover:text-foreground",
       )}
     >
+      {dotColor && <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: dotColor }} />}
       {label}
     </button>
   );
+}
+
+function GroupHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <p className="mt-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+      {children}
+    </p>
+  );
+}
+
+/** Skills grouped scope-first (workspace vs personal), then by folder — the
+ *  same hierarchy the Skills page uses, so nothing is a flat chip wall. */
+function groupSkillsByFolder(list: Skill[]) {
+  const map = new Map<string, Skill[]>();
+  for (const skill of list) {
+    const key = skill.folder || "Ungrouped";
+    const group = map.get(key);
+    if (group) group.push(skill);
+    else map.set(key, [skill]);
+  }
+  return [...map.entries()]
+    .sort(([a], [b]) => (a === "Ungrouped" ? 1 : b === "Ungrouped" ? -1 : a.localeCompare(b)))
+    .map(([folder, items]) => ({
+      folder,
+      items: [...items].sort((a, b) => a.name.localeCompare(b.name)),
+    }));
 }
 
 export default function AgentsPage() {
@@ -122,12 +171,16 @@ export default function AgentsPage() {
   const [agents, setAgents] = useState<AgentIdentity[]>([]);
   const [skills, setSkills] = useState<Skill[]>([]);
   const [integrations, setIntegrations] = useState<Integration[]>([]);
+  const [directoryUsers, setDirectoryUsers] = useState<DirectoryUser[]>([]);
+  const [directoryTeams, setDirectoryTeams] = useState<DirectoryTeam[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [editor, setEditor] = useState<EditorState | null>(null);
   const [saving, setSaving] = useState(false);
   const [editorError, setEditorError] = useState<string | null>(null);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [skillSearch, setSkillSearch] = useState("");
+  const [peopleSearch, setPeopleSearch] = useState("");
 
   const loadAgents = useCallback(async () => {
     try {
@@ -149,12 +202,34 @@ export default function AgentsPage() {
     fetchIntegrations()
       .then((list) => setIntegrations(list.filter((i) => i.status === "connected")))
       .catch(() => setIntegrations([]));
+    fetchShareDirectory()
+      .then((data) => {
+        setDirectoryUsers(data.users || []);
+        setDirectoryTeams(data.teams || []);
+      })
+      .catch(() => {
+        setDirectoryUsers([]);
+        setDirectoryTeams([]);
+      });
   }, [loadAgents]);
 
-  const toolOptions = useMemo(() => {
-    const fromIntegrations = integrations.map((i) => i.display_name || i.provider);
-    return [...new Set([...fromIntegrations, ...PERSONAL_TOOLS])];
-  }, [integrations]);
+  const integrationTools = useMemo(
+    () => [...new Set(integrations.map((i) => i.display_name || i.provider))],
+    [integrations],
+  );
+
+  const skillGroups = useMemo(() => {
+    const query = skillSearch.trim().toLowerCase();
+    const visible = query
+      ? skills.filter((s) =>
+          `${s.name} ${s.slug || ""} ${s.description}`.toLowerCase().includes(query),
+        )
+      : skills;
+    return {
+      workspace: groupSkillsByFolder(visible.filter((s) => s.scope !== "personal")),
+      personal: groupSkillsByFolder(visible.filter((s) => s.scope === "personal")),
+    };
+  }, [skills, skillSearch]);
 
   const canManage = useCallback(
     (agent: AgentIdentity) =>
@@ -166,10 +241,65 @@ export default function AgentsPage() {
     setEditor(state);
     setEditorError(null);
     setConfirmingDelete(false);
+    setSkillSearch("");
+    setPeopleSearch("");
   };
 
   const updateInput = (patch: Partial<EditorState["input"]>) => {
     setEditor((prev) => (prev ? { ...prev, input: { ...prev.input, ...patch } } : prev));
+  };
+
+  const setShareMode = (shareMode: ShareMode) => {
+    setEditor((prev) => (prev ? { ...prev, shareMode } : prev));
+  };
+
+  const toggleSkill = (slug: string) => {
+    if (!editor) return;
+    const active = editor.input.skills.includes(slug);
+    updateInput({
+      skills: active
+        ? editor.input.skills.filter((s) => s !== slug)
+        : [...editor.input.skills, slug],
+    });
+  };
+
+  const toggleTool = (tool: string) => {
+    if (!editor) return;
+    const active = editor.input.tools.includes(tool);
+    updateInput({
+      tools: active
+        ? editor.input.tools.filter((t) => t !== tool)
+        : [...editor.input.tools, tool],
+    });
+  };
+
+  const toggleShareTeam = (teamId: string) => {
+    if (!editor) return;
+    const { shared_with } = editor.input;
+    const active = shared_with.teams.includes(teamId);
+    updateInput({
+      shared_with: {
+        ...shared_with,
+        teams: active
+          ? shared_with.teams.filter((t) => t !== teamId)
+          : [...shared_with.teams, teamId],
+      },
+    });
+  };
+
+  const toggleShareUser = (email: string) => {
+    if (!editor) return;
+    const { shared_with } = editor.input;
+    const active = shared_with.users.includes(email);
+    updateInput({
+      shared_with: {
+        ...shared_with,
+        users: active
+          ? shared_with.users.filter((u) => u !== email)
+          : [...shared_with.users, email],
+      },
+    });
+    setPeopleSearch("");
   };
 
   const handleSave = async () => {
@@ -177,10 +307,18 @@ export default function AgentsPage() {
     setSaving(true);
     setEditorError(null);
     try {
+      const payload: AgentIdentityInput = {
+        ...editor.input,
+        visibility: editor.shareMode === "workspace" ? "workspace" : "private",
+        shared_with:
+          editor.shareMode === "specific"
+            ? editor.input.shared_with
+            : { users: [], teams: [] },
+      };
       if (editor.agent) {
-        await updateAgentIdentity(editor.agent.agent_id, editor.input);
+        await updateAgentIdentity(editor.agent.agent_id, payload);
       } else {
-        await createAgentIdentity(editor.input);
+        await createAgentIdentity(payload);
       }
       setEditor(null);
       await loadAgents();
@@ -211,6 +349,49 @@ export default function AgentsPage() {
     } catch {}
     router.push(`${basePath}/chat`);
   };
+
+  const shareLabel = (agent: AgentIdentity) => {
+    if (agent.visibility === "workspace") return { label: "Everyone", dot: "bg-emerald-500" };
+    const shared = agent.shared_with;
+    const count = (shared?.users.length || 0) + (shared?.teams.length || 0);
+    if (count > 0) return { label: `Shared with ${count}`, dot: "bg-amber-500" };
+    return { label: "Private", dot: "bg-gray-400" };
+  };
+
+  const selectedPeople = editor?.input.shared_with.users || [];
+  const peopleMatches = useMemo(() => {
+    const query = peopleSearch.trim().toLowerCase();
+    const unselected = directoryUsers.filter(
+      (u) => !selectedPeople.includes(u.email) && u.email !== user?.email,
+    );
+    if (!query) return unselected.slice(0, directoryUsers.length <= 15 ? 15 : 0);
+    return unselected
+      .filter((u) => `${u.email} ${u.name}`.toLowerCase().includes(query))
+      .slice(0, 8);
+  }, [directoryUsers, selectedPeople, peopleSearch, user?.email]);
+
+  const renderSkillGroups = (
+    groups: { folder: string; items: Skill[] }[],
+  ) =>
+    groups.map((group) => (
+      <div key={group.folder} className="grid gap-1.5">
+        <GroupHeading>{group.folder}</GroupHeading>
+        <div className="flex flex-wrap gap-1.5">
+          {group.items.map((skill) => {
+            const slug = skill.slug || skill.name;
+            return (
+              <ChipToggle
+                key={slug}
+                label={skill.name}
+                title={skill.description}
+                active={editor?.input.skills.includes(slug) || false}
+                onToggle={() => toggleSkill(slug)}
+              />
+            );
+          })}
+        </div>
+      </div>
+    ));
 
   return (
     <div className="flex-1 min-h-0 flex flex-col">
@@ -254,56 +435,54 @@ export default function AgentsPage() {
           />
         ) : (
           <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-            {agents.map((agent) => (
-              <Card key={agent.agent_id} className="p-4 flex flex-col gap-3">
-                <div className="flex items-start gap-3">
-                  <AgentAvatar avatar={agent.avatar} size={44} />
-                  <div className="min-w-0 flex-1">
-                    <p className="text-[13px] font-medium text-foreground truncate">{agent.name}</p>
-                    <p className="text-xs text-muted-foreground line-clamp-2">{agent.description}</p>
+            {agents.map((agent) => {
+              const share = shareLabel(agent);
+              return (
+                <Card key={agent.agent_id} className="p-4 flex flex-col gap-3">
+                  <div className="flex items-start gap-3">
+                    <AgentAvatar avatar={agent.avatar} size={44} />
+                    <div className="min-w-0 flex-1">
+                      <p className="text-[13px] font-medium text-foreground truncate">{agent.name}</p>
+                      <p className="text-xs text-muted-foreground line-clamp-2">{agent.description}</p>
+                    </div>
                   </div>
-                </div>
-                <div className="mt-auto flex items-center gap-2 text-xs text-muted-foreground">
-                  <span className="inline-flex items-center gap-1.5">
-                    <span
-                      className={cn(
-                        "h-1.5 w-1.5 rounded-full",
-                        agent.visibility === "workspace" ? "bg-emerald-500" : "bg-gray-400",
-                      )}
-                    />
-                    {agent.visibility === "workspace" ? "Shared" : "Private"}
-                  </span>
-                  <span className="truncate">
-                    {agent.created_by === user?.email ? "by you" : `by ${agent.created_by}`}
-                  </span>
-                  {(agent.conversation_count ?? 0) > 0 && (
-                    <span className="shrink-0">{agent.conversation_count} chats</span>
-                  )}
-                  <span className="ml-auto flex items-center gap-0.5">
-                    <Button
-                      variant="ghost"
-                      size="icon-sm"
-                      title={`Chat with ${agent.name}`}
-                      onClick={() => startChat(agent)}
-                      className="text-muted-foreground hover:text-foreground"
-                    >
-                      <RiChat1Line size={14} />
-                    </Button>
-                    {canManage(agent) && (
+                  <div className="mt-auto flex items-center gap-2 text-xs text-muted-foreground">
+                    <span className="inline-flex items-center gap-1.5">
+                      <span className={cn("h-1.5 w-1.5 rounded-full", share.dot)} />
+                      {share.label}
+                    </span>
+                    <span className="truncate">
+                      {agent.created_by === user?.email ? "by you" : `by ${agent.created_by}`}
+                    </span>
+                    {(agent.conversation_count ?? 0) > 0 && (
+                      <span className="shrink-0">{agent.conversation_count} chats</span>
+                    )}
+                    <span className="ml-auto flex items-center gap-0.5">
                       <Button
                         variant="ghost"
                         size="icon-sm"
-                        title="Edit agent"
-                        onClick={() => openEditor(editorFor(agent))}
+                        title={`Chat with ${agent.name}`}
+                        onClick={() => startChat(agent)}
                         className="text-muted-foreground hover:text-foreground"
                       >
-                        <RiPencilLine size={14} />
+                        <RiChat1Line size={14} />
                       </Button>
-                    )}
-                  </span>
-                </div>
-              </Card>
-            ))}
+                      {canManage(agent) && (
+                        <Button
+                          variant="ghost"
+                          size="icon-sm"
+                          title="Edit agent"
+                          onClick={() => openEditor(editorFor(agent))}
+                          className="text-muted-foreground hover:text-foreground"
+                        >
+                          <RiPencilLine size={14} />
+                        </Button>
+                      )}
+                    </span>
+                  </div>
+                </Card>
+              );
+            })}
           </div>
         )}
       </div>
@@ -387,81 +566,178 @@ export default function AgentsPage() {
               </div>
 
               {skills.length > 0 && (
-                <div className="grid gap-1.5">
-                  <Label>Skills</Label>
-                  <p className="text-xs text-muted-foreground -mt-1">
-                    Leave empty for all skills; pick some to focus the agent.
-                  </p>
-                  <div className="flex flex-wrap gap-1.5">
-                    {skills.map((skill) => {
-                      const slug = skill.slug || skill.name;
-                      const active = editor.input.skills.includes(slug);
-                      return (
-                        <ChipToggle
-                          key={slug}
-                          label={skill.name}
-                          title={skill.description}
-                          active={active}
-                          onToggle={() =>
-                            updateInput({
-                              skills: active
-                                ? editor.input.skills.filter((s) => s !== slug)
-                                : [...editor.input.skills, slug],
-                            })
-                          }
-                        />
-                      );
-                    })}
+                <div className="grid gap-2">
+                  <div className="flex items-baseline justify-between gap-2">
+                    <Label>Skills</Label>
+                    <span className="text-xs text-muted-foreground">
+                      {editor.input.skills.length > 0 ? (
+                        <>
+                          {editor.input.skills.length} selected
+                          {" · "}
+                          <button
+                            type="button"
+                            onClick={() => updateInput({ skills: [] })}
+                            className="underline-offset-2 hover:underline"
+                          >
+                            clear
+                          </button>
+                        </>
+                      ) : (
+                        "empty = all skills"
+                      )}
+                    </span>
+                  </div>
+                  <Input
+                    value={skillSearch}
+                    onChange={(e) => setSkillSearch(e.target.value)}
+                    placeholder="Search skills"
+                    className="h-8 text-[13px]"
+                  />
+                  <div className="grid max-h-56 gap-2.5 overflow-y-auto rounded-lg bg-muted/40 p-2.5">
+                    {skillGroups.workspace.length === 0 && skillGroups.personal.length === 0 && (
+                      <p className="py-2 text-center text-xs text-muted-foreground">
+                        No skills match that search.
+                      </p>
+                    )}
+                    {renderSkillGroups(skillGroups.workspace)}
+                    {skillGroups.personal.length > 0 && (
+                      <div className="grid gap-2.5 border-t border-border pt-2.5">
+                        <GroupHeading>Your personal skills</GroupHeading>
+                        {renderSkillGroups(skillGroups.personal)}
+                      </div>
+                    )}
                   </div>
                 </div>
               )}
 
-              {toolOptions.length > 0 && (
-                <div className="grid gap-1.5">
-                  <Label>Tools</Label>
-                  <p className="text-xs text-muted-foreground -mt-1">
-                    Leave empty for all tools; pick some to scope what the agent may use.
-                  </p>
-                  <div className="flex flex-wrap gap-1.5">
-                    {toolOptions.map((tool) => {
-                      const active = editor.input.tools.includes(tool);
-                      return (
-                        <ChipToggle
-                          key={tool}
-                          label={tool}
-                          active={active}
-                          onToggle={() =>
-                            updateInput({
-                              tools: active
-                                ? editor.input.tools.filter((t) => t !== tool)
-                                : [...editor.input.tools, tool],
-                            })
-                          }
-                        />
-                      );
-                    })}
+              {(integrationTools.length > 0 || PERSONAL_TOOLS.length > 0) && (
+                <div className="grid gap-2">
+                  <div className="flex items-baseline justify-between gap-2">
+                    <Label>Tools</Label>
+                    <span className="text-xs text-muted-foreground">
+                      {editor.input.tools.length > 0 ? `${editor.input.tools.length} selected` : "empty = all tools"}
+                    </span>
+                  </div>
+                  <div className="grid gap-2.5 rounded-lg bg-muted/40 p-2.5">
+                    {integrationTools.length > 0 && (
+                      <div className="grid gap-1.5">
+                        <GroupHeading>Integrations</GroupHeading>
+                        <div className="flex flex-wrap gap-1.5">
+                          {integrationTools.map((tool) => (
+                            <ChipToggle
+                              key={tool}
+                              label={tool}
+                              active={editor.input.tools.includes(tool)}
+                              onToggle={() => toggleTool(tool)}
+                            />
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                    <div className="grid gap-1.5">
+                      <GroupHeading>Personal tools</GroupHeading>
+                      <div className="flex flex-wrap gap-1.5">
+                        {PERSONAL_TOOLS.map((tool) => (
+                          <ChipToggle
+                            key={tool}
+                            label={tool}
+                            active={editor.input.tools.includes(tool)}
+                            onToggle={() => toggleTool(tool)}
+                          />
+                        ))}
+                      </div>
+                    </div>
                   </div>
                 </div>
               )}
 
-              <div className="grid gap-1.5">
+              <div className="grid gap-2">
                 <Label>Sharing</Label>
-                <div className="flex items-center gap-1.5">
+                <div className="flex flex-wrap items-center gap-1.5">
                   <ChipToggle
                     label="Private"
-                    active={editor.input.visibility === "private"}
-                    onToggle={() => updateInput({ visibility: "private" })}
+                    active={editor.shareMode === "private"}
+                    onToggle={() => setShareMode("private")}
+                  />
+                  <ChipToggle
+                    label="Specific people & teams"
+                    active={editor.shareMode === "specific"}
+                    onToggle={() => setShareMode("specific")}
                   />
                   <ChipToggle
                     label="Everyone in workspace"
-                    active={editor.input.visibility === "workspace"}
-                    onToggle={() => updateInput({ visibility: "workspace" })}
+                    active={editor.shareMode === "workspace"}
+                    onToggle={() => setShareMode("workspace")}
                   />
                 </div>
+
+                {editor.shareMode === "specific" && (
+                  <div className="grid gap-2.5 rounded-lg bg-muted/40 p-2.5">
+                    {directoryTeams.length > 0 && (
+                      <div className="grid gap-1.5">
+                        <GroupHeading>Teams</GroupHeading>
+                        <div className="flex flex-wrap gap-1.5">
+                          {directoryTeams.map((team) => (
+                            <ChipToggle
+                              key={team.team_id}
+                              label={team.name}
+                              dotColor={team.color}
+                              active={editor.input.shared_with.teams.includes(team.team_id)}
+                              onToggle={() => toggleShareTeam(team.team_id)}
+                            />
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                    <div className="grid gap-1.5">
+                      <GroupHeading>People</GroupHeading>
+                      {selectedPeople.length > 0 && (
+                        <div className="flex flex-wrap gap-1.5">
+                          {selectedPeople.map((email) => {
+                            const person = directoryUsers.find((u) => u.email === email);
+                            return (
+                              <button
+                                key={email}
+                                type="button"
+                                onClick={() => toggleShareUser(email)}
+                                title="Remove"
+                                className="inline-flex items-center gap-1 rounded-full bg-brand-800 px-2.5 py-1 text-xs text-brand-50 dark:bg-brand-200 dark:text-brand-900"
+                              >
+                                {person?.name || email}
+                                <RiCloseLine size={12} />
+                              </button>
+                            );
+                          })}
+                        </div>
+                      )}
+                      <Input
+                        value={peopleSearch}
+                        onChange={(e) => setPeopleSearch(e.target.value)}
+                        placeholder={directoryUsers.length > 0 ? "Search people by name or email" : "No teammates found"}
+                        disabled={directoryUsers.length === 0}
+                        className="h-8 text-[13px]"
+                      />
+                      {peopleMatches.length > 0 && (
+                        <div className="flex flex-wrap gap-1.5">
+                          {peopleMatches.map((person) => (
+                            <ChipToggle
+                              key={person.email}
+                              label={person.name || person.email}
+                              title={person.email}
+                              active={false}
+                              onToggle={() => toggleShareUser(person.email)}
+                            />
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                )}
+
                 <p className="text-xs text-muted-foreground">
                   Agents act with the credentials of whoever is chatting with them.
-                  {editor.input.visibility === "workspace" && !hasRole("operator") &&
-                    " Sharing with the workspace requires operator access."}
+                  {editor.shareMode === "workspace" && !hasRole("operator") &&
+                    " Sharing with the whole workspace requires operator access."}
                 </p>
               </div>
 

--- a/dashboard/src/lib/agents-api.ts
+++ b/dashboard/src/lib/agents-api.ts
@@ -12,6 +12,24 @@ export interface AgentAvatarSpec {
   motif: AgentMotif;
 }
 
+export interface AgentSharedWith {
+  users: string[];
+  teams: string[];
+}
+
+export interface DirectoryUser {
+  email: string;
+  name: string;
+  avatar: string;
+}
+
+export interface DirectoryTeam {
+  team_id: string;
+  name: string;
+  color?: string;
+  bg_color?: string;
+}
+
 export interface AgentIdentity {
   agent_id: string;
   name: string;
@@ -21,6 +39,7 @@ export interface AgentIdentity {
   tools: string[];
   auth_mode: "requester";
   visibility: AgentVisibility;
+  shared_with?: AgentSharedWith;
   default_model: string | null;
   avatar: AgentAvatarSpec;
   status: "active" | "disabled";
@@ -37,6 +56,7 @@ export interface AgentIdentityInput {
   skills?: string[];
   tools?: string[];
   visibility?: AgentVisibility;
+  shared_with?: AgentSharedWith;
   default_model?: string | null;
   avatar?: AgentAvatarSpec;
   status?: "active" | "disabled";
@@ -45,6 +65,12 @@ export interface AgentIdentityInput {
 async function parseError(res: Response, fallback: string): Promise<never> {
   const err = await res.json().catch(() => ({}));
   throw new Error(err.error || `${fallback}: ${res.status}`);
+}
+
+export async function fetchShareDirectory(): Promise<{ users: DirectoryUser[]; teams: DirectoryTeam[] }> {
+  const res = await fetch(`${API_BASE}/api/agent-identities/directory`);
+  if (!res.ok) return parseError(res, "Failed to fetch share directory");
+  return res.json();
 }
 
 export async function fetchAgentIdentities(): Promise<{ agents: AgentIdentity[] }> {

--- a/observability/db.py
+++ b/observability/db.py
@@ -126,6 +126,8 @@ async def init_observability():
     await _db.agent_identities.create_index("agent_id", unique=True)
     await _db.agent_identities.create_index("created_by")
     await _db.agent_identities.create_index("visibility")
+    await _db.agent_identities.create_index("shared_with.users")
+    await _db.agent_identities.create_index("shared_with.teams")
     await _db.conversations.create_index("metadata.agent_id")
 
     # Org integrations (dynamic MCP config)


### PR DESCRIPTION
## Summary

Recovers the agent-editor v2 that missed PR #148 (it was pushed to the branch a few minutes after the PR was merged, so it never reached main), rebased onto current main.

**Skills picker — hierarchy restored.** The flat chip wall is replaced with the same organization the Skills page uses: grouped by **workspace vs. your personal skills**, then by **folder** within each (folderless skills land in "Ungrouped", listed last — matching the Skills sidebar). Scrollable panel, search box, "N selected · clear" counter, descriptions on hover.

**Tools picker** — split into **Integrations** (connected only) and **Personal tools**.

**Sharing — three modes.** Private / **Specific people & teams** / Everyone in workspace:
- `shared_with: {users, teams}` on the agent, validated against real users/teams
- Visibility is team-aware and re-checked on every chat message, so revoking a share takes effect immediately
- New `GET /api/agent-identities/directory` — open to any authenticated user but deliberately minimal (email, name, avatar letter, team name/color) since the governance user/team lists are admin/maintainer-gated
- Specific sharing open to everyone; "Everyone in workspace" keeps the operator+ gate

## Verification
- Python AST parse of touched backend modules — clean
- `npm run build` (Next.js + TypeScript) on top of current main (post #149–#152) — clean
- Cherry-pick applied with no conflicts; `stream_agent`/chat-handler integration untouched

## Test plan
- [ ] Open agent editor: skills grouped by folder under Workspace / Your personal skills; search filters
- [ ] Share an agent with one person + one team; verify they see it in their picker and non-shared users don't
- [ ] Switch a shared agent back to Private; verify access is revoked on next message

🤖 Generated with [Claude Code](https://claude.com/claude-code)