### PR TITLE
feat: add GPT-6 Astra as top Codex favorite, bump Codex CLI to 0.153.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends nodejs npm git 
     && claude --version \
     # Codex CLI pinned: the app-server protocol is not stability-guaranteed,
     # so version bumps must go through CI (see agent/codex_runtime.py)
-    && npm install -g @openai/codex@0.144.1 \
+    && npm install -g @openai/codex@0.153.3 \
     && codex --version \
     && pip install --no-cache-dir uv \
     && uv --version \

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -54,6 +54,7 @@ DEFAULT_CODEX_MODEL = "gpt-5.6-sol"
 # path). The live list is fetched from ``model/list`` at worker warm time and
 # preferred over this tuple; override order: $CODEX_MODELS > model/list > this.
 DEFAULT_CODEX_MODEL_IDS = (
+    "gpt-6-astra",  # requires codex CLI >= 0.153 (older CLIs get a 400 from the server)
     "gpt-5.6-sol",
     "gpt-5.6-terra",
     "gpt-5.6-luna",

--- a/api/routes.py
+++ b/api/routes.py
@@ -147,6 +147,7 @@ SUPPORTED_CLAUDE_MODEL_IDS = (
 )
 
 FAVORITE_MODEL_IDS = (
+    "codex/gpt-6-astra",
     "codex/gpt-5.6-sol",
     "anthropic/claude-fable-5-1",
     "opencode-go/glm-5.3-flash",

--- a/dashboard/src/components/composer/ModelPicker.tsx
+++ b/dashboard/src/components/composer/ModelPicker.tsx
@@ -17,6 +17,7 @@ import type { AgentModel } from "@/lib/api";
 import { favoriteModelRank, isFavoriteModel, type ModelLoadState } from "@/hooks/useAgentModels";
 
 const FAVORITE_LABELS: Record<string, string> = {
+  "codex/gpt-6-astra": "GPT 6 Astra",
   "codex/gpt-5.6-sol": "GPT 5.6 Sol",
   "opencode-go/glm-5.3-flash": "GLM 5.3 Flash",
   "anthropic/claude-fable-5-1": "Claude Fable 5.1",

--- a/dashboard/src/hooks/useAgentModels.ts
+++ b/dashboard/src/hooks/useAgentModels.ts
@@ -6,6 +6,7 @@ import { fetchAgentModels, type AgentModel } from "@/lib/api";
 const MODEL_STORAGE_KEY = "dashboard-chat-selected-model";
 
 export const FAVORITE_MODEL_IDS = [
+  "codex/gpt-6-astra",
   "codex/gpt-5.6-sol",
   "anthropic/claude-fable-5-1",
   "opencode-go/glm-5.3-flash",

--- a/tests/test_codex_pool.py
+++ b/tests/test_codex_pool.py
@@ -53,6 +53,8 @@ def test_selected_model_is_codex():
 
     assert selected_model_is_codex("codex/gpt-5.6-sol")
     assert normalize_codex_model("codex/gpt-5.6-sol") == "gpt-5.6-sol"
+    assert selected_model_is_codex("codex/gpt-6-astra")
+    assert normalize_codex_model("codex/gpt-6-astra") == "gpt-6-astra"
     assert not selected_model_is_codex("anthropic/claude-opus-4-8")
     assert not selected_model_is_codex("openai/gpt-5.5")
     assert not selected_model_is_codex("gpt-5.6-sol")  # no provider prefix


### PR DESCRIPTION
## What

Adds **GPT-6 Astra** (`gpt-6-astra`) as the top Codex favorite in the Loma model picker, and bumps the pinned Codex CLI so the model can actually be served.

- `Dockerfile`: `@openai/codex@0.144.1` -> `@openai/codex@0.153.3`. `gpt-6-astra` is version-gated server-side: on 0.144.1 the catalog omits it and a turn returns `400 "The 'gpt-6-astra' model requires a newer version of Codex"`. On 0.153.3 the catalog lists it and turns complete.
- `agent/codex_runtime.py`: add `gpt-6-astra` to the static `DEFAULT_CODEX_MODEL_IDS` fallback (the live `model/list` still wins at warm time).
- `api/routes.py`: `codex/gpt-6-astra` first in `FAVORITE_MODEL_IDS`
- `dashboard/src/hooks/useAgentModels.ts`: same favorites change on the frontend
- `dashboard/src/components/composer/ModelPicker.tsx`: favorite label "GPT 6 Astra"
- `tests/test_codex_pool.py`: cover the new id in the codex model-id helpers

The default model is unchanged (`AGENT_DEFAULT_MODEL` env); only favorites ordering changes. Follows the same pattern as #142.

## Testing

**App-server protocol on 0.153.3** (the reason the pin exists): drove `CodexWorker` directly against Codex CLI 0.153.3 with `model="gpt-6-astra"`. `initialize` -> `thread/start` -> `model/list` -> `turn/start` all worked; `model/list` returned 8 models including `gpt-6-astra`; the turn streamed `agent_message_delta` x3, `agent_message` ("OK-ASTRA"), `token_count`, `task_complete`. No changes to the runtime were needed.

**Unit / static**: `pytest -q` 371 passed, 2 failed. Both failures (`test_archive_extraction.py::TestEdgeCases::test_zip_with_only_directories`, `test_opencode_runtime.py::test_stream_agent_uses_opencode_runtime_by_default`) fail identically on untouched `main`, so they are pre-existing and unrelated. `python -m compileall` clean, dashboard `tsc --noEmit` clean.

**In-browser**: booted the full stack locally (isolated backend :13000 with `CODEX_POOL_ENABLED=1` and Codex CLI 0.153.3 on PATH, dashboard :13001, throwaway Mongo), logged in, and verified the picker:

**Favorites row: GPT 6 Astra is first**

![Model picker favorites](https://cdn.plotline.so/loma-images/loma-pr/astra-picker-favorites.png)

**Search "astra": `gpt-6-astra` resolves from the live Codex catalog**

![Model picker search](https://cdn.plotline.so/loma-images/loma-pr/astra-picker-search.png)

**Selected: composer shows `gpt-6-astra`**

![Model picker selected](https://cdn.plotline.so/loma-images/loma-pr/astra-picker-selected.png)

## Deploy note

The running `loma-backend` container still has Codex CLI 0.144.1 until the image is rebuilt from this Dockerfile. Until then the live `model/list` will not include Astra, so the favorite simply will not appear in the picker (nothing breaks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
