### PR TITLE
feat: board settings drawer + global default task board context

### DIFF
--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -4,15 +4,23 @@ from config.app_config import APP_NAME
 
 logger = logging.getLogger(__name__)
 
-PROMPT_SETTING_KEYS = ("identity_guidelines", "company_information", "dictation_vocabulary")
+PROMPT_SETTING_KEYS = (
+    "identity_guidelines",
+    "company_information",
+    "dictation_vocabulary",
+    "task_board_default_context",
+)
 PROMPT_SETTING_TITLES = {
     "identity_guidelines": "Identity & Guidelines",
     "company_information": "Company Information",
     "dictation_vocabulary": "Dictation Vocabulary",
+    "task_board_default_context": "Task Board Default Context",
 }
 
 # Settings injected into the agent system prompt. dictation_vocabulary is
-# admin-edited through the same UI but only feeds the /api/transcribe hint.
+# admin-edited through the same UI but only feeds the /api/transcribe hint;
+# task_board_default_context is injected per task on the tasks board only
+# (see api.task_routes.build_board_context).
 RULEBOOK_KEYS = ("identity_guidelines", "company_information")
 
 _prompt_settings_cache: dict[str, str] = {}

--- a/api/prompt_setting_defaults.py
+++ b/api/prompt_setting_defaults.py
@@ -29,7 +29,7 @@ When asked to reply to a Slack thread, DM, or Slack URL on {{user_name}}'s behal
 
 Required workflow:
 - Load the `slack-reader` Loma skill first for Slack tool context.
-- Extract the Slack channel ID and parent thread timestamp from the Slack URL. For URLs like `https://plotlinespace.slack.com/archives/D02LLBHU9HQ/p1782671385831399`, use channel `D02LLBHU9HQ` and thread timestamp `1782671385.831399` (remove the leading `p`, then insert a decimal after the first 10 digits).
+- Extract the Slack channel ID and parent thread timestamp from the Slack URL. For URLs like `https://<workspace>.slack.com/archives/D0123ABCDEF/p1700000000123456`, use channel `D0123ABCDEF` and thread timestamp `1700000000.123456` (remove the leading `p`, then insert a decimal after the first 10 digits).
 - Use {{user_name}}'s personal credentials only: `--user-email {{user_email}}` and an auth token for {{user_name}}. If an auth token is not explicitly available in the runtime context, generate one locally with:
   `AUTH_TOKEN=$(python3 -c 'import sys; sys.path.insert(0, "tools"); from _auth_token import create_user_auth_token; print(create_user_auth_token("{{user_email}}"))')`
 - Send thread replies with:
@@ -40,7 +40,7 @@ Required workflow:
 - Only send the exact Slack message requested by the human. Do not add unrelated credentials, deployment instructions, or sensitive details unless the human explicitly requested them and the context is safe.
 
 == CODE IMPLEMENTATION DETAILS ==
-Whenever you're asked to implement something in Plotline (i.e. plotline-services) or Loma (plotlinelabs/loma) and you're working on creating a PR, always plan, implement, test and add testing screenshots to the PR. Refer to the run-plotline-services-local skill for Plotline and the run-loma-local skill for Loma.""",
+Whenever you're asked to implement something in a repository and you're working on creating a PR, always plan, implement, test and add testing screenshots to the PR. If a `run-<repo>-local` Loma skill exists for that repository (for example `run-loma-local`), follow it to boot the stack locally and verify the change in a real browser before opening the PR.""",
 }
 
 

--- a/api/prompt_setting_defaults.py
+++ b/api/prompt_setting_defaults.py
@@ -15,6 +15,32 @@ DEFAULT_PROMPT_SETTINGS = {
         "Loma, OpenCode, Claude, Anthropic, MongoDB, aiohttp, Next.js, PWA, "
         "Slack, webhook, kanban, repo, PR, API, MCP, agent, prompt, dashboard."
     ),
+    # Applied to every task on every user's board, ahead of their personal
+    # board context. {{user_name}} / {{user_email}} resolve per task owner.
+    "task_board_default_context": """You are a personal assistant operating on {{user_name}}'s personal taskboard.
+
+- Use whatever skills and MCP tools are needed to do what was asked (research, database lookups via MongoDB/ClickHouse, GitHub, web search, document creation, Drive/Docs, Gmail, Slack, Calendar, etc.). Load relevant Loma skills first.
+- AUTH / PERSONAL CONNECTIONS: This is {{user_name}}'s personal project. For ANY action that touches Google (Drive, Docs, Sheets, Gmail, Calendar), Slack, or any other personal connection, you MUST use {{user_name}}'s credentials: pass `--user-email {{user_email}} --auth-token <{{user_name}}'s personal tools auth token>` on every personal-tool call. The auth token is injected/resolved at runtime under {{user_name}}'s account context. Never use a different user's email.
+- If the request is ambiguous or you cannot complete it, say so clearly in your reply rather than guessing.
+- Keep your responses in simple english and never give complicated answers. Keep your answers as concise as possible; avoid verbosity.
+
+== PERSONAL SLACK REPLIES FOR {{user_name}} ==
+When asked to reply to a Slack thread, DM, or Slack URL on {{user_name}}'s behalf, use `tools/slack_user.py`, not `tools/slack_reader.py`. The bot-level `slack_reader.py` cannot access many DM channels and may return `Channel not found` for `D...` channels.
+
+Required workflow:
+- Load the `slack-reader` Loma skill first for Slack tool context.
+- Extract the Slack channel ID and parent thread timestamp from the Slack URL. For URLs like `https://plotlinespace.slack.com/archives/D02LLBHU9HQ/p1782671385831399`, use channel `D02LLBHU9HQ` and thread timestamp `1782671385.831399` (remove the leading `p`, then insert a decimal after the first 10 digits).
+- Use {{user_name}}'s personal credentials only: `--user-email {{user_email}}` and an auth token for {{user_name}}. If an auth token is not explicitly available in the runtime context, generate one locally with:
+  `AUTH_TOKEN=$(python3 -c 'import sys; sys.path.insert(0, "tools"); from _auth_token import create_user_auth_token; print(create_user_auth_token("{{user_email}}"))')`
+- Send thread replies with:
+  `python3 tools/slack_user.py --auth-token "$AUTH_TOKEN" --user-email {{user_email}} send-message --channel <CHANNEL_ID> --thread-ts <THREAD_TS> --text "<MESSAGE>"`
+- For DM channels, pass the raw `D...` channel ID. Do not prefix it with `#`.
+- If the command returns `{"sent": true, ...}`, treat the Slack send as successful and include the Slack `message_ts` in your reply.
+- If the command fails, do not retry blindly or switch users. Reply with the exact error and state that no Slack message was sent.
+- Only send the exact Slack message requested by the human. Do not add unrelated credentials, deployment instructions, or sensitive details unless the human explicitly requested them and the context is safe.
+
+== CODE IMPLEMENTATION DETAILS ==
+Whenever you're asked to implement something in Plotline (i.e. plotline-services) or Loma (plotlinelabs/loma) and you're working on creating a PR, always plan, implement, test and add testing screenshots to the PR. Refer to the run-plotline-services-local skill for Plotline and the run-loma-local skill for Loma.""",
 }
 
 

--- a/api/routes.py
+++ b/api/routes.py
@@ -1009,16 +1009,14 @@ async def handle_chat(request: web.Request) -> web.Response:
                 {"$set": {"tool_config": tool_config}},
             )
 
-        # Board tasks carry the owner's personal working context on every turn.
+        # Board tasks carry the global default context plus the owner's
+        # personal working context on every turn.
         if existing and existing.get("task_status"):
+            from api.task_routes import build_board_context
+
             owner = (existing.get("metadata") or {}).get("user_name") or user_email
-            owner_doc = await db.users.find_one({"email": owner}, {"task_board": 1})
-            board_prompt = ((owner_doc or {}).get("task_board") or {}).get("prompt", "").strip()
-            if board_prompt:
-                context_block = (
-                    "## User's role & working context (apply to this task)\n"
-                    f"{board_prompt}"
-                )
+            context_block = await build_board_context(db, owner)
+            if context_block:
                 conversation_context = (
                     f"{context_block}\n\n{conversation_context}"
                     if conversation_context else context_block

--- a/api/task_routes.py
+++ b/api/task_routes.py
@@ -28,10 +28,54 @@ from datetime import date, datetime, timezone
 from aiohttp import web
 
 from observability.db import get_db
+from agent.prompt import get_prompt_setting
 from api.auth_helpers import get_system_role, get_user_email
 from api.drain import DRAIN_MESSAGE, is_draining
 
 logger = logging.getLogger(__name__)
+
+BOARD_CONTEXT_HEADING = "## User's role & working context (apply to this task)"
+BOARD_PERSONAL_HEADING = "### Personal additions"
+# Placeholders admins can use in the global default context (Admin > Settings).
+_BOARD_PLACEHOLDER_RE = re.compile(r"\{\{\s*(user_name|user_email)\s*\}\}")
+
+
+def render_board_default_context(template: str, owner_doc: dict | None, owner_email: str) -> str:
+    """Fill {{user_name}} / {{user_email}} in the global default board context."""
+    template = (template or "").strip()
+    if not template:
+        return ""
+    email = ((owner_doc or {}).get("email") or owner_email or "").strip()
+    name = ((owner_doc or {}).get("name") or "").strip() or email.split("@")[0] or "the user"
+    values = {"user_name": name, "user_email": email}
+    return _BOARD_PLACEHOLDER_RE.sub(lambda m: values[m.group(1)], template)
+
+
+def merge_board_context(default_context: str, personal_prompt: str) -> str:
+    """Compose the per-task context block: global default first, then the
+    owner's personal board context. Empty when neither is configured."""
+    default_context = (default_context or "").strip()
+    personal_prompt = (personal_prompt or "").strip()
+    if not default_context and not personal_prompt:
+        return ""
+    parts = [BOARD_CONTEXT_HEADING]
+    if default_context:
+        parts.append(default_context)
+    if personal_prompt:
+        if default_context:
+            parts.append(f"\n{BOARD_PERSONAL_HEADING}")
+        parts.append(personal_prompt)
+    return "\n".join(parts)
+
+
+async def build_board_context(db, owner: str) -> str:
+    """The context block injected on every turn of a board task owned by `owner`."""
+    owner_doc = await db.users.find_one(
+        {"email": owner}, {"task_board": 1, "name": 1, "email": 1})
+    personal = ((owner_doc or {}).get("task_board") or {}).get("prompt", "")
+    default_context = render_board_default_context(
+        get_prompt_setting("task_board_default_context"), owner_doc, owner)
+    return merge_board_context(default_context, personal)
 
 
 async def _run_task_headless(db, conversation_id: str, prompt: str,
@@ -49,12 +93,7 @@ async def _run_task_headless(db, conversation_id: str, prompt: str,
         from observability.observer import ConversationObserver
 
         # Same per-task context block handle_chat injects for board tasks.
-        owner_doc = await db.users.find_one({"email": owner}, {"task_board": 1})
-        board_prompt = ((owner_doc or {}).get("task_board") or {}).get("prompt", "").strip()
-        conversation_context = (
-            f"## User's role & working context (apply to this task)\n{board_prompt}"
-            if board_prompt else ""
-        )
+        conversation_context = await build_board_context(db, owner)
 
         observer = ConversationObserver(
             db,
@@ -729,7 +768,13 @@ async def handle_get_board_settings(request: web.Request) -> web.Response:
     if not user_email:
         return web.json_response({"error": "Authentication required"}, status=401)
 
-    board = await _get_board_config_for(db, user_email)
+    user_doc = await db.users.find_one(
+        {"email": user_email}, {"task_board": 1, "name": 1, "email": 1})
+    board = get_board_config(user_doc)
+    # Resolved global default (Admin > Settings) so the drawer can show what
+    # is already applied ahead of the personal context.
+    board["default_context"] = render_board_default_context(
+        get_prompt_setting("task_board_default_context"), user_doc, user_email)
     return web.json_response(board)
 
 

--- a/dashboard/src/app/admin/page.tsx
+++ b/dashboard/src/app/admin/page.tsx
@@ -1707,7 +1707,9 @@ export default function AdminPage() {
                         onChange={(e) => setPromptDrafts((prev) => ({ ...prev, [setting.setting_key]: e.target.value }))}
                         placeholder={setting.setting_key === "identity_guidelines"
                           ? "Describe Loma's identity, tone, operating rules, and general guidelines."
-                          : "Describe the company, product, customer context, terminology, and other always-on company facts."}
+                          : setting.setting_key === "task_board_default_context"
+                            ? "Context applied to every task on every user's board, ahead of their personal board context. Use {{user_name}} and {{user_email}} for the task owner."
+                            : "Describe the company, product, customer context, terminology, and other always-on company facts."}
                         className="w-full min-h-[260px] resize-y text-[13px] leading-6 font-mono border border-border rounded-lg px-3 py-2 bg-card text-foreground focus:outline-none focus:ring-2 focus:ring-accent-200"
                       />
                     </section>

--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -279,6 +279,7 @@ export default function TasksPage() {
               <Button
                 variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground"
                 onClick={() => setSettingsOpen(true)}
+                aria-label="Board settings"
               >
                 <RiSettings3Line className="h-4 w-4" />
               </Button>

--- a/dashboard/src/components/tasks/BoardSettingsDialog.tsx
+++ b/dashboard/src/components/tasks/BoardSettingsDialog.tsx
@@ -4,16 +4,18 @@ import { useEffect, useState } from "react";
 import {
   RiAddLine,
   RiArrowDownSLine,
+  RiArrowRightSLine,
   RiArrowUpSLine,
   RiDeleteBinLine,
 } from "@remixicon/react";
 import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -35,6 +37,8 @@ interface BoardSettingsDialogProps {
 
 export function BoardSettingsDialog({ open, onOpenChange, laneCounts, onSaved }: BoardSettingsDialogProps) {
   const [prompt, setPrompt] = useState("");
+  const [defaultContext, setDefaultContext] = useState("");
+  const [showDefault, setShowDefault] = useState(false);
   const [lanes, setLanes] = useState<EditableLane[]>([]);
   const [removedWithTasks, setRemovedWithTasks] = useState<string[]>([]);
   const [busy, setBusy] = useState(false);
@@ -44,9 +48,11 @@ export function BoardSettingsDialog({ open, onOpenChange, laneCounts, onSaved }:
     if (!open) return;
     setError(null);
     setRemovedWithTasks([]);
+    setShowDefault(false);
     fetchBoardSettings()
       .then((settings) => {
         setPrompt(settings.prompt);
+        setDefaultContext(settings.default_context ?? "");
         setLanes(settings.lanes.map(({ id, name }) => ({ id, name })));
       })
       .catch((e) => setError(e instanceof Error ? e.message : "Failed to load settings"));
@@ -88,20 +94,51 @@ export function BoardSettingsDialog({ open, onOpenChange, laneCounts, onSaved }:
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-lg">
-        <DialogHeader>
-          <DialogTitle>Board settings</DialogTitle>
-        </DialogHeader>
-        <div className="space-y-5">
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className="gap-0 p-0 data-[side=right]:w-full data-[side=right]:sm:max-w-xl"
+      >
+        <SheetHeader className="flex-shrink-0 border-b border-border pr-12">
+          <SheetTitle>Board settings</SheetTitle>
+          <SheetDescription>Context and columns for your tasks board.</SheetDescription>
+        </SheetHeader>
+        <div className="min-h-0 flex-1 space-y-6 overflow-y-auto p-4">
+          {defaultContext && (
+            <div className="space-y-1.5">
+              <button
+                type="button"
+                onClick={() => setShowDefault((v) => !v)}
+                className="flex items-center gap-1 text-[13px] font-medium text-foreground"
+                aria-expanded={showDefault}
+              >
+                {showDefault
+                  ? <RiArrowDownSLine className="h-4 w-4 text-muted-foreground" />
+                  : <RiArrowRightSLine className="h-4 w-4 text-muted-foreground" />}
+                Team default context
+              </button>
+              <p className="text-xs text-muted-foreground">
+                Set by admins in Admin › Settings. Applied to every task before your personal context below.
+              </p>
+              {showDefault && (
+                <pre className="max-h-80 overflow-y-auto whitespace-pre-wrap rounded-lg border border-border bg-muted/40 px-3 py-2 font-mono text-xs leading-5 text-muted-foreground">
+                  {defaultContext}
+                </pre>
+              )}
+            </div>
+          )}
           <div className="space-y-1.5">
-            <Label htmlFor="board-prompt">Context</Label>
+            <Label htmlFor="board-prompt">{defaultContext ? "Personal context" : "Context"}</Label>
+            <p className="text-xs text-muted-foreground">
+              Your role and working context — added to every task on this board.
+            </p>
             <Textarea
               id="board-prompt"
               value={prompt}
               onChange={(e) => setPrompt(e.target.value)}
-              placeholder="Your role and working context — added to every task on this board"
-              rows={5}
+              placeholder="e.g. I lead the CS team. Prefer short answers. Always reply in my Slack voice."
+              rows={12}
+              className="min-h-[240px] resize-y font-mono text-xs leading-5 md:text-xs"
             />
           </div>
           <div className="space-y-1.5">
@@ -156,13 +193,13 @@ export function BoardSettingsDialog({ open, onOpenChange, laneCounts, onSaved }:
           </div>
           {error && <p className="text-xs text-destructive">{error}</p>}
         </div>
-        <DialogFooter>
+        <SheetFooter className="mt-0 flex-shrink-0 flex-row justify-end border-t border-border">
           <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={busy}>
             Cancel
           </Button>
           <Button onClick={save} disabled={busy}>Save</Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
   );
 }

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -1125,6 +1125,8 @@ export interface TasksBoardResponse {
 export interface BoardSettings {
   prompt: string;
   lanes: BoardLane[];
+  /** Global default context (Admin > Settings), resolved for the caller. Read-only. */
+  default_context?: string;
 }
 
 export async function fetchTasksBoard(query = ""): Promise<TasksBoardResponse> {

--- a/dashboard/src/lib/prompt-settings-api.ts
+++ b/dashboard/src/lib/prompt-settings-api.ts
@@ -3,7 +3,8 @@ const API_BASE = process.env.NEXT_PUBLIC_BASE_PATH || "";
 export type PromptSettingKey =
   | "identity_guidelines"
   | "company_information"
-  | "dictation_vocabulary";
+  | "dictation_vocabulary"
+  | "task_board_default_context";
 
 export interface PromptSetting {
   setting_key: PromptSettingKey;

--- a/tests/test_task_create.py
+++ b/tests/test_task_create.py
@@ -86,3 +86,56 @@ async def test_start_still_requires_prompt(monkeypatch):
 
     assert response.status == 400
     conversations.insert_one.assert_not_called()
+
+
+# ── Board context (global default + personal) ──────────────────────────────
+
+def test_render_board_default_context_fills_placeholders():
+    doc = {"email": "adarsh@example.com", "name": "Adarsh"}
+    out = task_routes.render_board_default_context(
+        "Assistant for {{user_name}}. Use --user-email {{ user_email }}.", doc, "adarsh@example.com")
+    assert out == "Assistant for Adarsh. Use --user-email adarsh@example.com."
+
+
+def test_render_board_default_context_falls_back_to_email_local_part():
+    out = task_routes.render_board_default_context(
+        "Hi {{user_name}} <{{user_email}}>", None, "jane.doe@example.com")
+    assert out == "Hi jane.doe <jane.doe@example.com>"
+
+
+def test_merge_board_context_default_then_personal():
+    out = task_routes.merge_board_context("DEFAULT", "PERSONAL")
+    assert out.startswith(task_routes.BOARD_CONTEXT_HEADING)
+    assert out.index("DEFAULT") < out.index(task_routes.BOARD_PERSONAL_HEADING) < out.index("PERSONAL")
+
+
+def test_merge_board_context_personal_only_keeps_legacy_shape():
+    assert task_routes.merge_board_context("", " PERSONAL ") == (
+        f"{task_routes.BOARD_CONTEXT_HEADING}\nPERSONAL")
+    assert task_routes.merge_board_context("", "") == ""
+
+
+@pytest.mark.asyncio
+async def test_build_board_context_uses_default_setting_and_owner_doc(monkeypatch):
+    from agent.prompt import set_prompt_settings_cache
+
+    set_prompt_settings_cache({
+        "task_board_default_context": "Global rules for {{user_name}} ({{user_email}}).",
+    })
+    users = SimpleNamespace(find_one=AsyncMock(return_value={
+        "email": "owner@example.com", "name": "Owner",
+        "task_board": {"prompt": "My personal notes"},
+    }))
+    try:
+        out = await task_routes.build_board_context(SimpleNamespace(users=users), "owner@example.com")
+    finally:
+        set_prompt_settings_cache({})
+
+    assert out == (
+        f"{task_routes.BOARD_CONTEXT_HEADING}\n"
+        "Global rules for Owner (owner@example.com).\n"
+        f"\n{task_routes.BOARD_PERSONAL_HEADING}\n"
+        "My personal notes"
+    )
+    users.find_one.assert_awaited_once_with(
+        {"email": "owner@example.com"}, {"task_board": 1, "name": 1, "email": 1})


### PR DESCRIPTION
## Summary
- Board settings now opens as a right-side **drawer** (`Sheet`) instead of a small centered dialog: the body scrolls, the Cancel/Save footer stays pinned, and the context textarea is wider with a mono font, so long context no longer overflows the screen.
- New admin prompt setting **Task Board Default Context** (Admin › Settings, maintainers/admins only). It is applied to every task on every user's board, ahead of the user's personal context. Supports `{{user_name}}` and `{{user_email}}`, resolved from the task owner's `users` doc at run time.
- The default is seeded with the current personal taskboard context (name/email replaced by placeholders), so users no longer need to paste their own.
- The drawer shows the resolved default as a read-only, collapsible "Team default context" block above the personal textarea.

## Injection order (per board task turn)
```
## User's role & working context (apply to this task)
<resolved default context>

### Personal additions
<user's personal board context, if any>
```
If no default is configured, the block is identical to today's (personal context only). If neither is set, nothing is injected.

## Changes
- `dashboard/src/components/tasks/BoardSettingsDialog.tsx` — Dialog → Sheet drawer, scrollable body, pinned footer, read-only default preview
- `dashboard/src/app/tasks/page.tsx` — `aria-label` on the Board settings button
- `dashboard/src/app/admin/page.tsx`, `dashboard/src/lib/prompt-settings-api.ts` — new setting key + placeholder hint
- `dashboard/src/lib/api.ts` — `BoardSettings.default_context`
- `agent/prompt.py` — register `task_board_default_context` (not part of the system-prompt rulebook; board tasks only)
- `api/prompt_setting_defaults.py` — seeded default with placeholders
- `api/task_routes.py` — `render_board_default_context`, `merge_board_context`, `build_board_context`; `GET /api/tasks/board-settings` returns `default_context`
- `api/routes.py` — `handle_chat` uses `build_board_context` (replaces the inline personal-prompt block)
- `tests/test_task_create.py` — placeholder substitution, fallback name, merge order, end-to-end helper test

## Testing
- `pytest tests/test_task_create.py tests/test_task_fork.py tests/test_prompt_settings.py` — 15 passed
- `tsc --noEmit` clean; eslint: no new warnings
- Booted an isolated local stack (fresh throwaway DB), logged in, set the default in Admin › Settings, opened the drawer, saved a long personal context, and checked `GET /api/tasks/board-settings`: `default_context` resolved with the owner's name/email and no raw `{{...}}` left.

### Admin › Settings — new section, after "Set default" + Save
![admin](https://cdn.plotline.so/loma-images/loma-pr/taskboard-ctx-admin-default-context.png)

### Board settings drawer (collapsed default)
![drawer](https://cdn.plotline.so/loma-images/loma-pr/taskboard-ctx-drawer-collapsed.png)

### Drawer — team default expanded (resolved for the signed-in user)
![drawer-default](https://cdn.plotline.so/loma-images/loma-pr/taskboard-ctx-drawer-default-expanded.png)

### Drawer — long personal context, body scrolled, footer pinned
![drawer-scrolled](https://cdn.plotline.so/loma-images/loma-pr/taskboard-ctx-drawer-scrolled.png)

## Notes
- Existing users who pasted the same text as the new default will see it twice (default + personal) until they clear their personal context in the drawer. No data migration in this PR.
- This PR was generated by Loma based on a request from Adarsh. Please review carefully before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
