### PR TITLE
fix: restore security release with corrected OpenCode image installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
-FROM python:3.12-slim
+FROM python:3.12-slim AS worker-base
 
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends nodejs npm git curl ca-certificates \
     poppler-utils tesseract-ocr openssh-client \
     && OPENCODE_INSTALL_DIR=/usr/local/bin sh -c 'curl -fsSL https://opencode.ai/install | bash' \
-    && ln -sf /root/.opencode/bin/opencode /usr/local/bin/opencode \
     && opencode --version \
     && npm install -g @anthropic-ai/claude-code \
     && claude --version \
@@ -26,9 +25,36 @@ RUN apt-get update && apt-get install -y --no-install-recommends nodejs npm git 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
+# This image contains runtimes and public dependencies, never application code,
+# .env files, account directories, or backend signing/provider credentials.
+COPY broker/sandbox_entry.py /usr/local/lib/loma_worker_entry.py
+COPY tools/pptx_creator.py /opt/loma-render/tools/pptx_creator.py
+RUN printf '1\n' > /.loma-worker-image && mkdir -p /run/loma /opt/loma-render/ppt/output
+
+FROM worker-base AS backend
+# Independent read-only image for each OCI worker, not the backend rootfs.
+COPY --from=worker-base / /opt/loma-worker-rootfs
+# Install the authenticated gVisor distribution only into the trusted backend.
+RUN apt-get update && apt-get install -y --no-install-recommends gnupg \
+    && curl -fsSL https://gvisor.dev/archive.key | gpg --dearmor -o /usr/share/keyrings/gvisor.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/gvisor.gpg] https://storage.googleapis.com/gvisor/releases release main" > /etc/apt/sources.list.d/gvisor.list \
+    && apt-get update && apt-get install -y --no-install-recommends runsc \
+    && rm -rf /var/lib/apt/lists/*
 COPY . .
+ENV LOMA_WORKER_SANDBOX=runsc
+ENV LOMA_WORKER_ROOTFS=/opt/loma-worker-rootfs
 ENV PYTHONPATH=/app
 ENV WEBHOOK_PORT=3000
+# Dedicated non-root identity for isolated per-run agent workers. The backend
+# (root in this image) drops every worker subprocess to this uid/gid, so
+# malicious run code cannot read backend-owned files (.env, /root/.ssh-host,
+# other runs' workspaces). See broker/worker.py and docs/execution-security.md.
+RUN groupadd -g 990 loma-worker \
+    && useradd -u 990 -g 990 -M -s /usr/sbin/nologin loma-worker \
+    && chmod 700 /root
+ENV LOMA_WORKER_UID=990
+ENV LOMA_WORKER_GID=990
+ENV LOMA_WORKER_UID_RANGE=200000-200999
 # Persistent in-container workspace for cloning & running repos (named volume
 # loma-workspace -> /opt/loma-workspace in docker-compose.yml). Lets long-running
 # agent tasks keep their clone across container recreation, unlike /tmp's

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,10 @@ WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends nodejs npm git curl ca-certificates \
     poppler-utils tesseract-ocr openssh-client \
-    && OPENCODE_INSTALL_DIR=/usr/local/bin sh -c 'curl -fsSL https://opencode.ai/install | bash' \
+    && curl -fsSL https://opencode.ai/install -o /tmp/install-opencode.sh \
+    && bash /tmp/install-opencode.sh --no-modify-path \
+    && install -m 0755 /root/.opencode/bin/opencode /usr/local/bin/opencode \
+    && rm -rf /root/.opencode /tmp/install-opencode.sh \
     && opencode --version \
     && npm install -g @anthropic-ai/claude-code \
     && claude --version \
@@ -21,6 +24,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends nodejs npm git 
         @sentry/mcp-server \
         @lishenxydlgzs/aws-athena-mcp \
     && rm -rf /var/lib/apt/lists/* /root/.npm
+
+# Fail the image build if a CLI relies on root's home or shell startup files.
+COPY scripts/check_worker_clis.py /tmp/check_worker_clis.py
+RUN python /tmp/check_worker_clis.py && rm /tmp/check_worker_clis.py
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt

--- a/agent/client.py
+++ b/agent/client.py
@@ -140,22 +140,8 @@ async def merge_db_integrations(config: dict) -> dict:
 
             # Custom connectors carry their own inline remote MCP config (no
             # catalog entry). Added by admins from the Integrations page.
-            if integration.get("is_custom"):
-                # OAuth connectors are handled per-user at stream_agent() time
-                if integration.get("auth_mode") == "oauth":
-                    logger.info("Skipping OAuth custom connector '%s' from shared pool config", provider)
-                    continue
-                try:
-                    cfg = {"type": "http", "url": integration["mcp_url"]}
-                    if integration.get("api_key_encrypted"):
-                        header = integration.get("auth_header") or "Authorization"
-                        cfg["headers"] = {
-                            header: decrypt_token(integration["api_key_encrypted"]),
-                        }
-                    mcp_servers[provider] = cfg
-                    logger.info("Loaded custom MCP connector '%s' from DB", provider)
-                except Exception:
-                    logger.exception("Failed to load custom MCP connector %s", provider)
+            if integration.get("is_custom") or provider in ("grain", "hubspot", "notion"):
+                mcp_servers.pop(provider, None)
                 continue
 
             catalog_entry = PROVIDER_CATALOG.get(provider)
@@ -188,47 +174,20 @@ async def merge_db_integrations(config: dict) -> dict:
 
 
 async def get_excluded_integrations_for_user(user_email: str) -> set[str]:
-    """Return MCP server names the user should NOT have access to.
-
-    Checks `shared_with` on each integration. If mode is "specific", the
-    user must be in the users list or a member of one of the listed teams.
-    """
-    try:
-        from observability.db import get_db
-        from integrations.registry import PROVIDER_CATALOG
-
-        db = get_db()
-        if db is None:
-            return set()
-
-        excluded = set()
-        async for integration in db.integrations.find({
-            "status": "active",
-            "shared_with.mode": "specific",
-        }):
+    from observability.db import get_db
+    from integrations.registry import PROVIDER_CATALOG
+    from integrations.access import can_access
+    db = get_db()
+    if db is None:
+        raise RuntimeError("Integration authorization unavailable")
+    excluded = set()
+    async for integration in db.integrations.find({}):
+        if integration.get("provider") in ("grain", "hubspot", "notion"):
+            continue  # personal OAuth is authorized independently of org sharing
+        if not await can_access(db, integration, user_email):
             provider = integration["provider"]
-            shared = integration.get("shared_with", {})
-            allowed_users = set(shared.get("users") or [])
-            allowed_teams = set(shared.get("teams") or [])
-
-            has_access = user_email in allowed_users
-            if not has_access and allowed_teams:
-                team_count = await db.teams.count_documents({
-                    "team_id": {"$in": list(allowed_teams)},
-                    "members": user_email,
-                })
-                has_access = team_count > 0
-
-            if not has_access:
-                catalog = PROVIDER_CATALOG.get(provider)
-                server_name = catalog["mcp_server_name"] if catalog and catalog.get("mcp_server_name") else provider
-                excluded.add(server_name)
-                logger.info("User %s excluded from integration %s", user_email, provider)
-
-        return excluded
-    except Exception:
-        logger.exception("Failed to compute excluded integrations for %s", user_email)
-        return set()
+            excluded.add(PROVIDER_CATALOG.get(provider, {}).get("mcp_server_name") or provider)
+    return excluded
 
 
 async def build_user_mcp_overrides(user_email: str) -> dict:
@@ -254,9 +213,17 @@ async def build_user_mcp_overrides(user_email: str) -> dict:
 
         # 1. Custom MCP OAuth connectors
         async for integration in db.integrations.find({
-            "is_custom": True, "status": "active", "auth_mode": "oauth",
+            "is_custom": True, "status": "active", "connected_by": user_email,
         }):
             provider = integration["provider"]
+            if integration.get("auth_mode") != "oauth":
+                cfg = {"type": "http", "url": integration["mcp_url"]}
+                if integration.get("api_key_encrypted"):
+                    from api.oauth_helpers import decrypt_token
+                    cfg["headers"] = {integration.get("auth_header") or "Authorization":
+                                      decrypt_token(integration["api_key_encrypted"])}
+                overrides[provider] = cfg
+                continue
             token = await get_valid_custom_mcp_token(user_email, provider, db=db)
             if token:
                 header = integration.get("auth_header") or "Authorization"
@@ -285,7 +252,7 @@ async def build_user_mcp_overrides(user_email: str) -> dict:
         return overrides
     except Exception:
         logger.exception("Failed to build user MCP overrides for %s", user_email)
-        return {}
+        raise RuntimeError("Personal integration authorization unavailable") from None
 
 
 def _resolve_mcp_template(template: dict, api_key: str, extra_fields: dict | None = None) -> dict:
@@ -527,7 +494,7 @@ def _encode_file_id(file_path: str) -> str:
     return base64.urlsafe_b64encode(file_path.encode()).decode().rstrip("=")
 
 
-def _detect_file_artifact(file_path: str) -> dict | None:
+def _detect_file_artifact(file_path: str, *, owner_email=None, conversation_id=None) -> dict | None:
     """
     Check if a file path corresponds to a binary file artifact.
     Registers the file for serving via /api/files/ and returns an artifact dict.
@@ -549,7 +516,7 @@ def _detect_file_artifact(file_path: str) -> dict | None:
     # and adds it to the in-memory registry so /api/files/{id} can serve it.
     try:
         from api.routes import register_served_file
-        file_info = register_served_file(file_path)
+        file_info = register_served_file(file_path, owner_email=owner_email, conversation_id=conversation_id)
         file_url = file_info["url"]
         logger.info("[FILE ARTIFACT] Registered %s -> %s", file_path, file_url)
     except Exception as e:
@@ -778,6 +745,63 @@ async def stream_agent(
     raise_on_opencode_error: bool = False,
     tool_config: dict | None = None,
 ) -> AsyncGenerator[str | dict, None]:
+    """Run one agent turn inside an isolated, broker-mediated run.
+
+    This wrapper owns the run lifecycle: it starts a run (fresh private
+    workspace + revocable run capability) before any runtime executes, and
+    always revokes the capability and cleans the workspace afterwards.
+    There is no non-isolated execution path.
+    """
+    from broker import controller as execution_controller
+
+    try:
+        run_ctx = await execution_controller.start_run(user_email, source=source)
+    except Exception:
+        logger.exception("Failed to start isolated run — refusing to execute")
+        if observer:
+            await observer.record_error("Execution environment unavailable")
+        yield ("The execution environment is unavailable right now. "
+               "Please try again shortly.")
+        return
+
+    context_token = execution_controller.current_run.set(run_ctx)
+    try:
+        async for event in _stream_agent_impl(
+            prompt,
+            conversation_context=conversation_context,
+            files=files,
+            observer=observer,
+            include_steps=include_steps,
+            source=source,
+            user_email=user_email,
+            selected_model=selected_model,
+            raise_on_opencode_error=raise_on_opencode_error,
+            tool_config=tool_config,
+            run_ctx=run_ctx,
+        ):
+            yield event
+    finally:
+        try:
+            await execution_controller.end_run(run_ctx)
+        except Exception:
+            logger.exception("Failed to finalize isolated run %s", run_ctx.run_id)
+        finally:
+            execution_controller.current_run.reset(context_token)
+
+
+async def _stream_agent_impl(
+    prompt: str,
+    conversation_context: str = "",
+    files: list | None = None,
+    observer=None,
+    include_steps: bool = False,
+    source: str = "slack",
+    user_email: str | None = None,
+    selected_model: str | None = None,
+    raise_on_opencode_error: bool = False,
+    tool_config: dict | None = None,
+    run_ctx=None,
+) -> AsyncGenerator[str | dict, None]:
     """
     Run the Claude agent and yield text blocks as they arrive.
 
@@ -816,34 +840,49 @@ async def stream_agent(
             f"skill index.]"
         )
 
-    # Inject authenticated user identity and auth token for personal tools
-    if user_email:
-        from tools._auth_token import create_user_auth_token
-        auth_token = create_user_auth_token(user_email)
+    # Inject authenticated user identity and the run-scoped capability for
+    # personal tools. The capability is the worker's ONLY credential: tools
+    # forward it to the execution broker, which runs the real tool
+    # server-side for this run's owner. It expires with the run and is
+    # revoked when the run ends.
+    auth_token = getattr(run_ctx, "capability", None)
+    if user_email and not auth_token:
         text_parts.append(
             f"[Authenticated User: {user_email}]\n"
-            f"[Personal Tools Auth Token: {auth_token}]\n"
+            f"[Personal tools are DISABLED for this run: the execution "
+            f"broker is unavailable. Do not attempt to use personal CLI "
+            f"tools; tell the user tool access is temporarily unavailable "
+            f"if they ask for an action that needs them.]"
+        )
+    if user_email and auth_token:
+        # The run capability is delivered to tool shims via the worker
+        # environment (LOMA_RUN_CAPABILITY), never via prompt text: it must
+        # not enter model context, transcripts, or tool argv.
+        text_parts.append(
+            f"[Authenticated User: {user_email}]\n"
             f"SECURITY RULE: You are acting on behalf of {user_email}. "
             f"You MUST ONLY use the personal CLI tools for Gmail, Google Drive, "
             f"Google Calendar, Google Sheets, Google Slides, Google Docs, and Slack. "
             f"You MUST NEVER use mcp__claude_ai_Gmail__*, mcp__claude_ai_Google_Drive__*, "
             f"mcp__claude_ai_Google_Calendar__*, or any other mcp__claude_ai_* tools. "
             f"These tools belong to a different account and would violate user privacy.\n"
-            f"When using personal tools (gmail, google_drive, google_calendar, "
-            f"google_sheets, google_slides, google_docs_personal, google_apps_script, slack_user, telegram, notify), you MUST pass "
-            f"`--user-email {user_email} --auth-token {auth_token}`. "
-            f"Never use a different user's email with --user-email."
+            f"Personal tools (gmail, google_drive, google_calendar, google_sheets, "
+            f"google_slides, google_docs_personal, google_apps_script, slack_user, "
+            f"telegram, notify) authenticate automatically as {user_email}: run them "
+            f"as `python3 tools/<name>.py <command> ...` with NO --user-email or "
+            f"--auth-token flags. Identity is enforced server-side and cannot be "
+            f"overridden."
         )
 
     # Expose the conversation id so tools (e.g. tools/notify.py) can deep-link
     # notifications back to this conversation.
     conversation_id = getattr(observer, "conversation_id", None) if observer else None
-    if user_email and conversation_id:
+    if user_email and auth_token and conversation_id:
         text_parts.append(
             f"[Conversation ID: {conversation_id}]\n"
             f"To leave a persistent notification in this user's Loma inbox (the bell icon "
-            f"in the dashboard), run `python3 tools/notify.py --user-email {user_email} "
-            f"--auth-token {auth_token} send --title \"...\" --body \"...\" "
+            f"in the dashboard), run `python3 tools/notify.py "
+            f"send --title \"...\" --body \"...\" "
             f"--conversation-id {conversation_id}`. Use it when a flow or long-running "
             f"task finishes with a result the user should see — the notification "
             f"deep-links back to this conversation and persists until dismissed. "
@@ -994,6 +1033,7 @@ async def stream_agent(
                 include_steps=include_steps,
                 source=source,
                 user_email=user_email,
+                run_ctx=run_ctx,
             ):
                 yield event
         except Exception as e:
@@ -1030,6 +1070,7 @@ async def stream_agent(
                 user_email=user_email,
                 user_mcp_overrides=user_mcp_overrides,
                 image_files=image_files or None,
+                run_ctx=run_ctx,
             ):
                 yield event
         except Exception as e:
@@ -1068,17 +1109,15 @@ async def stream_agent(
             yield "No Claude accounts are currently available."
             return
         try:
-            options = pool._build_options(model_override=selected_claude_model)
-            merged_mcp = dict(options.mcp_servers or {})
-            merged_mcp.update(user_mcp_overrides)
-            for excluded in excluded_integrations:
-                merged_mcp.pop(excluded, None)
-            options.mcp_servers = merged_mcp
+            # Per-user MCP overrides and sharing exclusions are resolved
+            # inside _build_options, which also rewrites every MCP server to
+            # go through the credential gateway (no tokens enter the worker).
+            options = pool._build_options(
+                model_override=selected_claude_model,
+                user_mcp_overrides=user_mcp_overrides,
+                excluded_servers=excluded_integrations,
+            )
             allowed_tools = list(options.allowed_tools or [])
-            for server_name in user_mcp_overrides:
-                tool_name = f"mcp__{server_name}"
-                if tool_name not in allowed_tools:
-                    allowed_tools.append(tool_name)
             # Per-chat tool filtering
             if tool_config and tool_config.get("enabled_tools") is not None:
                 enabled_set = set(tool_config["enabled_tools"])
@@ -1086,12 +1125,19 @@ async def stream_agent(
                 enabled_set.add("Skill")
                 allowed_tools = [t for t in allowed_tools if t in enabled_set]
             options.allowed_tools = allowed_tools
-            options.env = {"CLAUDE_CONFIG_DIR": account["config_dir"]}
+            from agent.pool import _prepare_worker_subscription_env
+            options.env, sub_tokens = _prepare_worker_subscription_env(account, options._worker_workspace)
             client = ClaudeSDKClient(options=options)
+            client._worker_workspace = options._worker_workspace
+            client._mcp_proxy_tokens = options._mcp_proxy_tokens
+            client._sub_proxy_tokens = sub_tokens
             await asyncio.wait_for(client.connect(), timeout=90)
             client._pool_account = account
             client._pool_model = options.model
             client._pool_ephemeral = True
+            client._worker_workspace = getattr(options, "_worker_workspace", None)
+            client._mcp_proxy_tokens = getattr(options, "_mcp_proxy_tokens", [])
+            client._disabled_mcp_servers = getattr(options, "_disabled_mcp_servers", [])
             pool._in_use += 1
             account_email = account.get("email")
             logger.info(
@@ -1102,8 +1148,7 @@ async def stream_agent(
             logger.error("Failed to create per-user MCP client: %s", e)
             if client is not None:
                 await pool.safe_disconnect(client)
-            client = None
-            user_mcp_overrides = {}
+            raise RuntimeError("Personal integration initialization failed; no shared fallback was started") from None
 
     if client is None:
         try:
@@ -1320,7 +1365,7 @@ async def stream_agent(
                                             emitted_file_paths.add(fpath)
                                             try:
                                                 from api.routes import register_served_file
-                                                file_info = register_served_file(fpath)
+                                                file_info = register_served_file(fpath, owner_email=user_email, conversation_id=conversation_id)
                                                 logger.info(
                                                     "[FILE] Registered %s as %s (%s, %d bytes)",
                                                     fpath, file_info["file_id"],
@@ -1462,7 +1507,7 @@ async def stream_agent(
                                     for fpath in file_paths:
                                         if fpath in emitted_file_paths:
                                             continue
-                                        artifact = _detect_file_artifact(fpath)
+                                        artifact = _detect_file_artifact(fpath, owner_email=user_email, conversation_id=conversation_id)
                                         if artifact:
                                             emitted_file_paths.add(fpath)
                                             logger.info(

--- a/agent/codex_pool.py
+++ b/agent/codex_pool.py
@@ -113,6 +113,17 @@ class CodexClientPool:
     def _mcp_servers(self) -> dict:
         return (self._config or {}).get("mcp_servers", {})
 
+    async def _authorized_mcp_servers(self) -> dict:
+        from broker.controller import current_run
+        from agent.client import build_user_mcp_overrides, get_excluded_integrations_for_user
+        ctx = current_run.get()
+        if ctx is None or not ctx.user_email:
+            return {}
+        servers = dict(self._mcp_servers())
+        servers.update(await build_user_mcp_overrides(ctx.user_email))
+        excluded = await get_excluded_integrations_for_user(ctx.user_email)
+        return {name: cfg for name, cfg in servers.items() if name not in excluded}
+
     async def reload_config(self, config: dict):
         """Drain idle workers after an MCP config change and re-warm."""
         old_servers = set(self._mcp_servers().keys()) if self._config else set()
@@ -314,7 +325,7 @@ class CodexClientPool:
             worker = CodexWorker(account, model=model_override)
             await asyncio.wait_for(
                 worker.connect(
-                    mcp_servers=self._mcp_servers(),
+                    mcp_servers=await self._authorized_mcp_servers(),
                     system_prompt=build_pooled_system_prompt(),
                 ),
                 timeout=_env_int("CODEX_CONNECT_TIMEOUT"),

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -258,6 +258,8 @@ class CodexWorker:
         self.thread_id: str | None = None
         self.available_models: list[dict] = []
         self.last_rate_limits: dict | None = None
+        self._workspace = None
+        self._mcp_proxy_tokens: list[str] = []
         # Pool bookkeeping (mirrors client._pool_account on ClaudeSDKClient)
         self._pool_account = account
         self._pool_model = self.model
@@ -418,13 +420,68 @@ class CodexWorker:
         acquire -> first token is near-instant, mirroring the Claude pool's
         pre-warmed MCP handshake.
         """
-        write_managed_codex_config(self.account["config_dir"], mcp_servers or {})
+        # Isolated worker boundary: MCP servers are rewritten through the
+        # credential gateway (stdio servers whose env would carry secrets
+        # into the worker are disabled — fail closed), the worker gets a
+        # fresh private workspace, and the backend environment is never
+        # inherited. Workers are single-use, so per-worker == per-run.
+        from broker import worker as worker_mod
+        from broker.controller import broker_url, proxy_mcp_servers_for_worker
+        from broker.gateway import gateway_base_url
+        from broker.operations import ALL_TOOLS
 
-        env = {**os.environ, "CODEX_HOME": self.account["config_dir"]}
-        env.pop("OPENAI_API_KEY", None)  # subscription auth only — never fall back to API billing
-        self._proc = await asyncio.create_subprocess_exec(
-            "codex", "app-server",
-            cwd=str(PROJECT_ROOT),
+        try:
+            proxied_servers, proxy_tokens, disabled = proxy_mcp_servers_for_worker(
+                mcp_servers or {},
+            )
+        except Exception:
+            proxied_servers, proxy_tokens, disabled = {}, [], sorted(mcp_servers or {})
+            logger.error(
+                "Execution gateway unavailable — all MCP servers disabled for "
+                "this Codex worker (fail closed): %s", disabled,
+            )
+        self._mcp_proxy_tokens = proxy_tokens
+        from broker.controller import current_run, get_subscription_registry, run_worker_env_extra
+        ctx = current_run.get()
+        if ctx is None or not ctx.capability:
+            raise CodexError("Subscription execution requires an authenticated run")
+        self._workspace = worker_mod.create_workspace(prefix="codex")
+        worker_mod.populate_tool_shims(self._workspace, sorted(ALL_TOOLS))
+        # The real account home stays backend-only. The worker gets fresh
+        # configuration and a revocable proxy reference, never auth.json.
+        config_home = self._workspace / "codex-config"
+        config_home.mkdir(mode=0o700)
+        from broker.credential_files import protect_account_directory
+        protect_account_directory(self.account["config_dir"])
+        token = get_subscription_registry().register(
+            "codex", Path(self.account["config_dir"]) / "auth.json", capability=ctx.capability)
+        ctx.sub_proxy_tokens.append(token)
+        self._sub_proxy_tokens = [token]
+        write_managed_codex_config(config_home, proxied_servers)
+        path = config_home / "config.toml"
+        provider = '\n'.join([
+            'model_provider = "loma_subscription"',
+            '[model_providers.loma_subscription]',
+            'name = "Loma subscription gateway"',
+            'base_url = ' + _toml_str(f"{gateway_base_url()}/sub/{token}"),
+            'env_key = "LOMA_RUN_CAPABILITY"',
+            'wire_api = "responses"',
+            'requires_openai_auth = false',
+            'supports_websockets = false',
+            '',
+        ])
+        # Top-level provider selection must precede any TOML table.
+        path.write_text('model_provider = "loma_subscription"\n' + path.read_text()
+                        + '\n' + provider.split('\n', 1)[1])
+        worker_mod.grant_worker_access(config_home, workspace=self._workspace)
+        env = worker_mod.build_worker_env(self._workspace, extra={
+            "CODEX_HOME": str(config_home), **run_worker_env_extra(),
+        })
+        # Subscription auth only — the scrubbed env can never fall back to
+        # API billing, and no provider API keys exist in the worker at all.
+        self._proc = await worker_mod.spawn_worker(
+            ["codex", "app-server"],
+            workspace=self._workspace,
             env=env,
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
@@ -441,7 +498,7 @@ class CodexWorker:
 
         params: dict = {
             "model": self.model,
-            "cwd": str(PROJECT_ROOT),
+            "cwd": str(self._workspace),
             "approvalPolicy": "never",
             "sandboxPolicy": {"mode": "danger-full-access"},
         }
@@ -483,6 +540,22 @@ class CodexWorker:
                 self._proc.kill()
                 await self._proc.wait()
         self._proc = None
+        # Revoke gateway proxy tokens and remove the private workspace.
+        from broker import worker as worker_mod
+        for token in getattr(self, "_sub_proxy_tokens", None) or []:
+            from broker.controller import get_subscription_registry
+            get_subscription_registry().revoke(token)
+        for proxy_token in getattr(self, "_mcp_proxy_tokens", None) or []:
+            try:
+                from broker.controller import get_proxy_registry
+                get_proxy_registry().revoke(proxy_token)
+            except Exception:
+                pass
+        self._mcp_proxy_tokens = []
+        workspace = getattr(self, "_workspace", None)
+        if workspace is not None:
+            worker_mod.cleanup_workspace(workspace)
+            self._workspace = None
 
     # ── Turn streaming ───────────────────────────────────────────────
 
@@ -711,11 +784,16 @@ async def run_codex_agent(
     include_steps: bool = False,
     source: str = "dashboard",
     user_email: str | None = None,
+    run_ctx=None,
 ) -> AsyncGenerator[str | dict, None]:
     """Run one turn through the Codex account pool, yielding dashboard events.
 
-    Same event contract as run_opencode_agent / the Claude SDK path.
+    Same event contract as run_opencode_agent / the Claude SDK path. Workers
+    are single-use sandboxed subprocesses with private workspaces and a
+    scrubbed environment (see CodexWorker.connect); the run capability from
+    ``run_ctx`` reaches tools via the prompt, like the Claude runtime.
     """
+    del run_ctx  # capability is prompt-delivered; nothing else is needed here
     from agent.codex_pool import get_codex_pool
 
     model_id = normalize_codex_model(selected_model) or default_codex_model()

--- a/agent/opencode_runtime.py
+++ b/agent/opencode_runtime.py
@@ -13,6 +13,7 @@ import logging
 import os
 import shutil
 import socket
+import secrets
 import tempfile
 import time
 from pathlib import Path
@@ -22,10 +23,21 @@ from urllib.parse import urlparse
 import aiohttp
 
 from agent.prompt import build_pooled_system_prompt
+from broker import worker as worker_mod
 
 logger = logging.getLogger(__name__)
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+# Neutral scratch workspace for catalog-only servers (never runs agent code).
+_catalog_workspace: Path | None = None
+
+
+def _catalog_dir() -> str:
+    global _catalog_workspace
+    if _catalog_workspace is None or not _catalog_workspace.exists():
+        _catalog_workspace = worker_mod.create_workspace(prefix="opencode-catalog")
+    return str(_catalog_workspace)
 DEFAULT_OPENCODE_HOST = "127.0.0.1"
 DEFAULT_OPENCODE_PORT = 4097
 OPENCODE_START_TIMEOUT_SECONDS = 20
@@ -108,6 +120,7 @@ class _OpenCodeServer:
         return data[-OPENCODE_SERVER_LOG_TAIL_BYTES:].decode("utf-8", errors="ignore").strip()
 
     async def terminate(self) -> None:
+        _managed_server_passwords.pop(self.base_url, None)
         if self.is_alive:
             self.process.terminate()
             try:
@@ -258,12 +271,19 @@ def _configured_server_url() -> str:
     return f"http://{host}:{port}"
 
 
-def _auth() -> aiohttp.BasicAuth | None:
+_managed_server_passwords: dict[str, str] = {}
+
+
+def _auth(base_url: str | None = None) -> aiohttp.BasicAuth | None:
+    if base_url in _managed_server_passwords:
+        return aiohttp.BasicAuth("opencode", _managed_server_passwords[base_url])
+    # Only explicitly configured external servers use operator credentials.
+    if base_url is not None and base_url.rstrip("/") != _configured_server_url():
+        return None
     password = os.environ.get("OPENCODE_SERVER_PASSWORD")
     if not password:
         return None
-    username = os.environ.get("OPENCODE_SERVER_USERNAME", "opencode")
-    return aiohttp.BasicAuth(username, password)
+    return aiohttp.BasicAuth(os.environ.get("OPENCODE_SERVER_USERNAME", "opencode"), password)
 
 
 async def _request_json(
@@ -278,7 +298,7 @@ async def _request_json(
     if base_url is None:
         base_url = await ensure_opencode_server()
     request_timeout = aiohttp.ClientTimeout(total=timeout or OPENCODE_REQUEST_TIMEOUT_SECONDS)
-    async with aiohttp.ClientSession(timeout=request_timeout, auth=_auth()) as session:
+    async with aiohttp.ClientSession(timeout=request_timeout, auth=_auth(base_url)) as session:
         async with session.request(
             method,
             f"{base_url}{path}",
@@ -298,11 +318,14 @@ async def _request_json(
                 raise OpenCodeError(f"OpenCode returned non-JSON for {method} {path}: {text[:500]}") from exc
 
 
-async def _health_check(base_url: str) -> bool:
+async def _health_check(base_url: str, directory: str | None = None) -> bool:
     try:
         timeout = aiohttp.ClientTimeout(total=3)
-        async with aiohttp.ClientSession(timeout=timeout, auth=_auth()) as session:
-            async with session.get(f"{base_url}/config/providers", params={"directory": str(PROJECT_ROOT)}) as resp:
+        async with aiohttp.ClientSession(timeout=timeout, auth=_auth(base_url)) as session:
+            async with session.get(
+                f"{base_url}/config/providers",
+                params={"directory": directory or _catalog_dir()},
+            ) as resp:
                 return resp.status == 200
     except Exception:
         return False
@@ -391,6 +414,9 @@ async def _ensure_server_instance(
     the operator.
     """
     if os.environ.get("OPENCODE_SERVER_URL"):
+        from broker import sandbox
+        if sandbox.enabled():
+            raise OpenCodeError("External OpenCode servers bypass per-run isolation and are disabled")
         base_url = _configured_server_url()
         if not await _health_check(base_url):
             raise OpenCodeError(f"Configured OPENCODE_SERVER_URL is not reachable: {base_url}")
@@ -440,22 +466,9 @@ async def _ensure_server_instance(
             config_hash[:12],
             log_path or "/dev/null",
         )
-        env = {
-            **os.environ,
-            "XDG_CONFIG_HOME": str(config_home),
-            "OPENCODE_DISABLE_EXTERNAL_SKILLS": "1",
-        }
-        process = await asyncio.create_subprocess_exec(
-            opencode_bin,
-            "serve",
-            "--port",
-            str(port),
-            "--hostname",
-            host,
-            cwd=str(PROJECT_ROOT),
-            env=env,
-            stdout=log_file if log_file is not None else asyncio.subprocess.DEVNULL,
-            stderr=asyncio.subprocess.STDOUT if log_file is not None else asyncio.subprocess.DEVNULL,
+        process = await _spawn_opencode_server_process(
+            opencode_bin, host=host, port=port, config_home=config_home,
+            workspace=_catalog_dir(), log_file=log_file,
         )
         server = _OpenCodeServer(
             config_hash=config_hash,
@@ -497,33 +510,252 @@ async def ensure_opencode_server(
     return server.base_url
 
 
+def _prepare_opencode_data_home(config_home: Path,
+                                workspace: str | Path | None = None) -> Path:
+    """Empty per-worker provider store. Real provider auth stays backend-only.
+
+    Only gateway-configured providers are available to isolated runs.
+    Subscription-only provider plugins need separate reviewed adapters.
+    """
+    data_home = config_home / "share"
+    target_dir = data_home / "opencode"
+    target_dir.mkdir(parents=True, exist_ok=True)
+    # Refuse stale shared catalog data rather than loading legacy auth.
+    if (target_dir / "auth.json").exists():
+        raise OpenCodeError("Legacy OpenCode credentials must be removed from the catalog cache")
+    worker_mod.grant_worker_access(data_home, workspace=workspace)
+    return data_home
+
+
+async def _spawn_opencode_server_process(
+    opencode_bin: str,
+    *,
+    host: str,
+    port: int,
+    config_home: Path,
+    workspace: str,
+    log_file,
+) -> asyncio.subprocess.Process:
+    """Spawn `opencode serve` as an isolated worker.
+
+    The backend environment is NOT inherited: the server receives only the
+    scrubbed worker env plus its isolated XDG config/data homes. Model
+    provider API keys stay on the backend and are reached through the
+    credential gateway (see _provider_gateway_overrides).
+    """
+    from broker import sandbox
+    if sandbox.enabled():
+        source = config_home / 'opencode' / 'opencode.json'
+        if not config_home.is_relative_to(Path(workspace)):
+            target = Path(workspace) / 'catalog-config' / 'opencode'
+            target.mkdir(parents=True, exist_ok=True)
+            (target / 'opencode.json').write_bytes(source.read_bytes())
+            config_home = target.parent
+    data_home = _prepare_opencode_data_home(config_home, workspace=workspace)
+    # The sandboxed (non-root) server must read its isolated config home.
+    worker_mod.grant_worker_access(config_home, workspace=workspace)
+    from broker.controller import run_worker_env_extra
+
+    from broker import sandbox
+    if sandbox.enabled() and host != '127.0.0.1':
+        raise OpenCodeError('Isolated OpenCode requires loopback transport')
+    base_url = f"http://{host}:{port}"
+    password = "loma_ocserver_" + secrets.token_urlsafe(32)
+    _managed_server_passwords[base_url] = password
+    env = worker_mod.build_worker_env(workspace, extra={
+        **({"LOMA_SANDBOX_INGRESS_PORT": str(port)} if sandbox.enabled() else {}),
+        "OPENCODE_SERVER_USERNAME": "opencode",
+        "OPENCODE_SERVER_PASSWORD": password,
+        "XDG_CONFIG_HOME": str(config_home),
+        "XDG_DATA_HOME": str(data_home),
+        "OPENCODE_DISABLE_EXTERNAL_SKILLS": "1",
+        **run_worker_env_extra(),
+    })
+    try:
+        return await worker_mod.spawn_worker(
+            [opencode_bin, "serve", "--port", str(port), "--hostname", host],
+            workspace=workspace,
+            env=env,
+            stdout=log_file if log_file is not None else asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.STDOUT if log_file is not None else asyncio.subprocess.DEVNULL,
+        )
+    except BaseException:
+        _managed_server_passwords.pop(base_url, None)
+        raise
+
+
+def _provider_gateway_overrides(run_capability: str | None) -> dict:
+    """Route env-key model providers through the credential gateway.
+
+    Providers whose API keys live in the backend env are configured with a
+    gateway baseURL and the run capability as the apiKey; the gateway admits
+    the call via the broker and injects the real key server-side. Providers
+    without a configured gateway credential are unavailable, never loaded from a worker auth file.
+    """
+    if not run_capability:
+        return {}
+    from broker.gateway import configured_model_providers, gateway_base_url
+
+    base = gateway_base_url()
+    paths = {
+        "anthropic": "/model/anthropic/v1",
+        "openai": "/model/openai/v1",
+        "openrouter": "/model/openrouter/v1",
+        "opencode": "/model/opencode",
+    }
+    overrides: dict = {}
+    for provider in configured_model_providers():
+        path = paths.get(provider)
+        if path:
+            overrides[provider] = {
+                "options": {"baseURL": base + path, "apiKey": run_capability},
+            }
+    return overrides
+
+
+async def _start_dedicated_server(
+    user_mcp_overrides: dict | None,
+    run_ctx,
+) -> _OpenCodeServer:
+    """Start a per-run, sandboxed OpenCode server (isolated worker).
+
+    Every agent run gets its own server process with a fresh workspace and
+    a per-run config: MCP servers are rewritten through the credential
+    gateway with revocable proxy tokens, model providers go through the
+    gateway with the run capability, and stdio MCP servers are disabled
+    (fail closed).
+    """
+    opencode_bin = shutil.which("opencode")
+    if not opencode_bin:
+        raise OpenCodeError("opencode binary not found on PATH")
+
+    workspace = getattr(run_ctx, "workspace", None)
+    if workspace is None:
+        workspace = worker_mod.create_workspace(prefix="opencode")
+    workspace = str(workspace)
+
+    app_config = await _load_current_agent_config()
+    mcp_servers = dict(app_config.get("mcp_servers", {}))
+    if user_mcp_overrides:
+        mcp_servers.update(user_mcp_overrides)
+
+    if run_ctx and run_ctx.user_email:
+        from agent.client import get_excluded_integrations_for_user
+        excluded = await get_excluded_integrations_for_user(run_ctx.user_email)
+        mcp_servers = {name: cfg for name, cfg in mcp_servers.items() if name not in excluded}
+    else:
+        mcp_servers = {}
+
+    proxy_tokens: list[str] = []
+    try:
+        from broker.controller import proxy_mcp_servers_for_worker
+
+        proxied, proxy_tokens, disabled = proxy_mcp_servers_for_worker(mcp_servers)
+    except Exception:
+        proxied, disabled = {}, sorted(mcp_servers)
+        logger.error(
+            "Execution gateway unavailable — all MCP servers disabled for "
+            "this OpenCode run (fail closed): %s", disabled,
+        )
+    global _opencode_mcp_names
+    _opencode_mcp_names = set(proxied.keys())
+
+    opencode_config = {
+        "$schema": "https://opencode.ai/config.json",
+        "mcp": claude_mcp_to_opencode(proxied),
+        "permission": _opencode_permission_config(),
+    }
+    provider_overrides = _provider_gateway_overrides(getattr(run_ctx, "capability", None))
+    from agent.subscription_providers import worker_providers
+    provider_overrides.update(worker_providers(run_ctx))
+    if provider_overrides:
+        opencode_config["provider"] = provider_overrides
+
+    config_home = Path(workspace) / "opencode-config"
+    config_dir = config_home / "opencode"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config_path = config_dir / "opencode.json"
+    config_path.write_text(json.dumps(opencode_config, indent=2, sort_keys=True))
+    config_path.chmod(0o600)
+
+    host = os.environ.get("OPENCODE_HOST", DEFAULT_OPENCODE_HOST)
+    port = _find_free_port(host)
+    log_path, log_file = _open_server_log(port)
+    logger.info(
+        "Starting dedicated OpenCode server on %s:%d (workspace=%s log=%s)",
+        host, port, workspace, log_path or "/dev/null",
+    )
+    process = await _spawn_opencode_server_process(
+        opencode_bin, host=host, port=port, config_home=config_home,
+        workspace=workspace, log_file=log_file,
+    )
+    server = _OpenCodeServer(
+        config_hash=f"dedicated-{port}",
+        config_home=config_home,
+        host=host,
+        port=port,
+        process=process,
+        log_path=log_path,
+        log_file=log_file,
+    )
+    server.workspace = workspace  # type: ignore[attr-defined]
+    server.proxy_tokens = proxy_tokens  # type: ignore[attr-defined]
+
+    deadline = asyncio.get_running_loop().time() + OPENCODE_START_TIMEOUT_SECONDS
+    while asyncio.get_running_loop().time() < deadline:
+        if await _health_check(server.base_url):
+            server.touch()
+            return server
+        if not server.is_alive:
+            tail = server.log_tail()
+            await _teardown_dedicated_server(server)
+            raise OpenCodeError(
+                f"OpenCode server exited with code {server.process.returncode}"
+                + (f"; last output:\n{tail}" if tail else "")
+            )
+        await asyncio.sleep(0.5)
+
+    tail = server.log_tail()
+    await _teardown_dedicated_server(server)
+    raise OpenCodeError(
+        f"OpenCode server did not become ready at {server.base_url}"
+        + (f"; last output:\n{tail}" if tail else "")
+    )
+
+
+async def _teardown_dedicated_server(server: _OpenCodeServer) -> None:
+    """Terminate a per-run server and revoke its gateway proxy tokens."""
+    try:
+        await server.terminate()
+    finally:
+        for token in getattr(server, "proxy_tokens", None) or []:
+            try:
+                from broker.controller import get_proxy_registry
+                get_proxy_registry().revoke(token)
+            except Exception:
+                pass
+
+
 async def _write_managed_opencode_config(
     user_mcp_overrides: dict | None = None,
 ) -> tuple[Path, str]:
-    """Write isolated OpenCode config from this app's MCP source of truth.
+    """Write the config for the shared CATALOG server.
 
-    Config homes are stable per config hash so each managed server keeps its
-    own isolated XDG config dir.
+    Agent runs no longer execute on shared servers — each run gets its own
+    sandboxed dedicated server (see _start_dedicated_server). The shared
+    server only answers /config/providers, so its config intentionally
+    carries NO MCP servers and therefore no integration credentials.
     """
-    global _opencode_mcp_names
+    del user_mcp_overrides  # catalog server never runs agent turns
 
-    overrides_key = json.dumps(sorted((user_mcp_overrides or {}).keys()))
     now = time.monotonic()
-    cached = _opencode_config_cache.get(overrides_key)
+    cached = _opencode_config_cache.get("catalog")
     if cached is not None and now - cached[2] < OPENCODE_CONFIG_TTL_SECONDS:
         return cached[0], cached[1]
 
-    app_config = await _load_current_agent_config()
-    # Merge per-user MCP overrides into the app config
-    if user_mcp_overrides:
-        mcp_servers = dict(app_config.get("mcp_servers", {}))
-        mcp_servers.update(user_mcp_overrides)
-        app_config["mcp_servers"] = mcp_servers
-    mcp_config = claude_mcp_to_opencode(app_config.get("mcp_servers", {}))
-    _opencode_mcp_names = set(mcp_config.keys())
     opencode_config = {
         "$schema": "https://opencode.ai/config.json",
-        "mcp": mcp_config,
+        "mcp": {},
         "permission": _opencode_permission_config(),
     }
     config_text = json.dumps(opencode_config, indent=2, sort_keys=True)
@@ -535,7 +767,7 @@ async def _write_managed_opencode_config(
     config_path = config_dir / "opencode.json"
     config_path.write_text(config_text)
     config_path.chmod(0o600)
-    _opencode_config_cache[overrides_key] = (config_home, config_hash, now)
+    _opencode_config_cache["catalog"] = (config_home, config_hash, now)
     return config_home, config_hash
 
 
@@ -675,7 +907,7 @@ async def get_agent_models() -> dict:
     payload = await _request_json(
         "GET",
         "/config/providers",
-        params={"directory": str(PROJECT_ROOT)},
+        params={"directory": _catalog_dir()},
         timeout=30,
         base_url=server.base_url,
     )
@@ -758,25 +990,11 @@ def _schedule_configured_prewarm(server: _OpenCodeServer, catalog: dict) -> None
 
 
 def _schedule_prewarm(server: _OpenCodeServer, model_id: str) -> None:
-    if not _should_prewarm_model(model_id):
-        return
-    try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        return
-
-    key = (server.config_hash, model_id)
-    sessions = _opencode_warm_sessions.get(key, [])
-    running_task = _opencode_prewarm_tasks.get(key)
-    if len(sessions) >= OPENCODE_PREWARM_POOL_SIZE:
-        return
-    if running_task is not None and not running_task.done():
-        return
-
-    needed = OPENCODE_PREWARM_POOL_SIZE - len(sessions)
-    _opencode_prewarm_tasks[key] = loop.create_task(
-        _prewarm_model_sessions(server, model_id, needed)
-    )
+    # Isolated worker mode: agent runs execute on dedicated per-run servers,
+    # so shared warm sessions can never be handed to a run. Prewarming is
+    # disabled; the pool-status endpoint reports available=0 accordingly.
+    del server, model_id
+    return
 
 
 async def _checkout_warm_session(server: _OpenCodeServer, model_id: str) -> str | None:
@@ -809,7 +1027,9 @@ async def _checkout_warm_session(server: _OpenCodeServer, model_id: str) -> str 
     return None
 
 
-async def _create_session(title: str, *, base_url: str | None = None) -> str:
+async def _create_session(
+    title: str, *, base_url: str | None = None, directory: str | None = None,
+) -> str:
     session = await _request_json(
         "POST",
         "/session",
@@ -817,7 +1037,7 @@ async def _create_session(title: str, *, base_url: str | None = None) -> str:
             "title": title[:120],
             "permission": _opencode_session_permission_rules(),
         },
-        params={"directory": str(PROJECT_ROOT)},
+        params={"directory": directory or _catalog_dir()},
         timeout=30,
         base_url=base_url,
     )
@@ -833,7 +1053,7 @@ async def _delete_session_messages(session_id: str, *, base_url: str | None = No
             messages = await _request_json(
                 "GET",
                 f"/session/{session_id}/message",
-                params={"directory": str(PROJECT_ROOT), "limit": 20},
+                params={"directory": _catalog_dir(), "limit": 20},
                 timeout=30,
                 base_url=base_url,
             )
@@ -847,7 +1067,7 @@ async def _delete_session_messages(session_id: str, *, base_url: str | None = No
                 await _request_json(
                     "DELETE",
                     f"/session/{session_id}/message/{message_id}",
-                    params={"directory": str(PROJECT_ROOT)},
+                    params={"directory": _catalog_dir()},
                     timeout=30,
                     base_url=base_url,
                 )
@@ -873,7 +1093,7 @@ async def _warm_opencode_session(server: _OpenCodeServer, model_id: str) -> str:
         "POST",
         f"/session/{session_id}/message",
         json_body=body,
-        params={"directory": str(PROJECT_ROOT)},
+        params={"directory": _catalog_dir()},
         timeout=OPENCODE_REQUEST_TIMEOUT_SECONDS,
         base_url=server.base_url,
     )
@@ -1000,14 +1220,16 @@ async def _iter_opencode_turn_events(
     body: dict,
     idle_timeout_seconds: int,
     request_timeout_seconds: int,
+    directory: str | None = None,
 ) -> AsyncGenerator[dict, None]:
     timeout = _turn_client_timeout(request_timeout_seconds)
+    directory = directory or _catalog_dir()
     prompt_task: asyncio.Task | None = None
-    async with aiohttp.ClientSession(timeout=timeout, auth=_auth()) as session:
+    async with aiohttp.ClientSession(timeout=timeout, auth=_auth(base_url)) as session:
         try:
             async with session.get(
                 f"{base_url}/event",
-                params={"directory": str(PROJECT_ROOT)},
+                params={"directory": directory},
                 headers={"Accept": "text/event-stream"},
             ) as resp:
                 if resp.status >= 400:
@@ -1015,7 +1237,10 @@ async def _iter_opencode_turn_events(
                     raise OpenCodeError(f"OpenCode event stream failed ({resp.status}): {text[:500]}")
 
                 prompt_task = asyncio.create_task(
-                    _post_prompt_async(session, base_url, session_id=session_id, body=body)
+                    _post_prompt_async(
+                        session, base_url, session_id=session_id, body=body,
+                        directory=directory,
+                    )
                 )
 
                 buffer = b""
@@ -1145,11 +1370,12 @@ async def _post_prompt_async(
     *,
     session_id: str,
     body: dict,
+    directory: str | None = None,
 ) -> dict:
     async with session.post(
         f"{base_url}/session/{session_id}/prompt_async",
         json=body,
-        params={"directory": str(PROJECT_ROOT)},
+        params={"directory": directory or _catalog_dir()},
     ) as resp:
         text = await resp.text()
         if resp.status >= 400:
@@ -1221,7 +1447,11 @@ async def _emit_text(
                 emitted_file_paths.add(fpath)
                 try:
                     from api.routes import register_served_file
-                    file_info = register_served_file(fpath)
+                    file_info = register_served_file(
+                        fpath,
+                        conversation_id=getattr(observer, "conversation_id", None),
+                        owner_email=(getattr(observer, "metadata", None) or {}).get("user_name"),
+                    )
                     yield {
                         "type": "file",
                         "file_id": file_info["file_id"],
@@ -1248,8 +1478,16 @@ async def run_opencode_agent(
     user_email: str | None = None,
     user_mcp_overrides: dict | None = None,
     image_files: list[dict] | None = None,
+    run_ctx=None,
 ) -> AsyncGenerator[str | dict, None]:
-    """Run one dashboard chat turn through OpenCode and yield dashboard events."""
+    """Run one turn through a DEDICATED, sandboxed per-run OpenCode server.
+
+    Each run gets its own `opencode serve` worker process with a private
+    workspace, a scrubbed environment, gateway-proxied MCP servers, and
+    gateway-brokered model providers. The server is terminated and its proxy
+    tokens revoked when the turn ends. Conversation continuity comes from
+    the textual conversation context in the prompt.
+    """
     started_at = time.perf_counter()
     if not await is_known_model(selected_model):
         raise OpenCodeError(f"Unknown or unavailable OpenCode model: {selected_model}")
@@ -1271,30 +1509,20 @@ async def run_opencode_agent(
     if request_timeout_seconds > 0:
         request_timeout_seconds = max(request_timeout_seconds, idle_timeout_seconds + 30)
 
-    server = await _ensure_server_instance(user_mcp_overrides=user_mcp_overrides)
+    # Dedicated sandboxed server per run — never a shared server, never a
+    # shared session. The private workspace comes from the run context.
+    server = await _start_dedicated_server(user_mcp_overrides, run_ctx)
     base_url = server.base_url
+    run_directory = getattr(server, "workspace", None) or _catalog_dir()
 
     conversation_id = getattr(observer, "conversation_id", None)
-    session_cache_key = (
-        (server.config_hash, conversation_id, selected_model) if conversation_id else None
-    )
-    session_id = _opencode_session_cache.get(session_cache_key) if session_cache_key else None
     warm_session_used = False
-    reused_session = bool(session_id)
-    if not session_id:
-        session_id = await _checkout_warm_session(server, selected_model)
-        if session_id is None:
-            session_id = await _create_session(
-                full_prompt[:80] or "Dashboard chat", base_url=base_url
-            )
-            _schedule_prewarm(server, selected_model)
-        else:
-            warm_session_used = True
-            _schedule_prewarm(server, selected_model)
-        if session_cache_key:
-            _opencode_session_cache[session_cache_key] = session_id
-    else:
-        logger.info("Reusing OpenCode session %s for conversation=%s model=%s", session_id, conversation_id, selected_model)
+    reused_session = False
+    session_id = await _create_session(
+        full_prompt[:80] or "Dashboard chat",
+        base_url=base_url,
+        directory=run_directory,
+    )
     session_created_at = time.perf_counter()
 
     pool_status = get_opencode_pool_status()
@@ -1511,6 +1739,7 @@ async def run_opencode_agent(
                     body=body,
                     idle_timeout_seconds=idle_timeout_seconds,
                     request_timeout_seconds=request_timeout_seconds,
+                    directory=run_directory,
                 ):
                     if first_event_at is None:
                         first_event_at = time.perf_counter()
@@ -1542,7 +1771,7 @@ async def run_opencode_agent(
                                 "POST",
                                 f"/session/{session_id}/permissions/{permission_id}",
                                 json_body={"response": "always"},
-                                params={"directory": str(PROJECT_ROOT)},
+                                params={"directory": run_directory},
                                 timeout=30,
                                 base_url=base_url,
                             )
@@ -1632,18 +1861,20 @@ async def run_opencode_agent(
                 stream_completed = False
                 first_event_at = None
                 server.active_turns = max(0, server.active_turns - 1)
-                server = await _ensure_server_instance(user_mcp_overrides=user_mcp_overrides)
+                await _teardown_dedicated_server(server)
+                server = await _start_dedicated_server(user_mcp_overrides, run_ctx)
                 server.active_turns += 1
                 base_url = server.base_url
+                run_directory = getattr(server, "workspace", None) or _catalog_dir()
                 session_id = await _create_session(
-                    full_prompt[:80] or "Dashboard chat", base_url=base_url
+                    full_prompt[:80] or "Dashboard chat",
+                    base_url=base_url,
+                    directory=run_directory,
                 )
-                if conversation_id:
-                    session_cache_key = (server.config_hash, conversation_id, selected_model)
-                    _opencode_session_cache[session_cache_key] = session_id
     finally:
         server.active_turns = max(0, server.active_turns - 1)
-        server.touch()
+        # Per-run server: terminate the worker and revoke its proxy tokens.
+        await _teardown_dedicated_server(server)
 
     if observer:
         usage_payload = total_usage if total_usage["input_tokens"] or total_usage["output_tokens"] else None

--- a/agent/pool.py
+++ b/agent/pool.py
@@ -21,6 +21,7 @@ import asyncio
 import json
 import logging
 import os
+import shutil as _shutil
 import signal
 import subprocess
 import time
@@ -29,8 +30,54 @@ from pathlib import Path
 from claude_agent_sdk import ClaudeSDKClient, ClaudeAgentOptions
 
 from agent.prompt import build_pooled_system_prompt
+from broker import worker as worker_mod
 
 logger = logging.getLogger(__name__)
+
+# Env vars the Claude Agent SDK itself sets on the CLI subprocess; the
+# launcher forwards ONLY these through the env scrub (never secret names).
+_SDK_PASSTHROUGH_VARS = (
+    "CLAUDE_CONFIG_DIR",
+    "CLAUDE_CODE_ENTRYPOINT",
+    "CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING",
+)
+
+# Additional passthrough in subscription-proxy mode: the gateway base URL
+# and the revocable proxy token (worker-scoped, never the real credential).
+_SUBSCRIPTION_PASSTHROUGH_VARS = (
+    "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_AUTH_TOKEN",
+)
+
+def _prepare_worker_claude_config(account: dict, workspace) -> str:
+    """Create fresh runtime state; never copy account sessions or settings."""
+    from pathlib import Path
+    dest = Path(workspace) / "claude-config"
+    dest.mkdir(mode=0o700)
+    worker_mod.grant_worker_access(dest, workspace=workspace)
+    return str(dest)
+
+
+def _prepare_worker_subscription_env(account: dict, workspace) -> tuple[dict[str, str], list[str]]:
+    """Require a live authenticated run. There is no credential-file fallback."""
+    from broker.gateway import gateway_base_url
+    from broker.controller import current_run, get_subscription_registry, ExecutionUnavailable
+    ctx = current_run.get()
+    capability = getattr(ctx, "capability", None)
+    if workspace is None or not capability:
+        raise ExecutionUnavailable("Subscription execution requires an authenticated run")
+    registry = get_subscription_registry()
+    from broker.credential_files import protect_account_directory
+    protect_account_directory(account["config_dir"])
+    config_copy = _prepare_worker_claude_config(account, workspace)
+    token = registry.register("claude", os.path.join(account["config_dir"], ".credentials.json"),
+                              capability=capability)
+    ctx.sub_proxy_tokens.append(token)
+    return {
+        "CLAUDE_CONFIG_DIR": config_copy,
+        "ANTHROPIC_BASE_URL": f"{gateway_base_url()}/sub/{token}",
+        "ANTHROPIC_AUTH_TOKEN": token,
+    }, [token]
 
 # Module-level pool singleton
 _pool: "ClientPool | None" = None
@@ -119,22 +166,36 @@ async def shutdown_pool():
         _pool = None
 
 
-def background_cli_env() -> dict[str, str]:
-    """Env for background `claude -p` utility calls (titles, topics, organize).
+async def run_background_cli(argv: list[str], timeout: float) -> tuple[int, bytes, bytes]:
+    """Run a background utility with the current run's brokered subscription.
 
-    The server process has no Claude credentials of its own — bare `claude`
-    subprocesses exit 1. Borrow an authenticated pool account's
-    CLAUDE_CONFIG_DIR (round-robin, cooldown-aware) so the CLI can run.
-    Falls back to the plain server env if the pool is empty or uninitialized.
+    No authenticated run means no credential access. Existing callers use their
+    deterministic fallback rather than borrowing ambient pooled credentials.
     """
-    env = dict(os.environ)
+    from broker.controller import current_run, get_subscription_registry
+    from broker.operations import _collect_tool_output
+    ctx = current_run.get()
+    if not getattr(ctx, 'capability', None):
+        return 1, b'', b'Authenticated run required for background inference'
+    workspace = worker_mod.create_workspace(prefix="bgcli")
+    tokens = []
+    process = None
     try:
         account = get_pool()._next_account()
-        if account:
-            env["CLAUDE_CONFIG_DIR"] = account["config_dir"]
-    except RuntimeError:
-        pass
-    return env
+        if not account:
+            return 1, b'', b'No subscription account available'
+        extra, tokens = _prepare_worker_subscription_env(account, workspace)
+        env = worker_mod.build_worker_env(workspace, extra=extra)
+        process = await worker_mod.spawn_worker(argv, workspace=workspace, env=env)
+        stdout, stderr = await asyncio.wait_for(_collect_tool_output(process), timeout=timeout)
+        return process.returncode, stdout, stderr
+    finally:
+        if process is not None and process.returncode is None:
+            worker_mod.terminate_worker(process)
+            await process.wait()
+        for token in tokens:
+            get_subscription_registry().revoke(token)
+        worker_mod.cleanup_workspace(workspace)
 
 
 class ClientPool:
@@ -337,71 +398,85 @@ class ClientPool:
     # ── Pool warmup ───────────────────────────────────────────────────
 
     async def warmup(self):
-        """Pre-warm the pool with clients (run as background task)."""
-        disabled = await self._get_disabled_emails()
-        self._scan_accounts(disabled_emails=disabled)
-        if not self._accounts:
-            logger.info("No accounts connected — pool will be empty until users log in")
-            return
-
-        target = min(self._pool_size, len(self._accounts) * 3)  # cap at 3 per account
-        logger.info("Starting pool warmup (%d clients across %d accounts)...",
-                     target, len(self._accounts))
-        tasks = []
-        for _ in range(target):
-            account = self._next_account()
-            if account is None:
-                break
-            tasks.append(self._create_client(account))
-
-        results = await asyncio.gather(*tasks, return_exceptions=True)
-
-        success = 0
-        for result in results:
-            if isinstance(result, Exception):
-                logger.error("Failed to warm client: %s", result)
-            else:
-                await self._available.put(result)
-                success += 1
-
-        logger.info(
-            "Pool warmup complete: %d/%d clients ready", success, len(tasks)
-        )
-
-        # Retry any failures
-        failures = len(tasks) - success
-        if failures > 0:
-            logger.info("Retrying %d failed warmups...", failures)
-            for _ in range(failures):
-                asyncio.create_task(self._warm_one())
+        """No anonymous workers: clients are created within authenticated runs."""
+        return
 
     @staticmethod
     def default_model() -> str:
         return os.environ.get("CLAUDE_MODEL", "claude-opus-4-8")
 
-    def _build_options(self, model_override: str | None = None) -> ClaudeAgentOptions:
-        """Build ClaudeAgentOptions from the stored config."""
+    def _build_options(
+        self,
+        model_override: str | None = None,
+        user_mcp_overrides: dict | None = None,
+        excluded_servers: set[str] | None = None,
+    ) -> ClaudeAgentOptions:
+        """Build ClaudeAgentOptions for an ISOLATED per-run worker.
+
+        The Claude CLI subprocess (one conversation per client — clients are
+        never reused) runs inside a fresh private workspace with a scrubbed
+        environment. MCP servers are rewritten to go through the credential
+        gateway; servers the gateway cannot mediate (stdio servers whose env
+        would carry credentials into the worker) are disabled — fail closed.
+        """
         system_prompt = build_pooled_system_prompt()
         model = model_override or self.default_model()
         max_turns = int(os.environ.get("AGENT_MAX_TURNS", "500"))
-        mcp_servers = self._config.get("mcp_servers", {})
+        mcp_servers = dict(self._config.get("mcp_servers", {}))
+        if user_mcp_overrides:
+            mcp_servers.update(user_mcp_overrides)
+        for server_name in excluded_servers or ():
+            mcp_servers.pop(server_name, None)
+
+        # Isolation boundary: private workspace + broker-backed tool shims.
+        from broker.controller import (
+            ExecutionUnavailable,
+            proxy_mcp_servers_for_worker,
+            run_worker_env_extra,
+        )
+        from broker.operations import ALL_TOOLS
+
+        workspace = worker_mod.create_workspace(prefix="claude")
+        worker_mod.populate_tool_shims(workspace, sorted(ALL_TOOLS))
+        try:
+            proxied_servers, proxy_tokens, disabled = proxy_mcp_servers_for_worker(mcp_servers)
+        except ExecutionUnavailable:
+            # No gateway -> no MCP credentials can be mediated: disable all.
+            proxied_servers, proxy_tokens, disabled = {}, [], sorted(mcp_servers)
+            logger.error(
+                "Execution gateway unavailable — all MCP servers disabled for "
+                "this worker (fail closed): %s", disabled,
+            )
+        worker_env = worker_mod.build_worker_env(workspace, extra=run_worker_env_extra())
+        real_cli = _shutil.which("claude") or "claude"
+        launcher = worker_mod.write_cli_launcher(
+            workspace, real_cli, worker_env,
+            passthrough=_SDK_PASSTHROUGH_VARS + _SUBSCRIPTION_PASSTHROUGH_VARS,
+        )
 
         allowed_tools = ["Bash", "Read", "Skill", "WebSearch", "Agent"]
-        for server_name in mcp_servers:
+        for server_name in proxied_servers:
             allowed_tools.append(f"mcp__{server_name}")
 
-        return ClaudeAgentOptions(
+        options = ClaudeAgentOptions(
             system_prompt=system_prompt,
             model=model,
             max_turns=max_turns,
-            mcp_servers=mcp_servers,
+            mcp_servers=proxied_servers,
             allowed_tools=allowed_tools,
             permission_mode="acceptEdits",
             setting_sources=["project"],
-            cwd=str(Path(__file__).parent.parent),
+            cwd=str(workspace),
+            cli_path=str(launcher),
+            env={},
             max_buffer_size=10 * 1024 * 1024,
             include_partial_messages=True,
         )
+        # Worker bookkeeping consumed by _create_client/safe_disconnect.
+        options._worker_workspace = workspace  # type: ignore[attr-defined]
+        options._mcp_proxy_tokens = proxy_tokens  # type: ignore[attr-defined]
+        options._disabled_mcp_servers = disabled  # type: ignore[attr-defined]
+        return options
 
     async def _create_client(self, account: dict, model_override: str | None = None) -> ClaudeSDKClient:
         """Create and connect a new ClaudeSDKClient for a specific account."""
@@ -409,12 +484,19 @@ class ClientPool:
         client = None
         try:
             options = self._build_options(model_override=model_override)
-            options.env = {"CLAUDE_CONFIG_DIR": account["config_dir"]}
+            options.env, sub_tokens = _prepare_worker_subscription_env(
+                account, options._worker_workspace)
             client = ClaudeSDKClient(options=options)
+            client._worker_workspace = options._worker_workspace
+            client._mcp_proxy_tokens = options._mcp_proxy_tokens
+            client._sub_proxy_tokens = sub_tokens
             await asyncio.wait_for(client.connect(), timeout=_env_int("AGENT_CONNECT_TIMEOUT"))
             # Attach account info for diagnostics and rate-limit tracking
             client._pool_account = account  # type: ignore[attr-defined]
             client._pool_model = options.model  # type: ignore[attr-defined]
+            client._worker_workspace = getattr(options, "_worker_workspace", None)  # type: ignore[attr-defined]
+            client._mcp_proxy_tokens = getattr(options, "_mcp_proxy_tokens", [])  # type: ignore[attr-defined]
+            client._disabled_mcp_servers = getattr(options, "_disabled_mcp_servers", [])  # type: ignore[attr-defined]
             if model_override:
                 client._pool_ephemeral = True  # type: ignore[attr-defined]
             logger.info("New client connected (account=%s, model=%s)", account["email"], options.model)
@@ -451,7 +533,10 @@ class ClientPool:
             raise RuntimeError("No Claude accounts connected. Ask a team member to log in via Integrations.")
 
         requested_model = model or self.default_model()
-        if requested_model != self.default_model():
+        from broker.controller import current_run
+        # A warm client was constructed without the caller's run capability.
+        # Never reuse its MCP configuration for an authenticated run.
+        if current_run.get() is not None or requested_model != self.default_model():
             account = self._next_account()
             if account is None:
                 raise RuntimeError("No Claude accounts are currently available for the selected model.")
@@ -595,51 +680,23 @@ class ClientPool:
         else:
             logger.warning("Could not find subprocess PID on client — orphan processes may leak")
 
-    async def _warm_one(self):
-        """Warm a single replacement client in the background with retries."""
-        if self._closed:
-            return
-        # Double-check we still need one (another warm task may have finished first)
-        if (self._available.qsize() + self._warming) >= self._pool_size:
-            return
-        account = self._next_account()
-        if account is None:
-            logger.warning("Cannot warm replacement — no accounts available (all on cooldown or none connected)")
-            return
-        for attempt in range(1, WARM_RETRIES + 1):
-            if self._closed:
-                return
+        # Revoke this worker's gateway proxy tokens and remove its workspace.
+        for token in getattr(client, "_sub_proxy_tokens", None) or []:
+            from broker.controller import get_subscription_registry
+            get_subscription_registry().revoke(token)
+        for proxy_token in getattr(client, "_mcp_proxy_tokens", None) or []:
             try:
-                client = await self._create_client(account)
-                if not self._closed:
-                    await self._available.put(client)
-                    logger.info(
-                        "Replacement client warmed (account=%s, available=%d, in_use=%d)",
-                        account["email"], self._available.qsize(), self._in_use,
-                    )
-                else:
-                    await self.safe_disconnect(client)
-                return  # success
-            except Exception as e:
-                logger.error(
-                    "Warm attempt %d/%d failed for account %s: %s",
-                    attempt, WARM_RETRIES, account["email"], e,
-                )
-                if attempt < WARM_RETRIES:
-                    await asyncio.sleep(WARM_RETRY_DELAY * attempt)
+                from broker.controller import get_proxy_registry
+                get_proxy_registry().revoke(proxy_token)
+            except Exception:
+                pass
+        workspace = getattr(client, "_worker_workspace", None)
+        if workspace:
+            worker_mod.cleanup_workspace(workspace)
 
-        logger.error("All %d warm attempts failed for account %s — pool may be depleted",
-                      WARM_RETRIES, account["email"])
-
-        # Schedule another warm cycle if pool is still needed
-        if not self._closed and (self._available.qsize() + self._warming + self._in_use) < self._pool_size:
-            logger.info(
-                "Scheduling recovery warm in %ds (available=%d, warming=%d, in_use=%d, queue_depth=%d)",
-                WARM_RECOVERY_DELAY, self._available.qsize(), self._warming, self._in_use, self._queue_depth,
-            )
-            await asyncio.sleep(WARM_RECOVERY_DELAY)
-            if not self._closed:
-                asyncio.create_task(self._warm_one())
+    async def _warm_one(self):
+        """No anonymous workers: clients are created within authenticated runs."""
+        return
 
     # ── Status & lifecycle ────────────────────────────────────────────
 

--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -82,7 +82,7 @@ _TOOLS_AND_SKILLS_SECTION = """
 
 This Loma deployment may provide optional MCP servers and CLI tools. Use connected tools when they are relevant, and clearly explain when a requested tool or integration is not connected.
 
-SECURITY: Never use mcp__claude_ai_* tools (Gmail, Google Drive, Calendar, Slack, etc.). These are connected to shared service accounts and do NOT belong to the current user. Always use the personal CLI tools (tools/gmail.py, tools/google_drive.py, tools/google_calendar.py, tools/slack_user.py, etc.) which verify user identity via --auth-token.
+SECURITY: Never use mcp__claude_ai_* tools (Gmail, Google Drive, Calendar, Slack, etc.). These are connected to shared service accounts and do NOT belong to the current user. Always use the personal CLI tools (tools/gmail.py, tools/google_drive.py, tools/google_calendar.py, tools/slack_user.py, etc.), which authenticate as the current user automatically — never pass --user-email or --auth-token flags.
 
 Guidelines:
 - Prefer read-only actions unless the user explicitly asks you to make a change.
@@ -114,7 +114,7 @@ Loma skills are DB-backed company playbooks and references stored in MongoDB. Us
 
 Do not use the built-in `Skill` tool for Loma DB-backed skills. Search or read the relevant Loma skill before starting work when the user asks for a domain-specific workflow, playbook, runbook, review, implementation, support investigation, or company procedure. When the user asks to print, inspect, or load an entire skill, use `dump --slug` instead of repeatedly calling `file`.
 
-Only update skills when the user explicitly asks you to change company playbooks or skills. For write commands, use the authenticated user's `--user-email` and `--auth-token` values when they are provided in the current message.
+Only update skills when the user explicitly asks you to change company playbooks or skills. Write commands run with the authenticated user's identity automatically; do not pass `--user-email` or `--auth-token` flags.
 
 Available skill index:
 {_loma_skill_index_cache}

--- a/agent/subscription_providers.py
+++ b/agent/subscription_providers.py
@@ -1,0 +1,84 @@
+"""Personal OpenCode providers using the existing backend subscription gateways.
+
+Use standard bundled AI SDK adapters instead of auth plugins that need readable
+OAuth files. Only the authenticated run owner's native CLI account is eligible;
+there is no pool-account or organization fallback for these providers.
+"""
+import os
+from pathlib import Path
+import re
+
+
+PROVIDERS = {
+    'claude': {'id': 'loma-claude', 'name': 'Personal Claude via OpenCode',
+               'directory_env': 'CLAUDE_USERS_DIR', 'default_directory': '/opt/claude-users',
+               'filename': '.credentials.json', 'npm': '@ai-sdk/anthropic', 'suffix': '/v1'},
+    'codex': {'id': 'loma-codex', 'name': 'Personal Codex via OpenCode',
+              'directory_env': 'CODEX_USERS_DIR', 'default_directory': '/opt/codex-users',
+              'filename': 'auth.json', 'npm': '@ai-sdk/openai', 'suffix': ''},
+}
+
+
+def personal_accounts(email):
+    if not isinstance(email, str) or not re.fullmatch(r'[A-Za-z0-9._+%-]+@[A-Za-z0-9.-]+', email):
+        return {}
+    result = {}
+    for provider, info in PROVIDERS.items():
+        directory = Path(os.environ.get(info['directory_env'], info['default_directory'])) / email
+        credential = directory / info['filename']
+        # No token is loaded to generate the model picker. A symlink cannot
+        # alias a different user's connected account.
+        try:
+            if directory.is_symlink() or credential.is_symlink() or not credential.is_file():
+                continue
+        except OSError:
+            continue
+        result[provider] = (directory, credential)
+    return result
+
+
+def model_ids(provider):
+    if provider == 'claude':
+        values = [os.environ.get('CLAUDE_MODEL', 'claude-opus-4-8')]
+    else:
+        from agent.codex_runtime import supported_codex_model_ids
+        values = supported_codex_model_ids()
+    return [value for value in dict.fromkeys(values)
+            if isinstance(value, str) and re.fullmatch(r'[A-Za-z0-9._:-]{1,128}', value)]
+
+
+def model_catalog(email):
+    models = []
+    for provider in personal_accounts(email):
+        info = PROVIDERS[provider]
+        for model in model_ids(provider):
+            models.append({'id': f'{info["id"]}/{model}', 'provider_id': info['id'],
+                           'model_id': model, 'label': f'{info["name"]} · {model}',
+                           'context_limit': None, 'supports_attachments': False,
+                           'supports_reasoning': False, 'status': 'active', 'cost': {}})
+    return models
+
+
+def worker_providers(ctx):
+    if not ctx or not getattr(ctx, 'capability', None) or not getattr(ctx, 'user_email', None):
+        return {}
+    from broker.controller import get_subscription_registry
+    from broker.credential_files import protect_account_directory
+    from broker.gateway import gateway_base_url
+    accounts = personal_accounts(ctx.user_email)
+    if not accounts:
+        return {}
+    registry = get_subscription_registry()
+    result = {}
+    for provider, (directory, credential) in accounts.items():
+        info = PROVIDERS[provider]
+        protect_account_directory(directory)
+        token = registry.register(provider, credential, capability=ctx.capability)
+        ctx.sub_proxy_tokens.append(token)
+        result[info['id']] = {
+            'name': info['name'], 'npm': info['npm'],
+            'options': {'baseURL': f'{gateway_base_url()}/sub/{token}{info["suffix"]}',
+                        'apiKey': token},
+            'models': {model: {'name': model} for model in model_ids(provider)},
+        }
+    return result

--- a/api/auth_middleware.py
+++ b/api/auth_middleware.py
@@ -10,6 +10,7 @@ import os
 from aiohttp import web
 
 from api.auth_helpers import ROLE_HIERARCHY
+from api.proxy_identity import verify_identity
 from observability.db import get_db
 
 logger = logging.getLogger(__name__)
@@ -51,7 +52,7 @@ async def auth_middleware(request, handler):
     if request.method == "OPTIONS":
         return await handler(request)
 
-    # API routes: attach user identity if available (never block)
+    # API routes require an authenticated, approved identity.
     if request.path.startswith("/api/"):
         user_email = request.headers.get("X-User-Email", "").strip()
         using_preview_fallback = False
@@ -69,6 +70,16 @@ async def auth_middleware(request, handler):
                     {"error": "Authentication required"}, status=401,
                 )
 
+        if not using_preview_fallback:
+            try:
+                valid_proxy = verify_identity(
+                    user_email, request.headers.get("X-Auth-Timestamp", ""),
+                    request.headers.get("X-Auth-Signature", ""))
+            except RuntimeError:
+                return web.json_response({"error": "Authentication unavailable"}, status=503)
+            if not valid_proxy:
+                return web.json_response({"error": "Authentication required"}, status=401)
+
         # Attach user email to request for downstream handlers
         request["user_email"] = user_email
         request["preview_fallback_user"] = using_preview_fallback
@@ -77,7 +88,9 @@ async def auth_middleware(request, handler):
         db = get_db()
         user = await db.users.find_one({"email": user_email}) if db is not None else None
         request["user"] = user
-        if using_preview_fallback or db is None:
+        if db is None and not using_preview_fallback:
+            return web.json_response({"error": "Authentication unavailable"}, status=503)
+        if using_preview_fallback:
             request["system_role"] = _DEFAULT_ROLE
             request["user_status"] = "active"
         else:
@@ -85,14 +98,13 @@ async def auth_middleware(request, handler):
                 user.get("system_role", _DEFAULT_ROLE) if user else _DEFAULT_ROLE
             )
             # Legacy users (no status field) are treated as active.
-            request["user_status"] = user.get("status", "active") if user else "active"
+            request["user_status"] = user.get("status", "active") if user else "pending"
 
-        # Gate users awaiting admin approval: they may only read their own profile
-        # (/api/governance/me, so the dashboard can show the pending screen). Every
-        # other API call is denied until an admin approves them.
-        if request.get("user_status") == "pending" and request.path != "/api/governance/me":
+        # Inactive/unprovisioned users may only read their approval status.
+        is_profile_read = request.method == "GET" and request.path == "/api/governance/me"
+        if request.get("user_status") != "active" and not is_profile_read:
             return web.json_response(
-                {"error": "Account pending admin approval"}, status=403,
+                {"error": "Account is not active"}, status=403,
             )
 
     return await handler(request)

--- a/api/claude_auth_routes.py
+++ b/api/claude_auth_routes.py
@@ -99,21 +99,10 @@ async def handle_claude_terminal_token(request: web.Request) -> web.Response:
     if not user_email:
         return web.json_response({"error": "Not authenticated"}, status=401)
 
-    # Ensure user dir exists
-    config_dir = _get_claude_users_dir() / user_email
-    config_dir.mkdir(parents=True, exist_ok=True)
+    from api.terminal_routes import register_login_terminal
+    token = register_login_terminal(user_email, "claude", _get_claude_users_dir() / user_email)
+    return web.json_response({"token": token})
 
-    # Clean expired tokens
-    now = time.time()
-    expired = [t for t, v in _claude_terminal_tokens.items() if v["expiry"] < now]
-    for t in expired:
-        _claude_terminal_tokens.pop(t, None)
-
-    token = secrets.token_urlsafe(32)
-    auto_command = f"CLAUDE_CONFIG_DIR={config_dir} claude login"
-    _claude_terminal_tokens[token] = {"expiry": now + TOKEN_TTL, "auto_command": auto_command}
-
-    return web.json_response({"token": token, "autoCommand": auto_command})
 
 
 async def handle_claude_disconnect(request: web.Request) -> web.Response:

--- a/api/codex_auth_routes.py
+++ b/api/codex_auth_routes.py
@@ -86,19 +86,10 @@ async def handle_codex_terminal_token(request: web.Request) -> web.Response:
     if not user_email:
         return web.json_response({"error": "Not authenticated"}, status=401)
 
-    config_dir = _get_codex_users_dir() / user_email
-    config_dir.mkdir(parents=True, exist_ok=True)
+    from api.terminal_routes import register_login_terminal
+    token = register_login_terminal(user_email, "codex", _get_codex_users_dir() / user_email)
+    return web.json_response({"token": token})
 
-    now = time.time()
-    expired = [t for t, v in _codex_terminal_tokens.items() if v["expiry"] < now]
-    for t in expired:
-        _codex_terminal_tokens.pop(t, None)
-
-    token = secrets.token_urlsafe(32)
-    auto_command = f"CODEX_HOME={config_dir} codex login {_codex_login_args()}".rstrip()
-    _codex_terminal_tokens[token] = {"expiry": now + TOKEN_TTL, "auto_command": auto_command}
-
-    return web.json_response({"token": token, "autoCommand": auto_command})
 
 
 async def handle_codex_disconnect(request: web.Request) -> web.Response:

--- a/api/dashboard_ingestion.py
+++ b/api/dashboard_ingestion.py
@@ -64,20 +64,17 @@ async def _extract_thread_refs_llm(prompt: str) -> dict[str, list[str]]:
     )
 
     try:
-        from agent.pool import background_cli_env
-        proc = await asyncio.create_subprocess_exec(
-            "claude", "-p", message,
-            "--model", "claude-haiku-4-5-20251001",
-            "--max-turns", "1",
-            "--output-format", "json",
-            "--allowedTools", "",
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env=background_cli_env(),
+        from agent.pool import run_background_cli
+        returncode, stdout, _ = await run_background_cli(
+            ["claude", "-p", message,
+             "--model", "claude-haiku-4-5-20251001",
+             "--max-turns", "1",
+             "--output-format", "json",
+             "--allowedTools", ""],
+            timeout=15,
         )
-        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=15)
 
-        if proc.returncode != 0:
+        if returncode != 0:
             return {}
 
         output = stdout.decode().strip()

--- a/api/env_routes.py
+++ b/api/env_routes.py
@@ -74,7 +74,11 @@ def _write_env_in_place(path: str, key: str, value: str | None) -> None:
             out.append(line)
     if value is not None and not found:
         out.append(f"{key}={value}")
-    p.write_text("\n".join(out) + ("\n" if out else ""))
+    # Create new files privately and tighten existing bind mounts before writing.
+    fd = os.open(p, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o600)
+    with os.fdopen(fd, "w") as target:
+        os.fchmod(target.fileno(), 0o600)
+        target.write("\n".join(out) + ("\n" if out else ""))
 
 
 def _is_sensitive(key: str) -> bool:

--- a/api/flow_routes.py
+++ b/api/flow_routes.py
@@ -218,16 +218,12 @@ async def handle_create_flow(request: web.Request) -> web.Response:
                 {"error": "Recurring flows require a cron expression"}, status=400,
             )
 
-    # Ensure created_by.source has an email.
-    # Only override if the agent didn't already pass one (contains @).
-    # The agent's curl bypasses Next.js middleware, so the auth email
-    # may be a dev fallback — prefer the agent-provided value when it's an email.
-    created_by = body.get("created_by", {})
-    if "@" not in (created_by.get("source") or ""):
-        user_email = get_user_email(request)
-        if user_email:
-            created_by["source"] = user_email
-            body["created_by"] = created_by
+    # Identity must come from authentication, never a caller-supplied creator.
+    requester_email = get_user_email(request)
+    if not requester_email:
+        return web.json_response({"error": "Authentication required"}, status=401)
+    body["created_by"] = {**(body.get("created_by") or {}), "source": requester_email}
+    body["run_as"] = body.get("run_as") or requester_email
 
     # Validate run_as: admins can set any active user, others only themselves
     run_as = body.get("run_as")

--- a/api/governance_routes.py
+++ b/api/governance_routes.py
@@ -49,6 +49,8 @@ def _serialize(doc):
     if isinstance(doc, dict):
         result = {}
         for k, v in doc.items():
+            if k == "local_auth":
+                continue
             if k == "_id":
                 result[k] = str(v)
             elif isinstance(v, datetime):

--- a/api/integration_routes.py
+++ b/api/integration_routes.py
@@ -6,6 +6,7 @@ in MongoDB and trigger MCP pool reload when integrations change.
 """
 
 import logging
+import hashlib
 import os
 import re
 import uuid
@@ -16,6 +17,7 @@ import aiohttp as _aiohttp
 from aiohttp import web
 
 from api.auth_helpers import require_admin, get_user_email
+from integrations.access import can_access
 from api.oauth_helpers import encrypt_token, decrypt_token, register_oauth_client
 from integrations.registry import PROVIDER_CATALOG, list_providers, get_provider
 from observability.db import get_db
@@ -70,6 +72,7 @@ async def _list_integrations(request: web.Request) -> web.Response:
             "webhook_secret_label": entry.get("webhook", {}).get("secret_label") if entry.get("webhook") else None,
             "extra_fields": entry.get("extra_fields", []),
             "status": status,
+            "scope": "organization",
         }
         if provider in connected:
             item.update(connected[provider])
@@ -79,6 +82,8 @@ async def _list_integrations(request: web.Request) -> web.Response:
     if db is not None:
         user_email = get_user_email(request)
         async for doc in db.integrations.find({"is_custom": True, "status": "active"}):
+            if not await can_access(db, doc, user_email):
+                continue
             item = {
                 "provider": doc["provider"],
                 "display_name": doc.get("display_name", doc["provider"]),
@@ -91,6 +96,7 @@ async def _list_integrations(request: web.Request) -> web.Response:
                 "extra_fields": [],
                 "status": "connected",
                 "is_custom": True,
+                "scope": "personal",
                 "url": doc.get("mcp_url", ""),
                 "has_token": bool(doc.get("api_key_encrypted")),
                 "auth_mode": doc.get("auth_mode", "none"),
@@ -111,6 +117,7 @@ async def _list_integrations(request: web.Request) -> web.Response:
 
 async def _connect_integration(request: web.Request) -> web.Response:
     """POST /api/integrations/connect — store encrypted API key and reload pool."""
+    require_admin(request)
     db = get_db()
     if db is None:
         return web.json_response({"error": "Database not available"}, status=503)
@@ -161,6 +168,7 @@ async def _connect_integration(request: web.Request) -> web.Response:
 
 async def _disconnect_integration(request: web.Request) -> web.Response:
     """DELETE /api/integrations/{provider} — remove integration and reload pool."""
+    require_admin(request)
     db = get_db()
     if db is None:
         return web.json_response({"error": "Database not available"}, status=503)
@@ -304,8 +312,8 @@ async def _add_custom_connector(request: web.Request) -> web.Response:
     """POST /api/integrations/custom — register a custom remote MCP server.
 
     Any user can add. Supports static token, per-user OAuth, or no auth.
-    If a connector with the same URL already exists, returns it instead of
-    creating a duplicate (dedup by URL).
+    The connector is private to its creator. Duplicate URLs are resolved
+    only within that owner's connectors.
     """
     db = get_db()
     if db is None:
@@ -323,9 +331,11 @@ async def _add_custom_connector(request: web.Request) -> web.Response:
     if not re.match(r"^https?://", url):
         return web.json_response({"error": "url must start with http:// or https://"}, status=400)
 
-    # Dedup by URL: if a connector with this URL already exists, return it
-    # so the user can connect their own auth to it instead of duplicating.
-    existing_by_url = await db.integrations.find_one({"mcp_url": url, "is_custom": True})
+    # Never reuse another owner's connector or credentials.
+    user_email = get_user_email(request)
+    if not user_email:
+        raise web.HTTPUnauthorized()
+    existing_by_url = await db.integrations.find_one({"mcp_url": url, "is_custom": True, "connected_by": user_email})
     if existing_by_url:
         return web.json_response({
             "status": "already_exists",
@@ -348,6 +358,7 @@ async def _add_custom_connector(request: web.Request) -> web.Response:
             {"error": f"'{slug}' collides with a built-in integration; choose another name"},
             status=409,
         )
+    slug = slug[:100] + "_" + hashlib.sha256(user_email.encode()).hexdigest()[:12]
     existing = await db.integrations.find_one({"provider": slug})
     if existing is not None:
         return web.json_response(
@@ -360,6 +371,7 @@ async def _add_custom_connector(request: web.Request) -> web.Response:
         "integration_id": str(uuid.uuid4()),
         "provider": slug,
         "is_custom": True,
+        "scope": "personal",
         "status": "active",
         "display_name": name,
         "mcp_url": url,
@@ -433,12 +445,14 @@ async def _add_custom_connector(request: web.Request) -> web.Response:
 
 async def _remove_custom_connector(request: web.Request) -> web.Response:
     """DELETE /api/integrations/custom/{provider} — remove a custom MCP connector."""
-    require_admin(request)
     db = get_db()
     if db is None:
         return web.json_response({"error": "Database not available"}, status=503)
 
     provider = request.match_info["provider"]
+    connector = await db.integrations.find_one({"provider": provider, "is_custom": True})
+    if connector and connector.get("connected_by") != get_user_email(request):
+        require_admin(request)
     result = await db.integrations.delete_one({"provider": provider, "is_custom": True})
     if result.deleted_count == 0:
         return web.json_response({"error": "Custom connector not found"}, status=404)

--- a/api/oauth_helpers.py
+++ b/api/oauth_helpers.py
@@ -6,7 +6,6 @@ The encryption key is read from OAUTH_ENCRYPTION_KEY env var.
 
 import base64
 import hashlib
-import hmac
 import json
 import logging
 import os
@@ -129,70 +128,49 @@ def generate_pkce_pair() -> tuple[str, str]:
     return code_verifier, code_challenge
 
 
-# ── HMAC state for CSRF protection ───────────────────────────────────────
+# OAuth state is opaque, short-lived, single-use and bound to a browser cookie.
+# Keep the PKCE verifier server-side, never in the provider-visible state.
+OAUTH_STATE_TTL = 600
 
 
-def create_oauth_state(email: str, code_verifier: str | None = None) -> str:
-    """Create an HMAC-signed OAuth state parameter.
-
-    Encodes user email + timestamp, signed with OAUTH_ENCRYPTION_KEY.
-    Optionally embeds a PKCE code_verifier for retrieval during callback.
-    """
-    key = os.environ.get("OAUTH_ENCRYPTION_KEY", "").strip().strip("'\"")
-    ts = str(int(time.time()))
-    payload = f"{email}:{ts}"
-    sig = hmac.new(key.encode(), payload.encode(), hashlib.sha256).hexdigest()
-    state_data: dict = {"email": email, "ts": ts, "sig": sig}
-    if code_verifier:
-        state_data["cv"] = code_verifier
-    return base64.urlsafe_b64encode(json.dumps(state_data).encode()).decode()
+def oauth_state_cookie(state: str) -> str:
+    return "loma_oauth_" + hashlib.sha256(state.encode()).hexdigest()[:24]
 
 
-def verify_oauth_state(state: str, max_age: int = 600) -> str | None:
-    """Verify an HMAC-signed OAuth state and return the email.
+async def create_oauth_state(db, email: str, provider: str,
+                             code_verifier: str | None = None) -> tuple[str, str]:
+    state = secrets.token_urlsafe(32)
+    browser_secret = secrets.token_urlsafe(32)
+    await db.oauth_states.create_index("expires_at", expireAfterSeconds=0)
+    await db.oauth_states.insert_one({
+        "_id": hashlib.sha256(state.encode()).hexdigest(),
+        "email": email,
+        "provider": provider,
+        "browser_hash": hashlib.sha256(browser_secret.encode()).hexdigest(),
+        "code_verifier": code_verifier,
+        "expires_at": datetime.fromtimestamp(time.time() + OAUTH_STATE_TTL, timezone.utc),
+    })
+    return state, browser_secret
 
-    Returns None if invalid or expired (default: 10 minute max age).
-    """
-    try:
-        state_data = json.loads(base64.urlsafe_b64decode(state).decode())
-    except Exception:
-        logger.warning("Invalid OAuth state encoding")
+
+async def consume_oauth_state(db, state: str, provider: str,
+                              browser_secret: str) -> dict | None:
+    if not state or not browser_secret or len(state) > 128 or len(browser_secret) > 128:
         return None
-
-    email = state_data.get("email", "")
-    ts = state_data.get("ts", "")
-    sig = state_data.get("sig", "")
-
-    if not email or not ts or not sig:
-        logger.warning("Missing fields in OAuth state")
+    # Match AND consume atomically: a wrong browser must not burn a valid state.
+    # Expiry is checked here too because Mongo TTL cleanup is asynchronous.
+    record = await db.oauth_states.find_one_and_delete({
+        "_id": hashlib.sha256(state.encode()).hexdigest(),
+        "provider": provider,
+        "browser_hash": hashlib.sha256(browser_secret.encode()).hexdigest(),
+        "expires_at": {"$gt": datetime.now(timezone.utc)},
+    })
+    if record is None:
         return None
-
-    # Check expiry
-    try:
-        if int(time.time()) - int(ts) > max_age:
-            logger.warning("OAuth state expired for %s", email)
-            return None
-    except ValueError:
+    user = await db.users.find_one({"email": record["email"]})
+    if not user or user.get("status", "active") != "active":
         return None
-
-    # Verify HMAC
-    key = os.environ.get("OAUTH_ENCRYPTION_KEY", "").strip().strip("'\"")
-    payload = f"{email}:{ts}"
-    expected_sig = hmac.new(key.encode(), payload.encode(), hashlib.sha256).hexdigest()
-    if not hmac.compare_digest(sig, expected_sig):
-        logger.warning("OAuth state HMAC mismatch for %s", email)
-        return None
-
-    return email
-
-
-def extract_code_verifier(state: str) -> str | None:
-    """Extract the PKCE code_verifier from an OAuth state, if present."""
-    try:
-        state_data = json.loads(base64.urlsafe_b64decode(state).decode())
-        return state_data.get("cv")
-    except Exception:
-        return None
+    return record
 
 
 # ── Token storage ─────────────────────────────────────────────────────────
@@ -632,6 +610,12 @@ async def get_valid_custom_mcp_token(user_email: str, provider: str, db=None) ->
     if db is None:
         return None
 
+    from integrations.access import require_provider
+    try:
+        await require_provider(db, provider, user_email)
+    except Exception:
+        return None
+
     doc = await db.oauth_tokens.find_one({
         "user_email": user_email, "provider": provider, "provider_type": "custom_mcp",
     })
@@ -846,10 +830,15 @@ async def get_valid_provider_token(user_email: str, provider: str, db=None) -> s
     if "refresh_token" in new_token:
         update["refresh_token"] = encrypt_token(new_token["refresh_token"])
 
-    await db.oauth_tokens.update_one(
-        {"user_email": user_email, "provider": provider},
+    updated = await db.oauth_tokens.update_one(
+        {"user_email": user_email, "provider": provider,
+         "access_token": doc["access_token"], "refresh_token": refresh_encrypted},
         {"$set": update},
     )
+    if updated.matched_count != 1:
+        # The connection was revoked, replaced or refreshed concurrently.
+        # Do not hand out this stale refresh result; retry on the next request.
+        return None
 
     logger.info("Refreshed %s token for %s", provider, user_email)
     return new_token["access_token"]

--- a/api/oauth_routes.py
+++ b/api/oauth_routes.py
@@ -1,5 +1,7 @@
 """OAuth API routes — Google & Slack OAuth flows for personal tool integrations."""
 
+import html
+import json
 import logging
 import os
 from datetime import datetime, timezone
@@ -26,8 +28,9 @@ from api.oauth_helpers import (
     SLACK_TOKEN_URL,
     SLACK_USER_SCOPES,
     create_oauth_state,
-    verify_oauth_state,
-    extract_code_verifier,
+    consume_oauth_state,
+    oauth_state_cookie,
+    OAUTH_STATE_TTL,
     generate_pkce_pair,
     store_google_tokens,
     revoke_google_tokens,
@@ -92,6 +95,16 @@ def _serialize(doc):
     return doc
 
 
+def _authorize_response(authorize_url: str, state: str, browser_secret: str,
+                        redirect_uri: str) -> web.Response:
+    response = web.json_response({"authorize_url": authorize_url},
+                                 headers={"Cache-Control": "no-store"})
+    response.set_cookie(oauth_state_cookie(state), browser_secret,
+                        max_age=OAUTH_STATE_TTL, httponly=True, samesite="Lax",
+                        secure=redirect_uri.startswith("https://"), path="/api/oauth/")
+    return response
+
+
 # ── Google OAuth flow ─────────────────────────────────────────────────────
 
 
@@ -114,7 +127,7 @@ async def handle_google_authorize(request: web.Request) -> web.Response:
             status=503,
         )
 
-    state = create_oauth_state(email)
+    state, browser_secret = await create_oauth_state(db, email, "google")
 
     params = {
         "client_id": client_id,
@@ -127,14 +140,14 @@ async def handle_google_authorize(request: web.Request) -> web.Response:
     }
 
     authorize_url = f"{GOOGLE_AUTH_URL}?{urlencode(params)}"
-    return web.json_response({"authorize_url": authorize_url})
+    return _authorize_response(authorize_url, state, browser_secret, redirect_uri)
 
 
 async def handle_google_callback(request: web.Request) -> web.Response:
     """GET /api/oauth/google/callback — handle Google OAuth redirect.
 
     This route is public (no X-User-Email header) because Google redirects
-    directly here. Authentication is via the HMAC-signed state parameter.
+    directly here. Authentication uses single-use state bound to the initiating browser.
     """
     db = get_db()
     if db is None:
@@ -153,7 +166,10 @@ async def handle_google_callback(request: web.Request) -> web.Response:
         return _callback_error("Missing authorization code or state")
 
     # Verify state (CSRF protection + user identification)
-    email = verify_oauth_state(state)
+    record = await consume_oauth_state(
+        db, state, "google", request.cookies.get(oauth_state_cookie(state), ""),
+    )
+    email = record["email"] if record else None
     if email is None:
         return _callback_error("Invalid or expired authorization state")
 
@@ -230,48 +246,27 @@ async def handle_google_callback(request: web.Request) -> web.Response:
     return _callback_success(google_email)
 
 
-def _callback_success(google_email: str) -> web.Response:
-    """Return HTML page that signals OAuth success to the opener and closes."""
-    html = f"""<!DOCTYPE html>
-<html>
-<head><title>Connected</title></head>
-<body>
-<p>Google account ({google_email}) connected successfully. This window will close.</p>
+def _callback_page(message: str, payload: dict, *, error: bool = False) -> web.Response:
+    # Provider strings and query errors are untrusted in both HTML and script contexts.
+    script_payload = json.dumps(payload).replace("<", "\\u003c").replace(">", "\\u003e").replace("&", "\\u0026")
+    page = f"""<!DOCTYPE html><html><head><title>Connection</title></head><body>
+<p>{html.escape(message)}</p>
 <script>
-  if (window.opener) {{
-    window.opener.postMessage({{
-      type: 'oauth-complete',
-      provider: 'google',
-      email: '{google_email}'
-    }}, '*');
-  }}
-  setTimeout(function() {{ window.close(); }}, 1500);
-</script>
-</body>
-</html>"""
-    return web.Response(text=html, content_type="text/html")
+if (window.opener) window.opener.postMessage({script_payload}, window.location.origin);
+{'setTimeout(function() { window.close(); }, 1500);' if not error else ''}
+</script></body></html>"""
+    return web.Response(text=page, content_type="text/html", status=400 if error else 200,
+                        headers={"Cache-Control": "no-store", "Referrer-Policy": "no-referrer"})
+
+
+def _callback_success(google_email: str) -> web.Response:
+    return _callback_page(f"Google account ({google_email}) connected successfully.",
+                          {"type": "oauth-complete", "provider": "google", "email": google_email})
 
 
 def _callback_error(message: str, provider: str = "google") -> web.Response:
-    """Return HTML page that signals OAuth error to the opener and closes."""
-    html = f"""<!DOCTYPE html>
-<html>
-<head><title>Error</title></head>
-<body>
-<p>Error: {message}</p>
-<p>You can close this window and try again.</p>
-<script>
-  if (window.opener) {{
-    window.opener.postMessage({{
-      type: 'oauth-error',
-      provider: '{provider}',
-      error: '{message}'
-    }}, '*');
-  }}
-</script>
-</body>
-</html>"""
-    return web.Response(text=html, content_type="text/html")
+    return _callback_page(f"Error: {message}. You can close this window and try again.",
+                          {"type": "oauth-error", "provider": provider, "error": message}, error=True)
 
 
 # ── Slack OAuth flow ──────────────────────────────────────────────────────
@@ -296,7 +291,7 @@ async def handle_slack_authorize(request: web.Request) -> web.Response:
             status=503,
         )
 
-    state = create_oauth_state(email)
+    state, browser_secret = await create_oauth_state(db, email, "slack")
 
     # Slack v2 OAuth uses "user_scope" (not "scope") for user token scopes
     params = {
@@ -307,14 +302,14 @@ async def handle_slack_authorize(request: web.Request) -> web.Response:
     }
 
     authorize_url = f"{SLACK_AUTH_URL}?{urlencode(params)}"
-    return web.json_response({"authorize_url": authorize_url})
+    return _authorize_response(authorize_url, state, browser_secret, redirect_uri)
 
 
 async def handle_slack_callback(request: web.Request) -> web.Response:
     """GET /api/oauth/slack/callback — handle Slack OAuth redirect.
 
     This route is public (no X-User-Email header) because Slack redirects
-    directly here. Authentication is via the HMAC-signed state parameter.
+    directly here. Authentication uses single-use state bound to the initiating browser.
     """
     db = get_db()
     if db is None:
@@ -333,7 +328,10 @@ async def handle_slack_callback(request: web.Request) -> web.Response:
         return _callback_error("Missing authorization code or state", provider="slack")
 
     # Verify state (CSRF protection + user identification)
-    email = verify_oauth_state(state)
+    record = await consume_oauth_state(
+        db, state, "slack", request.cookies.get(oauth_state_cookie(state), ""),
+    )
+    email = record["email"] if record else None
     if email is None:
         return _callback_error("Invalid or expired authorization state", provider="slack")
 
@@ -407,27 +405,8 @@ async def handle_slack_callback(request: web.Request) -> web.Response:
 
 
 def _callback_success_generic(provider: str, display_name: str) -> web.Response:
-    """Return HTML page that signals OAuth success for any provider."""
-    html = f"""<!DOCTYPE html>
-<html>
-<head><title>Connected</title></head>
-<body>
-<p>{display_name} connected successfully. This window will close.</p>
-<script>
-  if (window.opener) {{
-    window.opener.postMessage({{
-      type: 'oauth-complete',
-      provider: '{provider}'
-    }}, '*');
-  }}
-  setTimeout(function() {{ window.close(); }}, 1500);
-</script>
-</body>
-</html>"""
-    return web.Response(text=html, content_type="text/html")
-
-
-# ── Connections management ────────────────────────────────────────────────
+    return _callback_page(f"{display_name} connected successfully.",
+                          {"type": "oauth-complete", "provider": provider})
 
 
 async def handle_list_connections(request: web.Request) -> web.Response:
@@ -579,7 +558,7 @@ async def handle_provider_authorize(request: web.Request) -> web.Response:
             status=503,
         )
 
-    state = create_oauth_state(email)
+    state, browser_secret = await create_oauth_state(db, email, provider)
 
     params: dict = {
         "client_id": client_id,
@@ -593,7 +572,7 @@ async def handle_provider_authorize(request: web.Request) -> web.Response:
         params["owner"] = cfg["owner_type"]
 
     authorize_url = f"{cfg['auth_url']}?{urlencode(params)}"
-    return web.json_response({"authorize_url": authorize_url})
+    return _authorize_response(authorize_url, state, browser_secret, redirect_uri)
 
 
 async def handle_provider_callback(request: web.Request) -> web.Response:
@@ -616,7 +595,10 @@ async def handle_provider_callback(request: web.Request) -> web.Response:
     if not code or not state:
         return _callback_error("Missing authorization code or state", provider)
 
-    email = verify_oauth_state(state)
+    record = await consume_oauth_state(
+        db, state, provider, request.cookies.get(oauth_state_cookie(state), ""),
+    )
+    email = record["email"] if record else None
     if email is None:
         return _callback_error("Invalid or expired authorization state", provider)
 
@@ -660,23 +642,7 @@ async def handle_provider_callback(request: web.Request) -> web.Response:
 
     logger.info("%s OAuth completed for %s", provider.title(), email)
 
-    html = f"""<!DOCTYPE html>
-<html>
-<head><title>Connected</title></head>
-<body>
-<p>{provider.title()} connected successfully. This window will close.</p>
-<script>
-  if (window.opener) {{
-    window.opener.postMessage({{
-      type: 'oauth-complete',
-      provider: '{provider}'
-    }}, '*');
-  }}
-  setTimeout(function() {{ window.close(); }}, 1500);
-</script>
-</body>
-</html>"""
-    return web.Response(text=html, content_type="text/html")
+    return _callback_success_generic(provider, provider.title())
 
 
 async def handle_disconnect_provider(request: web.Request) -> web.Response:
@@ -716,6 +682,7 @@ async def handle_custom_mcp_authorize(request: web.Request) -> web.Response:
 
     integration = await db.integrations.find_one({
         "provider": provider, "is_custom": True, "auth_mode": "oauth",
+        "connected_by": email, "status": "active",
     })
     if not integration:
         return web.json_response({"error": "No OAuth-configured connector found"}, status=404)
@@ -731,7 +698,9 @@ async def handle_custom_mcp_authorize(request: web.Request) -> web.Response:
 
     redirect_uri = _oauth_redirect_uri(request, f"custom-mcp/{provider}")
     code_verifier, code_challenge = generate_pkce_pair()
-    state = create_oauth_state(email, code_verifier=code_verifier)
+    state, browser_secret = await create_oauth_state(
+        db, email, f"custom-mcp/{provider}", code_verifier=code_verifier,
+    )
 
     params = {
         "client_id": client_id,
@@ -746,7 +715,7 @@ async def handle_custom_mcp_authorize(request: web.Request) -> web.Response:
         params["scope"] = " ".join(scopes)
 
     authorize_url = f"{auth_endpoint}?{urlencode(params)}"
-    return web.json_response({"authorize_url": authorize_url})
+    return _authorize_response(authorize_url, state, browser_secret, redirect_uri)
 
 
 async def handle_custom_mcp_callback(request: web.Request) -> web.Response:
@@ -767,14 +736,20 @@ async def handle_custom_mcp_callback(request: web.Request) -> web.Response:
     if not code or not state:
         return _callback_error("Missing authorization code or state", provider=provider)
 
-    email = verify_oauth_state(state)
+    record = await consume_oauth_state(
+        db, state, f"custom-mcp/{provider}", request.cookies.get(oauth_state_cookie(state), ""),
+    )
+    email = record["email"] if record else None
     if email is None:
         return _callback_error("Invalid or expired authorization state", provider=provider)
 
-    code_verifier = extract_code_verifier(state)
+    code_verifier = record.get("code_verifier")
+    if not code_verifier:
+        return _callback_error("Missing PKCE verifier; reconnect the integration", provider)
 
     integration = await db.integrations.find_one({
         "provider": provider, "is_custom": True, "auth_mode": "oauth",
+        "connected_by": email, "status": "active",
     })
     if not integration:
         return _callback_error("Connector not found", provider=provider)

--- a/api/proxy_identity.py
+++ b/api/proxy_identity.py
@@ -1,0 +1,36 @@
+"""Short-lived, purpose-bound identity assertions from trusted HTTP proxies."""
+import hashlib
+import hmac
+import os
+import time
+
+DOMAIN = 'loma-proxy-identity-v1'
+MAX_AGE = 60
+
+
+def _key() -> bytes:
+    value = os.environ.get('BACKEND_PROXY_SECRET') or os.environ.get('OAUTH_ENCRYPTION_KEY', '')
+    if len(value) < 32:
+        raise RuntimeError('Backend proxy authentication is not configured')
+    return value.encode()
+
+
+def sign_identity(email: str, timestamp: str) -> str:
+    if not email or any(c in email for c in '\r\n\0'):
+        raise ValueError('Invalid identity')
+    payload = f'{DOMAIN}\n{timestamp}\n{email}'.encode()
+    return hmac.new(_key(), payload, hashlib.sha256).hexdigest()
+
+
+def verify_identity(email: str, timestamp: str, signature: str) -> bool:
+    # Require configuration even on invalid requests; callers can return 503.
+    _key()
+    try:
+        if not timestamp.isascii() or not timestamp.isdecimal() or len(timestamp) != 10:
+            return False
+        age = time.time() - int(timestamp)
+        if not 0 <= age <= MAX_AGE or len(signature) != 64:
+            return False
+        return hmac.compare_digest(sign_identity(email, timestamp), signature)
+    except (ValueError, TypeError):
+        return False

--- a/api/routes.py
+++ b/api/routes.py
@@ -17,6 +17,7 @@ from agent.opencode_runtime import get_agent_models, get_opencode_pool_status
 from agent.pool import ClientPool, get_pool
 from agent.prompt import refresh_loma_skill_index_from_db
 from observability.db import get_db
+from utils.secret_redaction import redact_secrets
 from observability.observer import ConversationObserver
 from api.auth_helpers import (
     get_system_role,
@@ -42,7 +43,10 @@ SERVED_FILES_DIR.mkdir(parents=True, exist_ok=True)
 _served_files: dict[str, dict] = {}
 
 
-def register_served_file(source_path: str, original_name: str | None = None) -> dict:
+def register_served_file(
+    source_path: str, original_name: str | None = None, *,
+    owner_email: str | None = None, conversation_id: str | None = None,
+) -> dict:
     """Copy a file to the served directory and register it for download.
 
     Returns a dict with file_id, url, name, mime_type, size.
@@ -51,7 +55,7 @@ def register_served_file(source_path: str, original_name: str | None = None) -> 
     if not src.exists() or not src.is_file():
         raise FileNotFoundError(f"File not found: {source_path}")
 
-    file_id = uuid.uuid4().hex[:16]
+    file_id = uuid.uuid4().hex
     name = original_name or src.name
     ext = src.suffix
     dest = SERVED_FILES_DIR / f"{file_id}{ext}"
@@ -66,7 +70,15 @@ def register_served_file(source_path: str, original_name: str | None = None) -> 
         "original_name": name,
         "mime_type": mime_type,
         "size": size,
+        "owner_email": owner_email,
+        "conversation_id": conversation_id,
     }
+    # Atomic sidecar publication survives process restarts without trusting paths
+    # supplied by download callers. Keep this directory on a persistent volume.
+    manifest = SERVED_FILES_DIR / f"{file_id}.meta.json"
+    temporary = manifest.with_suffix(".json.tmp")
+    temporary.write_text(json.dumps(entry))
+    temporary.replace(manifest)
     _served_files[file_id] = entry
 
     return {
@@ -89,33 +101,43 @@ _INLINE_MIME_TYPES = {
 async def handle_serve_file(request: web.Request) -> web.Response:
     """GET /api/files/{file_id} — serve a registered file for download or inline preview."""
     file_id = request.match_info["file_id"]
+    if not re.fullmatch(r"[0-9a-f]{32}", file_id):
+        return web.json_response({"error": "File not found"}, status=404)
     entry = _served_files.get(file_id)
-
-    # Fallback: try decoding file_id as a base64-encoded file path
-    # (backward compat for any persisted file artifact URLs)
-    if not entry:
-        import base64
+    if entry is None:
         try:
-            # Re-add padding stripped during encoding
-            padded = file_id + "=" * (-len(file_id) % 4)
-            decoded_path = base64.urlsafe_b64decode(padded).decode()
-            if os.path.isfile(decoded_path):
-                # Register the file so subsequent requests use the fast path
-                file_info = register_served_file(decoded_path)
-                entry = _served_files.get(file_info["file_id"])
-        except Exception:
-            pass
+            entry = json.loads((SERVED_FILES_DIR / f"{file_id}.meta.json").read_text())
+        except (OSError, ValueError):
+            return web.json_response({"error": "File not found"}, status=404)
 
-    if not entry:
+    user_email = get_user_email(request)
+    if not user_email:
+        return web.json_response({"error": "Authentication required"}, status=401)
+    cid = entry.get("conversation_id")
+    if cid:
+        db = get_db()
+        if db is None:
+            return web.json_response({"error": "Authorization unavailable"}, status=503)
+        conversation = await db.conversations.find_one({
+            "conversation_id": cid, "deleted": {"$ne": True},
+        })
+        allowed = conversation and _check_conversation_access(
+            conversation, user_email, get_system_role(request),
+        )
+    else:
+        allowed = entry.get("owner_email") == user_email
+    if not allowed:
         return web.json_response({"error": "File not found"}, status=404)
 
     file_path = Path(entry["path"])
-    if not file_path.exists():
-        del _served_files[file_id]
+    if file_path.is_symlink() or file_path.resolve().parent != SERVED_FILES_DIR.resolve():
+        return web.json_response({"error": "File not found"}, status=404)
+    if not file_path.is_file():
+        _served_files.pop(file_id, None)
         return web.json_response({"error": "File expired"}, status=410)
 
     mime_type = entry["mime_type"]
-    filename = entry["original_name"]
+    filename = re.sub(r'[\x00-\x1f\x7f"\\]', "_", entry["original_name"])
 
     # Use inline disposition for previewable types (PDF, images)
     # so they can be rendered in iframes; attachment for everything else
@@ -129,7 +151,9 @@ async def handle_serve_file(request: web.Request) -> web.Response:
         headers={
             "Content-Disposition": disposition,
             "Content-Type": mime_type,
-            "Access-Control-Allow-Origin": "*",
+            "Cache-Control": "private, no-store",
+            "X-Content-Type-Options": "nosniff",
+            "Content-Security-Policy": "sandbox; default-src 'none'; style-src 'unsafe-inline'",
         },
     )
 
@@ -226,7 +250,8 @@ _search_index_ensured = False
 
 
 def _serialize(doc):
-    """Make a MongoDB document JSON-serializable."""
+    """Make a MongoDB document JSON-serializable without historical credentials."""
+    doc = redact_secrets(doc)
     if doc is None:
         return None
     if isinstance(doc, list):
@@ -304,21 +329,18 @@ async def _generate_title_llm(prompt: str, response_snippet: str = "") -> str:
     )
 
     try:
-        from agent.pool import background_cli_env
-        proc = await asyncio.create_subprocess_exec(
-            "claude", "-p", message,
-            "--model", "claude-haiku-4-5-20251001",
-            "--max-turns", "1",
-            "--output-format", "json",
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env=background_cli_env(),
+        from agent.pool import run_background_cli
+        returncode, stdout, stderr = await run_background_cli(
+            ["claude", "-p", message,
+             "--model", "claude-haiku-4-5-20251001",
+             "--max-turns", "1",
+             "--output-format", "json"],
+            timeout=15,
         )
-        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=15)
 
-        if proc.returncode != 0:
+        if returncode != 0:
             detail = stderr.decode()[:300].strip() or stdout.decode()[:300].strip()
-            logger.warning("Title generation CLI failed (rc=%d): %s", proc.returncode, detail)
+            logger.warning("Title generation CLI failed (rc=%d): %s", returncode, detail)
             return _fallback_title(prompt)
 
         output = stdout.decode().strip()
@@ -361,21 +383,18 @@ async def _classify_topic_llm(prompt: str, response_snippet: str = "") -> str:
     )
 
     try:
-        from agent.pool import background_cli_env
-        proc = await asyncio.create_subprocess_exec(
-            "claude", "-p", message,
-            "--model", "claude-haiku-4-5-20251001",
-            "--max-turns", "1",
-            "--output-format", "json",
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env=background_cli_env(),
+        from agent.pool import run_background_cli
+        returncode, stdout, stderr = await run_background_cli(
+            ["claude", "-p", message,
+             "--model", "claude-haiku-4-5-20251001",
+             "--max-turns", "1",
+             "--output-format", "json"],
+            timeout=15,
         )
-        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=15)
 
-        if proc.returncode != 0:
+        if returncode != 0:
             detail = stderr.decode()[:300].strip() or stdout.decode()[:300].strip()
-            logger.warning("Topic classification CLI failed (rc=%d): %s", proc.returncode, detail)
+            logger.warning("Topic classification CLI failed (rc=%d): %s", returncode, detail)
             return "other"
 
         output = stdout.decode().strip()
@@ -832,16 +851,20 @@ async def handle_inject_message(request: web.Request) -> web.Response:
     if not stream:
         return web.json_response({"error": "No active stream for this conversation"}, status=404)
 
+    db = get_db()
+    if db is None:
+        return web.json_response({"error": "Observability unavailable"}, status=503)
     try:
         await stream.client.query(message)
-        db = request.app["db"]
-        from observability.observer import ConversationObserver
-        observer = ConversationObserver(db, {}, conversation_id=cid)
-        await observer.record_injected_message(message)
-        return web.json_response({"injected": True, "conversation_id": cid})
-    except Exception as e:
+    except Exception:
         logger.exception("Failed to inject message into conversation %s", cid)
-        return web.json_response({"error": str(e)}, status=500)
+        return web.json_response({"error": "Message injection failed"}, status=500)
+    observer = ConversationObserver(db, {}, conversation_id=cid)
+    try:
+        await observer.record_injected_message(message)
+    except Exception:
+        logger.exception("Failed to record injected message in %s", cid)
+    return web.json_response({"injected": True, "conversation_id": cid})
 
 
 async def handle_interrupt_agent(request: web.Request) -> web.Response:
@@ -939,7 +962,7 @@ async def handle_chat(request: web.Request) -> web.Response:
                 {"conversation_id": existing_conversation_id},
                 {"_id": 1, "task_status": 1, "started_at": 1, "metadata": 1, "source": 1, "tool_config": 1},
             )
-            if existing and not _check_conversation_access(
+            if existing and not _check_conversation_manage_access(
                 existing, user_email, get_system_role(request)
             ):
                 return web.json_response({"error": "Not found"}, status=404)
@@ -1090,9 +1113,9 @@ async def handle_chat(request: web.Request) -> web.Response:
 
             try:
                 if isinstance(event, dict):
-                    data = json.dumps(event)
+                    data = json.dumps(redact_secrets(event))
                 else:
-                    data = json.dumps({"type": "text", "text": event})
+                    data = json.dumps({"type": "text", "text": redact_secrets(event)})
                 await response.write(f"data: {data}\n\n".encode())
                 await response.drain()
             except (ConnectionResetError, ConnectionError, Exception) as write_err:
@@ -1175,9 +1198,12 @@ async def handle_agent_models(request: web.Request) -> web.Response:
     except RuntimeError:
         pass
 
+    from agent.subscription_providers import model_catalog as personal_subscription_models
+    personal_models = personal_subscription_models(get_user_email(request))
+
     try:
         catalog = await get_agent_models()
-        filtered_models = list(claude_models) + list(codex_models)
+        filtered_models = list(claude_models) + list(codex_models) + personal_models
         for model in catalog.get("models", []):
             model_id = model.get("model_id") or ""
             provider_id = model.get("provider_id") or ""
@@ -1202,18 +1228,20 @@ async def handle_agent_models(request: web.Request) -> web.Response:
         logger.exception("Failed to load OpenCode model catalog")
         return web.json_response({
             "default_model": default_agent_model,
-            "models": _order_agent_models(_ensure_favorite_models(claude_models + codex_models)),
+            "models": _order_agent_models(_ensure_favorite_models(claude_models + codex_models + personal_models)),
             "warning": str(e),
         })
 
 
 async def handle_list_skills(request: web.Request) -> web.Response:
     """GET /api/skills — list DB-native agent skills."""
-    require_analyst_or_above(request)
     db = get_db()
     if db is None:
         return web.json_response({"error": "MongoDB is not configured"}, status=503)
     skills = await skill_service.list_skills(db)
+    email = get_user_email(request)
+    skills = [skill for skill in skills if skill.get("scope") in ("system", "workspace")
+              or skill.get("created_by") == email]
     return web.json_response({"skills": skills})
 
 

--- a/api/skill_service.py
+++ b/api/skill_service.py
@@ -488,6 +488,15 @@ async def update_skill_folder(
         raise SkillError("Skill not found", status=404)
     if skill.get("scope") == "system":
         raise SkillError("Cannot organize system skills into folders", status=403)
+    scope = skill.get("scope") or "personal"
+    if scope == "personal" and skill.get("created_by") != actor:
+        raise SkillError("You can only organize your own personal skills", status=403)
+    if scope == "workspace":
+        user = await db.users.find_one({"email": actor})
+        if not user or user.get("system_role") != "admin":
+            raise SkillError("Admin access required", status=403)
+    if folder is not None and not isinstance(folder, str):
+        raise SkillError("folder must be a string", status=400)
     folder = folder.strip() if folder else None
     await db.skills.update_one(
         {"slug": slug},
@@ -590,21 +599,18 @@ async def auto_organize_skills(db) -> dict[str, Any]:
         )
 
         try:
-            from agent.pool import background_cli_env
-            proc = await asyncio.create_subprocess_exec(
-                "claude", "-p", message,
-                "--model", "claude-haiku-4-5-20251001",
-                "--max-turns", "1",
-                "--output-format", "json",
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                env=background_cli_env(),
+            from agent.pool import run_background_cli
+            returncode, stdout, stderr = await run_background_cli(
+                ["claude", "-p", message,
+                 "--model", "claude-haiku-4-5-20251001",
+                 "--max-turns", "1",
+                 "--output-format", "json"],
+                timeout=120,
             )
-            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=120)
-            if proc.returncode != 0:
+            if returncode != 0:
                 detail = stderr.decode()[:300].strip() or stdout.decode()[:300].strip() or "no output"
-                logger.warning("Skill organize CLI failed (rc=%d): %s", proc.returncode, detail)
-                errors.append(f"{batch_label}: claude CLI exited {proc.returncode}: {detail}")
+                logger.warning("Skill organize CLI failed (rc=%d): %s", returncode, detail)
+                errors.append(f"{batch_label}: claude CLI exited {returncode}: {detail}")
                 continue
 
             output = stdout.decode().strip()

--- a/api/task_routes.py
+++ b/api/task_routes.py
@@ -28,6 +28,7 @@ from datetime import date, datetime, timezone
 from aiohttp import web
 
 from observability.db import get_db
+from utils.secret_redaction import redact_secrets
 from api.auth_helpers import get_system_role, get_user_email
 from api.drain import DRAIN_MESSAGE, is_draining
 
@@ -128,7 +129,8 @@ MAX_DRAFT_FILES_BYTES = 8 * 1024 * 1024
 
 
 def _serialize(doc):
-    """Make a MongoDB document JSON-serializable."""
+    """Make a MongoDB document JSON-serializable without historical credentials."""
+    doc = redact_secrets(doc)
     if doc is None:
         return None
     if isinstance(doc, list):
@@ -416,7 +418,7 @@ async def handle_fork_task(request: web.Request) -> web.Response:
         "finished_at": source.get("finished_at"),
         "duration_ms": None,
         "status": "interrupted" if source.get("status") == "running" else source.get("status"),
-        "metadata": {**copy.deepcopy(source.get("metadata") or {}), "user_name": user_email},
+        "metadata": {**copy.deepcopy(source.get("metadata") or {}), "user_name": user_email, "visibility": "private"},
         "prompt": source.get("prompt") or "",
         "model": source.get("model") or "",
         "total_turns": source.get("total_turns", 0),

--- a/api/terminal_routes.py
+++ b/api/terminal_routes.py
@@ -7,52 +7,125 @@ import os
 import pty
 import secrets
 import signal
+import shutil
+from pathlib import Path
 import struct
 import termios
 import time
 
 from aiohttp import web, WSMsgType
 
+from api.auth_helpers import get_user_email, require_maintainer_or_above
+
 
 logger = logging.getLogger(__name__)
 
-# One-time tokens: token -> expiry timestamp
-_terminal_tokens: dict[str, float] = {}
+# One-time tokens: token -> (expiry timestamp, authenticated owner)
+_terminal_tokens: dict[str, tuple[float, str]] = {}
 TOKEN_TTL = 30  # seconds
+
+_login_tokens: dict[str, dict] = {}
+
+
+def register_login_terminal(email: str, provider: str, config_dir: Path) -> str:
+    """Trusted login-only PTY, never a backend shell or model invocation."""
+    if not email or Path(email).name != email or email in {".", ".."}:
+        raise web.HTTPBadRequest(text="Invalid account identity")
+    commands = {"claude": ["claude", "auth", "login"],
+                "codex": ["codex", "login", "--device-auth"]}
+    if provider not in commands:
+        raise web.HTTPBadRequest(text="Unknown login provider")
+    if config_dir.is_symlink():
+        raise web.HTTPBadRequest(text="Invalid account directory")
+    config_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    os.chmod(config_dir, 0o700)
+    executable = shutil.which(provider)
+    if not executable:
+        raise web.HTTPServiceUnavailable(text="Login client unavailable")
+    command = [executable, *commands[provider][1:]]
+    env = {"PATH": "/usr/local/bin:/usr/bin:/bin", "HOME": str(config_dir),
+           "TERM": "xterm-256color",
+           "CLAUDE_CONFIG_DIR" if provider == "claude" else "CODEX_HOME": str(config_dir)}
+    now = time.time()
+    for old in [key for key, value in _login_tokens.items() if value["expiry"] < now]:
+        _login_tokens.pop(old, None)
+    token = secrets.token_urlsafe(32)
+    _login_tokens[token] = {"expiry": now + TOKEN_TTL, "email": email,
+                            "argv": command, "env": env, "cwd": str(config_dir)}
+    return token
 
 
 async def handle_terminal_token(request: web.Request) -> web.Response:
     """POST /api/terminal/token — issue a one-time token for WebSocket auth."""
+    require_maintainer_or_above(request)
+    if not get_user_email(request):
+        raise web.HTTPUnauthorized()
     # Clean expired tokens
     now = time.time()
-    expired = [t for t, exp in _terminal_tokens.items() if exp < now]
+    expired = [t for t, (exp, _) in _terminal_tokens.items() if exp < now]
     for t in expired:
         _terminal_tokens.pop(t, None)
 
     token = secrets.token_urlsafe(32)
-    _terminal_tokens[token] = now + TOKEN_TTL
+    _terminal_tokens[token] = (now + TOKEN_TTL, get_user_email(request))
     return web.json_response({"token": token})
 
 
 async def handle_terminal_ws(request: web.Request) -> web.WebSocketResponse:
     """GET /api/terminal/ws?token=... — WebSocket endpoint that spawns a PTY shell."""
-    # Validate one-time token
     token = request.query.get("token", "")
-    expiry = _terminal_tokens.pop(token, None)
-    if not expiry or expiry < time.time():
-        return web.json_response({"error": "Invalid or expired token"}, status=403)
+    user_email = get_user_email(request)
+    login = _login_tokens.pop(token, None)
+    if login is not None:
+        if login["expiry"] < time.time() or login["email"] != user_email:
+            return web.json_response({"error": "Invalid or expired token"}, status=403)
+    else:
+        require_maintainer_or_above(request)
+        grant = _terminal_tokens.pop(token, None)
+        if not grant or grant[0] < time.time() or not user_email or grant[1] != user_email:
+            return web.json_response({"error": "Invalid or expired token"}, status=403)
 
     ws = web.WebSocketResponse()
     await ws.prepare(request)
 
-    # Spawn a PTY with bash
-    env = {**os.environ, "TERM": "xterm-256color"}
-    env.pop("CLAUDECODE", None)
+    # Terminals go through the same worker boundary as agent runs: a fresh
+    # private workspace and a scrubbed allowlist environment. The backend
+    # env (DB URIs, encryption keys, provider/API tokens) is NEVER inherited.
+    from broker import worker as worker_mod
+
+    if login is not None:
+        # Fixed vendor authentication command. No shell interpolation, backend
+        # environment inheritance, model prompt or post-login interactive shell.
+        workspace = None
+        env, command, cwd = login["env"], login["argv"], login["cwd"]
+        def child_setup():
+            os.umask(0o077)
+    else:
+        workspace = worker_mod.create_workspace(prefix="terminal")
+        cwd = str(workspace)
+        env = worker_mod.build_worker_env(workspace)
+        command = ["/bin/bash", "--noprofile", "--norc", "-i"]
+        from broker import sandbox
+        if sandbox.enabled():
+            command = sandbox.prepare(command, workspace, env)
+            env = {'PATH': '/usr/local/bin:/usr/bin:/bin'}
+            def child_setup():
+                os.umask(0o077)
+        else:
+            if worker_mod.bwrap_available():
+                command = worker_mod.build_bwrap_argv(command, workspace)
+            child_setup = worker_mod.worker_preexec_fn(setsid=False, workspace=workspace)
     pid, fd = pty.fork()
 
     if pid == 0:
-        # Child process — exec into bash
-        os.execvpe("/bin/bash", ["/bin/bash", "--login"], env)
+        # Child process — apply worker limits, confine to the workspace,
+        # then exec into bash. Never fall back to an unconfined shell.
+        try:
+            child_setup()
+            os.chdir(cwd)
+            os.execvpe(command[0], command, env)
+        except Exception:
+            pass
         os._exit(1)
 
     # Parent — bridge the PTY fd and the WebSocket
@@ -63,6 +136,12 @@ async def handle_terminal_ws(request: web.Request) -> web.WebSocketResponse:
     fcntl.fcntl(fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
 
     closed = False
+
+    async def expire_terminal():
+        await asyncio.sleep(600 if login else 3600)
+        await ws.close()
+
+    expiry_task = asyncio.create_task(expire_terminal())
 
     def on_pty_readable():
         nonlocal closed
@@ -100,6 +179,7 @@ async def handle_terminal_ws(request: web.Request) -> web.WebSocketResponse:
         logger.exception("Terminal WebSocket error")
     finally:
         closed = True
+        expiry_task.cancel()
         loop.remove_reader(fd)
         os.close(fd)
         try:
@@ -110,6 +190,12 @@ async def handle_terminal_ws(request: web.Request) -> web.WebSocketResponse:
             os.waitpid(pid, os.WNOHANG)
         except ChildProcessError:
             pass
+        try:
+            from broker import worker as worker_mod
+            if workspace is not None:
+                worker_mod.cleanup_workspace(workspace)
+        except Exception:
+            logger.warning("Failed to clean terminal workspace %s", workspace)
 
     return ws
 

--- a/app.py
+++ b/app.py
@@ -44,6 +44,13 @@ from api.prompt_settings_routes import setup_prompt_settings_routes
 from api.agent_identity_routes import setup_agent_identity_routes
 from api.telegram_routes import setup_telegram_routes
 from api.drain import setup_drain_routes
+from broker.controller import (
+    init_execution_controller,
+    get_proxy_registry,
+    get_subscription_registry,
+)
+from broker.gateway import create_gateway_app
+from broker.http import create_app as create_broker_app
 from recovery import start_recovery_loop, mark_all_running_interrupted
 from scheduler.engine import init_scheduler
 from agent.client import load_config, merge_db_integrations
@@ -73,6 +80,11 @@ async def log_404_middleware(request, handler):
 
 
 async def main():
+    # The mounted dotenv must not be readable by untrusted runtime uids.
+    # Refuse startup on permission errors instead of launching exposed workers.
+    from api.env_routes import DOTENV_PATH
+    if os.path.exists(DOTENV_PATH):
+        os.chmod(DOTENV_PATH, 0o600)
     # Initialize observability MongoDB
     await init_observability()
     # Ensure skill indexes exist (idempotent, covers new indexes on upgrades).
@@ -82,6 +94,37 @@ async def main():
     await seed_default_skills(get_db())
     await refresh_prompt_settings_from_db()
     await refresh_loma_skill_index_from_db()
+
+    # Execution broker + credential-injection gateway. Bound to loopback:
+    # workers on this host reach them; they are never publicly routable.
+    # If startup fails, agent runs proceed with NO tool/credential access
+    # (fail closed) \u2014 there is no fallback to ambient backend credentials.
+    try:
+        broker = await init_execution_controller(get_db())
+        broker_runner = web.AppRunner(create_broker_app(broker))
+        await broker_runner.setup()
+        await web.TCPSite(
+            broker_runner,
+            os.environ.get("LOMA_BROKER_HOST", "127.0.0.1"),
+            int(os.environ.get("LOMA_BROKER_PORT", "3100")),
+        ).start()
+        gateway_runner = web.AppRunner(create_gateway_app(
+            broker, get_proxy_registry(), get_subscription_registry()))
+        await gateway_runner.setup()
+        await web.TCPSite(
+            gateway_runner,
+            os.environ.get("LOMA_GATEWAY_HOST", "127.0.0.1"),
+            int(os.environ.get("LOMA_GATEWAY_PORT", "3101")),
+        ).start()
+        from broker import sandbox
+        if sandbox.enabled():
+            await sandbox.serve_transports(broker_runner, gateway_runner)
+        logger.info("Execution broker and worker gateway running")
+    except Exception:
+        logger.exception(
+            "Execution broker failed to start \u2014 worker tool/credential "
+            "access is disabled (fail closed)"
+        )
 
     # Pre-warm Claude SDK client pool (background \u2014 doesn't block startup)
     agent_config = load_config()

--- a/broker/__init__.py
+++ b/broker/__init__.py
@@ -1,0 +1,1 @@
+"""Trusted-side execution broker. Never package this module in worker images."""

--- a/broker/controller.py
+++ b/broker/controller.py
@@ -1,0 +1,297 @@
+"""Trusted execution controller: run lifecycle, grants, and worker configs.
+
+The controller is the ONLY component allowed to mint or revoke run
+capabilities. It runs inside the backend process, next to the broker, and:
+
+- starts/ends runs (fresh workspace + capability issuance + revocation),
+- decides resource grants from deployment policy and integration sharing
+  rules — never from prompts or model output,
+- rewrites MCP configs so workers talk to the credential-injection gateway
+  instead of holding real credentials, and disables (fail closed) anything
+  the broker/gateway cannot mediate yet.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+from dataclasses import dataclass, field
+from contextvars import ContextVar
+from pathlib import Path
+
+from broker.gateway import (
+    McpProxyRegistry,
+    SubscriptionProxyRegistry,
+    configured_model_providers,
+    gateway_base_url,
+)
+from broker.grain import GrainTranscript
+from broker.operations import (
+    ALL_TOOLS,
+    INTEGRATION_TOOLS,
+    PERSONAL_TOOLS,
+    UTILITY_TOOLS,
+    ModelRequest,
+    McpRequest,
+    SubscriptionRequest,
+    ToolInvoke,
+)
+from broker.service import Broker
+from broker import worker as worker_mod
+
+logger = logging.getLogger(__name__)
+
+current_run: ContextVar = ContextVar("loma_run", default=None)
+
+_broker: Broker | None = None
+_registry: McpProxyRegistry | None = None
+_sub_registry: SubscriptionProxyRegistry | None = None
+
+
+class ExecutionUnavailable(RuntimeError):
+    """The execution controller is not initialized; runs must fail closed."""
+
+
+def broker_url() -> str:
+    host = os.environ.get("LOMA_BROKER_HOST", "127.0.0.1")
+    port = int(os.environ.get("LOMA_BROKER_PORT", "3100"))
+    return f"http://{host}:{port}"
+
+
+def _deployment_id() -> str:
+    explicit = os.environ.get("LOMA_DEPLOYMENT_ID", "").strip()
+    if explicit:
+        return explicit
+    base = os.environ.get("PUBLIC_BASE_URL", "").strip() or "loma-default-deployment"
+    return "dep-" + hashlib.sha256(base.encode()).hexdigest()[:16]
+
+
+async def init_execution_controller(db) -> Broker:
+    """Create the broker + proxy registry singletons. Called at startup."""
+    global _broker, _registry, _sub_registry
+    operations = {
+        "tool.invoke": ToolInvoke(),
+        "mcp.request": McpRequest(),
+        "grain.transcript": GrainTranscript(),
+        "model.request": ModelRequest(configured_model_providers()),
+        "subscription.request": SubscriptionRequest(),
+    }
+    _broker = Broker(db, _deployment_id(), operations)
+    await _broker.initialize()
+    _registry = McpProxyRegistry()
+    _sub_registry = SubscriptionProxyRegistry()
+    logger.info(
+        "Execution controller initialized (deployment=%s, model_providers=%s)",
+        _deployment_id(), sorted(configured_model_providers()),
+    )
+    return _broker
+
+
+def get_broker() -> Broker:
+    if _broker is None:
+        raise ExecutionUnavailable("Execution broker is not initialized")
+    return _broker
+
+
+def get_proxy_registry() -> McpProxyRegistry:
+    if _registry is None:
+        raise ExecutionUnavailable("Execution gateway registry is not initialized")
+    return _registry
+
+
+def get_subscription_registry() -> SubscriptionProxyRegistry:
+    if _sub_registry is None:
+        raise ExecutionUnavailable("Subscription proxy registry is not initialized")
+    return _sub_registry
+
+
+def controller_ready() -> bool:
+    return _broker is not None and _registry is not None
+
+
+# ── Run lifecycle ────────────────────────────────────────────────────────
+
+
+@dataclass
+class RunContext:
+    run_id: str | None
+    capability: str | None
+    workspace: Path
+    user_email: str | None
+    proxy_tokens: list[str] = field(default_factory=list)
+    sub_proxy_tokens: list[str] = field(default_factory=list)
+
+    @property
+    def worker_env_extra(self) -> dict[str, str]:
+        extra = {
+            "LOMA_BROKER_URL": broker_url(),
+            "LOMA_GATEWAY_URL": gateway_base_url(),
+        }
+        if self.run_id:
+            extra["LOMA_RUN_ID"] = self.run_id
+        if self.capability:
+            # The run capability is DESIGNED to be handed to the worker: it
+            # is the worker's only broker credential. Delivering it in the
+            # environment keeps it out of prompt text and model context.
+            extra["LOMA_RUN_CAPABILITY"] = self.capability
+        return extra
+
+
+def run_worker_env_extra() -> dict[str, str]:
+    """Worker env additions for a spawn inside the current run context.
+
+    Falls back to the broker/gateway URLs alone (no capability) when no run
+    context is active — such workers get no brokered access (fail closed).
+    """
+    extra = {
+        "LOMA_BROKER_URL": broker_url(),
+        "LOMA_GATEWAY_URL": gateway_base_url(),
+    }
+    ctx = current_run.get()
+    if ctx is not None:
+        if getattr(ctx, "run_id", None):
+            extra["LOMA_RUN_ID"] = ctx.run_id
+        if getattr(ctx, "capability", None):
+            extra["LOMA_RUN_CAPABILITY"] = ctx.capability
+    return extra
+
+
+async def _denied_integration_providers(db, user_email: str) -> set[str]:
+    """Providers whose sharing rules exclude this user (fail closed on error)."""
+    from integrations.access import can_access
+    denied = set(INTEGRATION_TOOLS.values())
+    async for integration in db.integrations.find({"status": "active"}):
+        if await can_access(db, integration, user_email):
+            denied.discard(integration.get("provider"))
+    return denied
+
+
+async def _tool_grants(db, user_email: str) -> list[str]:
+    denied_providers = await _denied_integration_providers(db, user_email)
+    tools = set(PERSONAL_TOOLS) | set(UTILITY_TOOLS)
+    for tool, provider in INTEGRATION_TOOLS.items():
+        if provider not in denied_providers:
+            tools.add(tool)
+    return sorted(tools)
+
+
+async def start_run(user_email: str | None, *, source: str = "run") -> RunContext:
+    """Create a workspace and (when the run has an owner) a run capability.
+
+    Runs without an authenticated owner (e.g. anonymous webhooks) get a
+    workspace but no capability: every brokered operation fails closed.
+    """
+    workspace = worker_mod.create_workspace(prefix=source)
+    worker_mod.populate_tool_shims(workspace, sorted(ALL_TOOLS))
+
+    if not user_email or not controller_ready():
+        if user_email and not controller_ready():
+            logger.error(
+                "Execution controller unavailable — run for %s proceeds with "
+                "NO tool/credential access (fail closed)", user_email,
+            )
+        return RunContext(run_id=None, capability=None, workspace=workspace,
+                          user_email=user_email)
+
+    broker = get_broker()
+    grants: dict = {"tool.invoke": await _tool_grants(broker.db, user_email)}
+    from integrations.access import can_access
+    from integrations.registry import PROVIDER_CATALOG
+    mcp_grants = []
+    async for integration in broker.db.integrations.find({"status": "active"}):
+        if await can_access(broker.db, integration, user_email):
+            provider = integration["provider"]
+            mcp_grants.append(PROVIDER_CATALOG.get(provider, {}).get("mcp_server_name") or provider)
+    for provider in ("grain", "hubspot", "notion"):
+        if await broker.db.oauth_tokens.find_one({"provider": provider, "user_email": user_email}):
+            mcp_grants.append(PROVIDER_CATALOG.get(provider, {}).get("mcp_server_name") or provider)
+    if mcp_grants:
+        grants["mcp.request"] = sorted(set(mcp_grants))
+    providers = configured_model_providers()
+    if providers:
+        grants["model.request"] = sorted(providers)
+    # Subscription-account gateway admission (revocation/budget per call).
+    grants["subscription.request"] = sorted(SubscriptionRequest.RESOURCES)
+
+    ttl = int(os.environ.get("LOMA_RUN_TTL_SECONDS", "3600"))
+    max_calls = int(os.environ.get("LOMA_RUN_MAX_CALLS", "500"))
+    try:
+        run_id, capability = await broker.issue(
+            user_email=user_email, grants=grants,
+            ttl_seconds=ttl, max_calls=max_calls,
+        )
+    except Exception:
+        # Inactive user, DB failure, invalid grants: fail closed with no
+        # capability rather than falling back to ambient credentials.
+        logger.exception("Capability issuance failed for %s — run gets no tool access", user_email)
+        return RunContext(run_id=None, capability=None, workspace=workspace,
+                          user_email=user_email)
+    return RunContext(run_id=run_id, capability=capability, workspace=workspace,
+                      user_email=user_email)
+
+
+async def end_run(ctx: RunContext) -> None:
+    """Revoke the run's capability and proxy tokens; clean its workspace."""
+    if ctx is None:
+        return
+    if ctx.run_id and controller_ready():
+        try:
+            await get_broker().revoke(ctx.run_id)
+        except Exception:
+            logger.exception("Failed to revoke run %s", ctx.run_id)
+    if ctx.proxy_tokens and _registry is not None:
+        for token in ctx.proxy_tokens:
+            _registry.revoke(token)
+    if getattr(ctx, "sub_proxy_tokens", None) and _sub_registry is not None:
+        for token in ctx.sub_proxy_tokens:
+            _sub_registry.revoke(token)
+    worker_mod.cleanup_workspace(ctx.workspace)
+
+
+# ── Worker-facing MCP config rewriting ───────────────────────────────────
+
+
+def proxy_mcp_servers_for_worker(mcp_servers: dict) -> tuple[dict, list[str], list[str]]:
+    """Rewrite an MCP server config so no credentials enter the worker.
+
+    HTTP-type servers are re-pointed at the gateway with a revocable proxy
+    token; their real URL + auth headers stay server-side. Stdio servers
+    (which would carry credentials in env vars inside the worker) are
+    DISABLED in isolated mode — fail closed, never a silent org-credential
+    fallback.
+
+    Returns (proxied_config, proxy_tokens, disabled_server_names).
+    """
+    registry = get_proxy_registry()
+    ctx = current_run.get()
+    if ctx is None or not ctx.capability:
+        return {}, [], sorted(mcp_servers or {})
+    proxied: dict = {}
+    tokens: list[str] = []
+    disabled: list[str] = []
+    for name, conf in (mcp_servers or {}).items():
+        if not isinstance(conf, dict):
+            continue
+        server_type = conf.get("type")
+        if server_type in ("http", "sse", "remote", "streamable-http") and conf.get("url"):
+            try:
+                token = registry.register(name, conf["url"], conf.get("headers"), capability=ctx.capability)
+            except Exception:
+                logger.warning("MCP server %s could not be proxied; disabling for workers", name)
+                disabled.append(name)
+                continue
+            tokens.append(token)
+            ctx.proxy_tokens.append(token)
+            proxied[name] = {
+                "type": "http",
+                "url": f"{gateway_base_url()}/mcp/{token}",
+            }
+        else:
+            disabled.append(name)
+    if disabled:
+        logger.info(
+            "Isolated worker mode: MCP servers disabled pending broker support: %s",
+            sorted(disabled),
+        )
+    return proxied, tokens, disabled

--- a/broker/credential_files.py
+++ b/broker/credential_files.py
@@ -1,0 +1,32 @@
+"""Reclaim legacy worker-readable account directories for the trusted backend."""
+import os
+import stat
+
+from broker.service import Denied
+
+
+def protect_account_directory(path):
+    """Remove traversal by old worker UIDs before starting any new worker.
+
+    Open without following a final symlink; tighten ownership/mode through the
+    descriptor. A non-root backend may only secure directories it already owns.
+    This cannot revoke file descriptors held by processes from an older deploy;
+    those processes must be stopped during upgrade.
+    """
+    fd = None
+    try:
+        fd = os.open(path, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+        info = os.fstat(fd)
+        if not stat.S_ISDIR(info.st_mode):
+            raise Denied()
+        uid = os.geteuid()
+        if info.st_uid != uid:
+            if uid != 0:
+                raise Denied()
+            os.fchown(fd, uid, os.getegid())
+        os.fchmod(fd, 0o700)
+    except Exception:
+        raise Denied() from None
+    finally:
+        if fd is not None:
+            os.close(fd)

--- a/broker/gateway.py
+++ b/broker/gateway.py
@@ -1,0 +1,422 @@
+"""Credential-injection gateway for isolated workers.
+
+Workers never receive org integration keys, per-user OAuth tokens, or model
+provider API keys. Instead:
+
+- **MCP proxying** — HTTP MCP servers configured for a run are registered
+  here with their real upstream URL + auth headers. The worker's MCP config
+  points at ``/mcp/{proxy_token}`` with no real credentials; the gateway
+  validates the unguessable, revocable proxy token, strips client-supplied
+  auth headers, and forwards with the registered headers injected.
+  Stdio MCP servers cannot be proxied and are disabled in isolated mode
+  (fail closed — never a silent fallback to org credentials).
+
+- **Model proxying** — workers reach ``/model/{provider}/...`` with their
+  run capability as the bearer token. The gateway asks the broker to admit
+  the call (operation ``model.request``), then forwards to the pinned
+  upstream with the server-side API key injected.
+
+Bind this app to loopback (or a private, TLS-protected network in
+distributed deployments). It must never be exposed publicly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import secrets
+import time
+from pathlib import Path
+from urllib.parse import urlsplit
+
+import aiohttp
+from aiohttp import web
+
+from broker.service import Denied
+
+logger = logging.getLogger(__name__)
+
+_MAX_BODY = 32 * 1024 * 1024
+_UPSTREAM_TIMEOUT = aiohttp.ClientTimeout(total=600, sock_connect=30)
+
+# Headers never forwarded from the worker to an upstream.
+_STRIP_REQUEST_HEADERS = {
+    "authorization", "proxy-authorization", "cookie", "host",
+    "content-length", "transfer-encoding", "connection", "x-api-key",
+    "chatgpt-account-id", "openai-organization", "openai-project",
+}
+_STRIP_RESPONSE_HEADERS = {
+    "content-length", "transfer-encoding", "connection", "set-cookie",
+}
+
+# Pinned model provider upstreams and their credential injection.
+MODEL_PROVIDERS = {
+    "anthropic": {
+        "upstream": "https://api.anthropic.com",
+        "env_key": "ANTHROPIC_API_KEY",
+        "header": "x-api-key",
+        "prefix": "",
+    },
+    "openai": {
+        "upstream": "https://api.openai.com",
+        "env_key": "OPENAI_API_KEY",
+        "header": "Authorization",
+        "prefix": "Bearer ",
+    },
+    "openrouter": {
+        "upstream": "https://openrouter.ai/api",
+        "env_key": "OPENROUTER_API_KEY",
+        "header": "Authorization",
+        "prefix": "Bearer ",
+    },
+    "opencode": {
+        "upstream": "https://opencode.ai/zen/v1",
+        "env_key": "OPENCODE_API_KEY",
+        "header": "Authorization",
+        "prefix": "Bearer ",
+    },
+}
+
+
+def configured_model_providers() -> set[str]:
+    """Providers with a server-side credential available for injection."""
+    return {
+        name for name, conf in MODEL_PROVIDERS.items()
+        if os.environ.get(conf["env_key"], "").strip()
+    }
+
+
+def gateway_base_url() -> str:
+    host = os.environ.get("LOMA_GATEWAY_HOST", "127.0.0.1")
+    port = int(os.environ.get("LOMA_GATEWAY_PORT", "3101"))
+    return f"http://{host}:{port}"
+
+
+class McpProxyRegistry:
+    """Server-side registry of MCP upstreams keyed by unguessable tokens.
+
+    Registered by the trusted controller when it builds a worker's MCP
+    config; revoked when the owning client/run is discarded. The upstream
+    URL and headers stay in backend memory only.
+    """
+
+    def __init__(self):
+        self._entries: dict[str, dict] = {}
+
+    def register(self, server_name: str, url: str, headers: dict | None,
+                 *, ttl_seconds: int = 24 * 3600, capability: str | None = None) -> str:
+        if not isinstance(url, str):
+            raise Denied()
+        try:
+            parsed = urlsplit(url)
+            if (not parsed.hostname or parsed.username is not None or parsed.password is not None
+                    or parsed.fragment or any(c.isspace() for c in url)):
+                raise Denied()
+            if parsed.scheme != "https" and not (
+                parsed.scheme == "http" and parsed.hostname in {"127.0.0.1", "localhost", "::1"}
+            ):
+                raise Denied()
+            parsed.port  # Validate a supplied port before issuing a capability.
+        except ValueError as exc:
+            raise Denied() from exc
+        token = "loma_mcpproxy_" + secrets.token_urlsafe(24)
+        self._entries[token] = {
+            "name": server_name,
+            "capability": capability,
+            "url": url.rstrip("/"),
+            "headers": dict(headers or {}),
+            "expires_at": time.monotonic() + ttl_seconds,
+        }
+        return token
+
+    def revoke(self, token: str) -> None:
+        self._entries.pop(token, None)
+
+    def lookup(self, token: str) -> dict:
+        entry = self._entries.get(token)
+        if not entry or entry["expires_at"] <= time.monotonic():
+            self._entries.pop(token, None)
+            raise Denied()
+        return entry
+
+
+# Pinned upstreams for subscription-account proxying. Only providers whose
+# CLI can be redirected at the protocol level appear here.
+SUBSCRIPTION_UPSTREAMS = {
+    "claude": "https://api.anthropic.com",
+    "codex": "https://chatgpt.com/backend-api/codex",
+}
+
+
+class SubscriptionProxyRegistry:
+    """Run-scoped proxies for pooled subscription-account auth.
+
+    A worker never holds the subscription credential. It gets the gateway
+    base URL plus an unguessable, revocable proxy token; on each request the
+    gateway re-admits the run via the broker (``subscription.request``),
+    reads the account's CURRENT auth material server-side, and injects it
+    upstream. Tokens are revoked when the run ends.
+    """
+
+    def __init__(self):
+        self._entries: dict[str, dict] = {}
+
+    def register(self, provider: str, credentials_path: str | Path, *,
+                 capability: str, ttl_seconds: int = 24 * 3600) -> str:
+        if provider not in SUBSCRIPTION_UPSTREAMS or not capability:
+            raise Denied()
+        token = "loma_subproxy_" + secrets.token_urlsafe(24)
+        self._entries[token] = {
+            "provider": provider,
+            "credentials_path": str(credentials_path),
+            "capability": capability,
+            "expires_at": time.monotonic() + ttl_seconds,
+        }
+        return token
+
+    def revoke(self, token: str) -> None:
+        self._entries.pop(token, None)
+
+    def lookup(self, token: str) -> dict:
+        entry = self._entries.get(token)
+        if not entry or entry["expires_at"] <= time.monotonic():
+            self._entries.pop(token, None)
+            raise Denied()
+        return entry
+
+
+def _claude_subscription_auth(credentials_path: str) -> tuple[str, str]:
+    """Read the CURRENT Claude subscription access token server-side.
+
+    Returns (access_token, oauth_beta_flag). Raises Denied when the account
+    has no usable auth material — never falls back to another credential.
+    """
+    try:
+        data = json.loads(Path(credentials_path).read_text())
+    except (OSError, ValueError) as exc:
+        raise Denied() from exc
+    if not isinstance(data, dict):
+        raise Denied()
+    oauth = data.get("claudeAiOauth") or {}
+    if not isinstance(oauth, dict):
+        raise Denied()
+    access_token = oauth.get("accessToken") or ""
+    if not isinstance(access_token, str) or not access_token:
+        raise Denied()
+    expires_at = oauth.get("expiresAt")
+    if isinstance(expires_at, (int, float)) and expires_at / 1000 < time.time():
+        raise Denied()
+    return access_token, "oauth-2025-04-20"
+
+
+def _codex_subscription_auth(credentials_path: str) -> dict[str, str]:
+    """Read subscription auth only in the backend; never fall back to API billing."""
+    try:
+        data = json.loads(Path(credentials_path).read_text())
+        tokens = data.get("tokens") if isinstance(data, dict) else None
+        if not isinstance(tokens, dict):
+            raise Denied()
+        access_token = tokens.get("access_token")
+        account_id = tokens.get("account_id")
+        if not all(isinstance(v, str) and v and "\r" not in v and "\n" not in v
+                   for v in (access_token, account_id)):
+            raise Denied()
+        return {"Authorization": "Bearer " + access_token, "ChatGPT-Account-Id": account_id}
+    except (OSError, ValueError) as exc:
+        raise Denied() from exc
+
+
+def create_gateway_app(broker, registry: McpProxyRegistry,
+                       sub_registry: "SubscriptionProxyRegistry | None" = None) -> web.Application:
+    async def _forward(request: web.Request, upstream_url: str,
+                       inject_headers: dict[str, str], recover_auth=None) -> web.StreamResponse:
+        headers = {
+            key: value for key, value in request.headers.items()
+            if key.lower() not in _STRIP_REQUEST_HEADERS
+        }
+        headers.update(inject_headers)
+        body = await request.read()
+        if len(body) > _MAX_BODY:
+            return web.json_response({"error": "Request too large"}, status=413)
+
+        async with aiohttp.ClientSession(
+            timeout=_UPSTREAM_TIMEOUT, trust_env=False, auto_decompress=False,
+        ) as session:
+            # Retry only a pre-stream authentication rejection, never a timeout,
+            # transport failure, 403, 429 or a response that has begun streaming.
+            for attempt in range(2):
+                async with session.request(
+                    request.method, upstream_url, data=body or None,
+                    headers=headers, allow_redirects=False,
+                ) as upstream:
+                    if upstream.status == 401 and recover_auth is not None and attempt == 0:
+                        upstream.close()
+                        headers.update(await recover_auth(headers))
+                        continue
+                    response = web.StreamResponse(status=upstream.status)
+                    for key, value in upstream.headers.items():
+                        if key.lower() not in _STRIP_RESPONSE_HEADERS:
+                            response.headers[key] = value
+                    response.headers["Cache-Control"] = "no-store"
+                    await response.prepare(request)
+                    async for chunk in upstream.content.iter_chunked(65536):
+                        await response.write(chunk)
+                    await response.write_eof()
+                    return response
+
+    async def mcp_proxy(request: web.Request) -> web.StreamResponse:
+        try:
+            entry = registry.lookup(request.match_info["token"])
+            if not entry.get("capability"):
+                raise Denied()
+            await asyncio.wait_for(broker.execute(
+                entry["capability"], "mcp.request", entry["name"],
+            ), timeout=15)
+        except Denied:
+            return web.json_response({"error": "Access denied"}, status=403)
+        except Exception:
+            return web.json_response({"error": "Authorization unavailable"}, status=503)
+        # A transport grant is for one endpoint, not an authenticated proxy
+        # for every route on that host. Static configured queries are kept;
+        # callers cannot append a route, query, or arbitrary HTTP operation.
+        if request.match_info.get("tail") or request.query_string or request.method not in {"GET", "POST", "DELETE"}:
+            return web.json_response({"error": "Unsupported MCP transport request"}, status=403)
+        upstream_url = entry["url"]
+        try:
+            return await _forward(request, upstream_url, entry["headers"])
+        except Exception:
+            # Never relay upstream/connection error text (may embed secrets).
+            return web.json_response({"error": "Upstream unavailable"}, status=502)
+
+    async def model_proxy(request: web.Request) -> web.StreamResponse:
+        provider = request.match_info["provider"]
+        conf = MODEL_PROVIDERS.get(provider)
+        auth = request.headers.get("Authorization", "")
+        token = auth[7:] if auth.startswith("Bearer ") else request.headers.get("x-api-key", "")
+        if conf is None:
+            return web.json_response({"error": "Unknown model provider"}, status=403)
+        api_key = os.environ.get(conf["env_key"], "").strip()
+        if not api_key:
+            return web.json_response(
+                {"error": f"Model provider {provider} is not configured on this deployment"},
+                status=403,
+            )
+        try:
+            await asyncio.wait_for(
+                broker.execute(token, "model.request", provider), timeout=15,
+            )
+        except Denied:
+            return web.json_response({"error": "Access denied"}, status=403)
+        except Exception:
+            # Fail closed on any admission-path failure.
+            return web.json_response({"error": "Broker unavailable"}, status=503)
+
+        tail = request.match_info.get("tail", "")
+        inference_paths = {
+            "anthropic": {"v1/messages", "v1/messages/count_tokens"},
+            "openai": {"v1/responses", "v1/responses/compact", "v1/chat/completions"},
+            "openrouter": {"v1/chat/completions", "v1/responses"},
+            "opencode": {"chat/completions", "responses", "messages", "messages/count_tokens"},
+        }
+        model_path = "models" if provider == "opencode" else "v1/models"
+        allowed = ((request.method == "POST" and tail in inference_paths[provider])
+                   or (request.method == "GET" and tail == model_path))
+        allowed_query = {"beta"} if provider == "anthropic" else set()
+        if not allowed or set(request.query) - allowed_query:
+            return web.json_response({"error": "Unsupported model operation"}, status=403)
+        upstream_url = conf["upstream"].rstrip("/") + (f"/{tail}" if tail else "")
+        if request.query_string:
+            upstream_url += f"?{request.query_string}"
+        try:
+            return await _forward(
+                request, upstream_url, {conf["header"]: conf["prefix"] + api_key},
+            )
+        except Exception:
+            return web.json_response({"error": "Upstream unavailable"}, status=502)
+
+    async def subscription_proxy(request: web.Request) -> web.StreamResponse:
+        if sub_registry is None:
+            return web.json_response({"error": "Subscription proxy unavailable"}, status=503)
+        try:
+            entry = sub_registry.lookup(request.match_info["token"])
+            if not entry.get("capability"):
+                raise Denied()
+            await asyncio.wait_for(broker.execute(
+                    entry["capability"], "subscription.request", entry["provider"],
+                ), timeout=15)
+        except Denied:
+            return web.json_response({"error": "Access denied"}, status=403)
+        except Exception:
+            return web.json_response({"error": "Authorization unavailable"}, status=503)
+
+        tail = request.match_info.get("tail", "")
+        allowed_paths = {"claude": {"v1/messages", "v1/messages/count_tokens"},
+                         "codex": {"responses", "responses/compact"}}
+        if request.method != "POST" or tail not in allowed_paths.get(entry["provider"], set()):
+            return web.json_response({"error": "Access denied"}, status=403)
+        allowed_query = {"beta"} if entry["provider"] == "claude" else set()
+        if set(request.query) - allowed_query:
+            return web.json_response({"error": "Access denied"}, status=403)
+        try:
+            from broker.subscription_refresh import ensure_fresh
+            refreshed = await ensure_fresh(entry["provider"], entry["credentials_path"])
+            # Refresh can take time. Recheck revocation and admission before using
+            # the renewed credential for a request whose permission may have changed.
+            sub_registry.lookup(request.match_info["token"])
+            if refreshed:
+                await asyncio.wait_for(broker.execute(
+                    entry["capability"], "subscription.request", entry["provider"],
+                ), timeout=15)
+            if entry["provider"] == "codex":
+                inject = _codex_subscription_auth(entry["credentials_path"])
+            else:
+                access_token, beta_flag = _claude_subscription_auth(entry["credentials_path"])
+                inject = {"Authorization": f"Bearer {access_token}"}
+                existing_beta = request.headers.get("anthropic-beta", "")
+                inject["anthropic-beta"] = ",".join(dict.fromkeys(
+                    [*filter(None, existing_beta.split(",")), beta_flag]))
+        except Denied:
+            return web.json_response(
+                {"error": "Subscription auth is unavailable for this account"}, status=503)
+        except Exception:
+            return web.json_response({"error": "Subscription auth unavailable"}, status=503)
+        tail = request.match_info.get("tail", "")
+        upstream_url = SUBSCRIPTION_UPSTREAMS[entry["provider"]].rstrip("/")
+        if tail:
+            upstream_url += f"/{tail}"
+        if request.query_string:
+            upstream_url += f"?{request.query_string}"
+        async def recover_auth(sent_headers):
+            # Admission happens before credential access AND after a potentially
+            # slow refresh. Revoking either the proxy or run stops the replay.
+            sub_registry.lookup(request.match_info["token"])
+            await asyncio.wait_for(broker.execute(
+                entry["capability"], "subscription.request", entry["provider"],
+            ), timeout=15)
+            await ensure_fresh(entry["provider"], entry["credentials_path"],
+                               rejected_access_token=sent_headers["Authorization"][7:])
+            sub_registry.lookup(request.match_info["token"])
+            await asyncio.wait_for(broker.execute(
+                entry["capability"], "subscription.request", entry["provider"],
+            ), timeout=15)
+            if entry["provider"] == "codex":
+                return _codex_subscription_auth(entry["credentials_path"])
+            access, _ = _claude_subscription_auth(entry["credentials_path"])
+            return {"Authorization": f"Bearer {access}"}
+
+        try:
+            return await _forward(request, upstream_url, inject, recover_auth=recover_auth)
+        except Exception:
+            # Never relay upstream/connection error text (may embed secrets).
+            return web.json_response({"error": "Upstream unavailable"}, status=502)
+
+    app = web.Application(client_max_size=_MAX_BODY)
+    app.router.add_route("*", "/mcp/{token}", mcp_proxy)
+    app.router.add_route("*", "/mcp/{token}/{tail:.*}", mcp_proxy)
+    app.router.add_route("*", "/model/{provider}/{tail:.*}", model_proxy)
+    app.router.add_route("*", "/model/{provider}", model_proxy)
+    app.router.add_route("*", "/sub/{token}", subscription_proxy)
+    app.router.add_route("*", "/sub/{token}/{tail:.*}", subscription_proxy)
+    return app

--- a/broker/grain.py
+++ b/broker/grain.py
@@ -1,0 +1,57 @@
+"""Narrow read-only Grain adapter; personal OAuth only, no org fallback.
+
+Contract: https://developers.grain.com/ (v2 transcript text endpoint).
+Expired tokens fail closed until a trusted refresh service is integrated.
+"""
+import re
+from datetime import datetime, timezone
+
+import aiohttp
+
+from api.oauth_helpers import decrypt_token
+from broker.service import Denied
+from utils.secret_redaction import redact_secrets
+
+MAX_TRANSCRIPT_BYTES = 1024 * 1024
+
+
+class GrainTranscript:
+    @staticmethod
+    def valid_resource(value):
+        return isinstance(value, str) and bool(re.fullmatch(
+            r"[a-f0-9]{8}(?:-[a-f0-9]{4}){3}-[a-f0-9]{12}", value,
+        ))
+
+    async def execute(self, db, email, recording_id):
+        if not self.valid_resource(recording_id):
+            raise Denied()
+        # Read on every invocation; deleting a connection revokes future access.
+        doc = await db.oauth_tokens.find_one({"user_email": email, "provider": "grain"})
+        if not doc:
+            raise Denied()
+        expiry = doc.get("token_expiry")
+        if expiry is not None and expiry.replace(tzinfo=timezone.utc) <= datetime.now(timezone.utc):
+            raise Denied()
+        token = decrypt_token(doc["access_token"])
+        if not token:
+            raise Denied()
+        # No worker-supplied hosts, methods, paths, query strings, or headers.
+        url = f"https://api.grain.com/_/public-api/v2/recordings/{recording_id}/transcript.txt"
+        async with aiohttp.ClientSession(
+            trust_env=False, timeout=aiohttp.ClientTimeout(total=30),
+            auto_decompress=False,
+        ) as session:
+            async with session.get(url, headers={
+                "Authorization": f"Bearer {token}", "Public-Api-Version": "2025-10-31",
+                "Accept-Encoding": "identity",
+            }, allow_redirects=False) as response:
+                if response.status != 200 or response.headers.get("Content-Encoding", "identity") != "identity":
+                    raise Denied()
+                chunks = bytearray()
+                async for chunk in response.content.iter_chunked(65536):
+                    chunks.extend(chunk)
+                    if len(chunks) > MAX_TRANSCRIPT_BYTES:
+                        raise Denied()
+        # Defense in depth for an upstream echo. Do not relay provider headers.
+        transcript = chunks.decode("utf-8").replace(token, "[REDACTED]")
+        return {"recording_id": recording_id, "transcript": redact_secrets(transcript)}

--- a/broker/http.py
+++ b/broker/http.py
@@ -1,0 +1,47 @@
+"""Dedicated worker-facing app. Do not mount on the public backend router.
+
+Deploy behind a private TLS/mTLS gateway with per-worker network admission and
+rate limits. No mint/revoke routes and no X-User-Email or browser authentication.
+"""
+import asyncio
+import json
+
+from aiohttp import web
+
+from broker.service import Denied
+from utils.secret_redaction import redact_secrets
+
+
+def create_app(broker):
+    async def invoke(request):
+        try:
+            auth = request.headers.get("Authorization", "")
+            if not auth.startswith("Bearer "):
+                raise Denied()
+            token = auth[7:]
+            body = await request.json()
+            if (not isinstance(body, dict)
+                    or not {"operation", "resource"} <= set(body)
+                    or set(body) - {"operation", "resource", "params"}):
+                return web.json_response({"error": "Invalid request"}, status=400)
+            result = await asyncio.wait_for(broker.execute(
+                token, body["operation"], body["resource"], body.get("params"),
+            ), timeout=240)
+            # Capabilities must not reappear in provider-generated output.
+            encoded = json.dumps(redact_secrets(result), allow_nan=False).replace(token, "[REDACTED]")
+            return web.Response(text=encoded, content_type="application/json",
+                                headers={"Cache-Control": "no-store"})
+        except Denied:
+            return web.json_response({"error": "Access denied"}, status=403)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return web.json_response({"error": "Invalid request"}, status=400)
+        except web.HTTPRequestEntityTooLarge:
+            return web.json_response({"error": "Request too large"}, status=413)
+        except Exception:
+            # Never relay/log exception strings: they may include URLs or tokens.
+            return web.json_response({"error": "Broker unavailable"}, status=503)
+
+    # Sized for tool invocations that upload small workspace files inline.
+    app = web.Application(client_max_size=2 * 1024 * 1024)
+    app.router.add_post("/v1/invoke", invoke)
+    return app

--- a/broker/operations.py
+++ b/broker/operations.py
@@ -1,0 +1,363 @@
+"""Broker operations for isolated workers.
+
+Workers hold no credentials and no database access. Every tool invocation is
+forwarded to the broker, which authenticates the run capability, enforces the
+grant, and executes the real tool **server-side** with the run owner's
+identity. Credentials (OAuth tokens, integration API keys, the encryption
+key, the database URI) never enter a worker process.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import binascii
+import logging
+import os
+import sys
+import signal
+import stat
+import tempfile
+from pathlib import Path
+
+from broker.service import Denied
+from broker.tool_policy import prepare_argv, command_spec, output_paths
+
+logger = logging.getLogger(__name__)
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+# Tools that authenticate the acting user via --user-email/--auth-token.
+# The broker always injects server-minted values for these; worker-supplied
+# identity flags are stripped unconditionally for every tool.
+AUTH_TOOLS = frozenset({
+    "gmail", "google_drive", "google_calendar", "google_sheets",
+    "google_slides", "google_docs_personal", "google_apps_script",
+    "slack_user", "telegram", "notify", "loma_skills", "grain", "agreement_review", "diagrams",
+})
+
+# Personal tools: always grantable to an active user (each tool fails closed
+# if that user has no connection for the underlying account).
+PERSONAL_TOOLS = frozenset(AUTH_TOOLS)
+
+# Integration-backed CLI tools -> provider key in db.integrations. Grants are
+# filtered by integration sharing rules at issue time; the tool itself loads
+# the org credential server-side (never in the worker).
+INTEGRATION_TOOLS = {
+    "apollo": "apollo",
+    "ashby": "ashby",
+    "cdn_upload": "cdn_r2",
+    "dataroom": "dataroom",
+    "github_pr_resolve": "github",
+    "grafana": "grafana",
+    "linear": "linear",
+    "monetize_now": "monetize_now",
+    "phantombuster": "phantombuster",
+    "posthog": "posthog",
+    "pylon": "pylon",
+    "sentry": "sentry",
+    "slack_reader": "slack_bot",
+    "stitch": "stitch",
+    "zoho_books": "zoho_books",
+}
+
+# Credential-free utility tools (run server-side for consistency; their file
+# outputs land in backend temp paths that file delivery already serves).
+UTILITY_TOOLS = frozenset({"pptx_creator"})
+
+ALL_TOOLS = frozenset(PERSONAL_TOOLS) | frozenset(INTEGRATION_TOOLS) | UTILITY_TOOLS
+
+_MAX_ARGV_ITEMS = 64
+_MAX_ARG_CHARS = 20_000
+_MAX_ARGV_CHARS = 200_000
+_MAX_FILES = 8
+_MAX_FILES_CHARS = 1_500_000
+_MAX_OUTPUT_BYTES = 1_000_000
+_TOOL_TIMEOUT_SECONDS = 180
+
+
+class ToolOutputLimit(RuntimeError):
+    pass
+
+
+async def _collect_tool_output(process, input_data=None):
+    async def bounded_read(stream):
+        data = bytearray()
+        while chunk := await stream.read(65536):
+            data.extend(chunk)
+            if len(data) > _MAX_OUTPUT_BYTES:
+                raise ToolOutputLimit()
+        return bytes(data)
+
+    tasks = [asyncio.create_task(bounded_read(process.stdout)),
+             asyncio.create_task(bounded_read(process.stderr)),
+             asyncio.create_task(process.wait())]
+    async def write_input():
+        try:
+            process.stdin.write(input_data)
+            await process.stdin.drain()
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+        finally:
+            process.stdin.close()
+    if input_data is not None:
+        tasks.append(asyncio.create_task(write_input()))
+    try:
+        results = await asyncio.gather(*tasks)
+        return results[0], results[1]
+    finally:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+async def _terminate_tool(process):
+    # Each tool is a session leader. Stop descendants as well as the CLI.
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    await process.wait()
+
+
+def _strip_identity_flags(argv: list[str]) -> list[str]:
+    """Remove any worker-supplied --user-email/--auth-token pairs."""
+    cleaned: list[str] = []
+    skip = False
+    for arg in argv:
+        if skip:
+            skip = False
+            continue
+        if arg.startswith(("--user-email=", "--auth-token=")):
+            continue
+        if arg in ("--user-email", "--auth-token"):
+            skip = True
+            continue
+        cleaned.append(arg)
+    return cleaned
+
+
+class ToolInvoke:
+    """Execute a first-party Loma CLI tool server-side for the run owner."""
+
+    accepts_params = True
+
+    @staticmethod
+    def valid_resource(value) -> bool:
+        return isinstance(value, str) and value in ALL_TOOLS
+
+    @staticmethod
+    def _validate_params(params) -> tuple[list[str], dict[str, str]]:
+        if not isinstance(params, dict) or set(params) - {"argv", "files", "stdin"}:
+            raise Denied()
+        stdin = params.get("stdin", "")
+        if not isinstance(stdin, str) or len(stdin.encode("utf-8")) > 200_000:
+            raise Denied()
+        argv = params.get("argv", [])
+        files = params.get("files", {})
+        if (not isinstance(argv, list) or len(argv) > _MAX_ARGV_ITEMS
+                or not all(isinstance(a, str) and len(a) <= _MAX_ARG_CHARS for a in argv)
+                or sum(len(a) for a in argv) > _MAX_ARGV_CHARS):
+            raise Denied()
+        if (not isinstance(files, dict) or len(files) > _MAX_FILES
+                or not all(isinstance(k, str) and 0 < len(k) <= 4096 for k in files)):
+            raise Denied()
+        decoded = {}
+        total = 0
+        for name, value in files.items():
+            if isinstance(value, str):
+                content = value.encode("utf-8")
+            elif (isinstance(value, dict) and set(value) == {"encoding", "data"}
+                  and value["encoding"] == "base64" and isinstance(value["data"], str)
+                  and len(value["data"]) <= _MAX_FILES_CHARS * 4 // 3 + 4):
+                try:
+                    content = base64.b64decode(value["data"], validate=True)
+                except (ValueError, binascii.Error) as exc:
+                    raise Denied() from exc
+            else:
+                raise Denied()
+            total += len(content)
+            if total > _MAX_FILES_CHARS:
+                raise Denied()
+            decoded[name] = content
+        return argv, decoded
+
+    async def execute(self, db, email, tool_name, params=None):
+        if not self.valid_resource(tool_name):
+            raise Denied()
+        if tool_name in INTEGRATION_TOOLS:
+            from integrations.access import require_provider
+            await require_provider(db, INTEGRATION_TOOLS[tool_name], email)
+        argv, files = self._validate_params(params)
+        argv = _strip_identity_flags(argv)
+
+        # Validate before touching disk or invoking privileged backend tools.
+        outputs = output_paths(tool_name, argv)
+        if set(outputs) & set(files):
+            raise Denied()
+        argv = prepare_argv(tool_name, argv, {key: key for key in [*files, *outputs]})
+        stdin = params.get("stdin", "")
+        if stdin and not command_spec(tool_name, argv)[0].stdin:
+            raise Denied()
+
+        script = PROJECT_ROOT / "tools" / f"{tool_name}.py"
+        if not script.is_file():
+            return {"exit_code": 1, "stdout": "",
+                    "stderr": f"Tool {tool_name} is not available on this deployment."}
+
+        tmp_dir = None
+        identity_token = None
+        artifacts = {}
+        output_mapping = {}
+        try:
+            # Only request-owned uploads may become local CLI inputs.
+            if files or outputs:
+                tmp_dir = tempfile.mkdtemp(prefix="loma-broker-files-")
+                os.chmod(tmp_dir, 0o700)
+                mapping: dict[str, str] = {}
+                for index, (worker_path, content) in enumerate(files.items()):
+                    suffix = Path(worker_path).suffix
+                    if not suffix.isascii() or not suffix[1:].isalnum() or len(suffix) > 12:
+                        suffix = ""
+                    local = os.path.join(tmp_dir, f"input-{index}{suffix}")
+                    with open(local, "wb") as fh:
+                        fh.write(content)
+                    mapping[worker_path] = local
+                for index, worker_path in enumerate(outputs):
+                    suffix = Path(worker_path).suffix
+                    if not suffix.isascii() or not suffix[1:].isalnum() or len(suffix) > 12:
+                        suffix = ""
+                    local = os.path.join(tmp_dir, f"output-{index}{suffix}")
+                    mapping[worker_path] = local
+                    output_mapping[worker_path] = local
+                argv = prepare_argv(tool_name, argv, mapping)
+
+            if tool_name in AUTH_TOOLS or tool_name in INTEGRATION_TOOLS:
+                from tools._auth_token import create_user_auth_token
+                identity_token = create_user_auth_token(email)
+                # argparse Google tools require the token before the subcommand.
+                if tool_name in {'agreement_review', 'diagrams'}:
+                    # This CLI declares identity arguments on its subparsers.
+                    argv = [*argv, "--auth-token", identity_token, "--user-email", email]
+                else:
+                    argv = ["--auth-token", identity_token, *argv, "--user-email", email]
+
+            process = await asyncio.create_subprocess_exec(
+                sys.executable, str(script), *argv,
+                cwd=str(PROJECT_ROOT), start_new_session=True,
+                stdin=asyncio.subprocess.PIPE if stdin else asyncio.subprocess.DEVNULL,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            try:
+                stdout, stderr = await asyncio.wait_for(
+                    _collect_tool_output(process, stdin.encode("utf-8")) if stdin else _collect_tool_output(process), timeout=_TOOL_TIMEOUT_SECONDS,
+                )
+            except (asyncio.TimeoutError, ToolOutputLimit) as exc:
+                await _terminate_tool(process)
+                return {"exit_code": 124 if isinstance(exc, asyncio.TimeoutError) else 125,
+                        "stdout": "", "stderr": "Tool execution exceeded its time or output limit."}
+            except BaseException:
+                await _terminate_tool(process)
+                raise
+            # Only explicit request-owned outputs can be returned. Never follow
+            # symlinks or accept a CLI's stdout as authority to read a path.
+            total_output = 0
+            for worker_path, local in output_mapping.items():
+                try:
+                    fd = os.open(local, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
+                except FileNotFoundError:
+                    continue
+                with os.fdopen(fd, "rb") as fh:
+                    info = os.fstat(fh.fileno())
+                    if not stat.S_ISREG(info.st_mode) or info.st_nlink != 1:
+                        raise Denied()
+                    content = fh.read(_MAX_FILES_CHARS + 1)
+                total_output += len(content)
+                if total_output > _MAX_FILES_CHARS:
+                    raise Denied()
+                artifacts[worker_path] = {"encoding": "base64", "data": base64.b64encode(content).decode("ascii")}
+        finally:
+            if tmp_dir:
+                import shutil
+                shutil.rmtree(tmp_dir, ignore_errors=True)
+
+        from utils.secret_redaction import redact_secrets
+        def clean_output(data):
+            text = data.decode("utf-8", errors="replace")
+            if identity_token:
+                text = text.replace(identity_token, "[REDACTED]")
+            for worker_path, local in output_mapping.items():
+                text = text.replace(local, worker_path)
+            return redact_secrets(text)
+        return {"exit_code": process.returncode,
+                "stdout": clean_output(stdout), "stderr": clean_output(stderr), "artifacts": artifacts}
+
+
+
+class ModelRequest:
+    """Admission-only operation for the model gateway.
+
+    The gateway calls the broker with this operation before proxying a model
+    request; the operation itself performs no I/O. Providers must be granted
+    at issue time and configured with a server-side credential.
+    """
+
+    def __init__(self, providers: set[str] | None = None):
+        self._providers = set(providers or [])
+
+    def valid_resource(self, value) -> bool:
+        return isinstance(value, str) and value in self._providers
+
+    async def execute(self, db, email, provider):
+        if not self.valid_resource(provider):
+            raise Denied()
+        return {"ok": True, "provider": provider}
+
+
+class SubscriptionRequest:
+    """Admission-only operation for the subscription-credential gateway.
+
+    Checked on every proxied request for a pooled subscription account
+    (Claude today). Performs no I/O itself: admission gives revocation,
+    call-budget, TTL, and active-account semantics per request.
+    """
+
+    RESOURCES = frozenset({"claude", "codex", "opencode"})
+
+    def valid_resource(self, value) -> bool:
+        return isinstance(value, str) and value in self.RESOURCES
+
+    async def execute(self, db, email, provider):
+        if not self.valid_resource(provider):
+            raise Denied()
+        return {"ok": True, "provider": provider}
+
+
+class McpRequest:
+    """Check current provider ownership/sharing before each gateway request."""
+
+    @staticmethod
+    def valid_resource(value):
+        import re
+        return isinstance(value, str) and bool(re.fullmatch(r"[A-Za-z0-9_-]{1,128}", value))
+
+    async def execute(self, db, email, server_name):
+        from integrations.registry import PROVIDER_CATALOG
+        from integrations.access import require_provider
+        provider = next((key for key, entry in PROVIDER_CATALOG.items()
+                         if entry.get("mcp_server_name") == server_name), server_name)
+        if provider in ("grain", "hubspot", "notion"):
+            # Personal providers never silently use an organization connection.
+            from api.oauth_helpers import get_valid_provider_token
+            if not await get_valid_provider_token(email, provider, db=db):
+                raise Denied()
+        else:
+            await require_provider(db, provider, email)
+            doc = await db.integrations.find_one({"provider": provider})
+            if doc and doc.get("is_custom") and doc.get("auth_mode") == "oauth":
+                from api.oauth_helpers import get_valid_custom_mcp_token
+                if not await get_valid_custom_mcp_token(email, provider, db=db):
+                    raise Denied()
+        return {"ok": True}

--- a/broker/sandbox.py
+++ b/broker/sandbox.py
@@ -1,0 +1,215 @@
+"""Trusted OCI supervisor configuration for independent gVisor workers.
+
+No container socket is needed or exposed. The OCI bundle stays backend-owned;
+only a private workspace and two credential-broker sockets cross the boundary.
+The runtime, image, namespace and cgroup requirements are fail-closed.
+"""
+import asyncio
+import json
+import os
+from pathlib import Path
+import secrets
+import shutil
+import stat
+import subprocess
+import sys
+
+from broker.worker import WorkerIsolationError
+
+
+# Development mode exists only for local unit tests / single-user development.
+# The shipping image selects runsc explicitly; it must never fall back at runtime.
+def enabled():
+    mode = os.environ.get('LOMA_WORKER_SANDBOX', 'runsc')
+    if mode not in {'runsc', 'development'}:
+        raise WorkerIsolationError('Unknown worker sandbox mode')
+    if mode == 'development' and os.environ.get('LOMA_ENV') != 'development':
+        raise WorkerIsolationError('Unisolated workers require explicit development mode')
+    return mode == 'runsc'
+
+
+def _trusted_directory(path, *, create=False):
+    path = Path(path)
+    if not path.is_absolute() or '..' in path.parts:
+        raise WorkerIsolationError('Sandbox paths must be absolute')
+    if create:
+        path.mkdir(mode=0o700, parents=True, exist_ok=True)
+    for candidate in [path, *path.parents]:
+        info = candidate.lstat()
+        if not stat.S_ISDIR(info.st_mode) or info.st_uid not in {0, os.geteuid()}:
+            raise WorkerIsolationError('Sandbox control directories must be backend-owned')
+        # /tmp may be sticky; the private leaf must never be writable by others.
+        if info.st_mode & 0o022 and not (candidate != path and info.st_mode & stat.S_ISVTX):
+            raise WorkerIsolationError('Sandbox control directories must not be shared-writable')
+    return path
+
+
+def state_root():
+    return _trusted_directory(os.environ.get('LOMA_SANDBOX_STATE', '/var/lib/loma/sandboxes'), create=True)
+
+
+def socket_root():
+    return _trusted_directory(os.environ.get('LOMA_SANDBOX_SOCKETS', '/run/loma-worker-transports'), create=True)
+
+
+async def serve_transports(broker_runner, gateway_runner):
+    from aiohttp import web
+    root = socket_root()
+    # runsc's trusted gofer traverses this private directory. Workers see only
+    # the mounted socket files, not this directory or its host siblings.
+    sites = []
+    for name, runner in [('broker', broker_runner), ('gateway', gateway_runner)]:
+        path = root / f'{name}.sock'
+        if path.exists() or path.is_symlink():
+            info = path.lstat()
+            if not stat.S_ISSOCK(info.st_mode) or info.st_uid != os.geteuid():
+                raise WorkerIsolationError('Invalid sandbox transport socket')
+            # Do not unlink another live server's socket at startup.
+            import socket
+            probe = socket.socket(socket.AF_UNIX)
+            probe.settimeout(1)
+            try:
+                probe.connect(str(path))
+            except ConnectionRefusedError:
+                path.unlink()
+            else:
+                raise WorkerIsolationError('Sandbox transport is already active')
+            finally:
+                probe.close()
+        site = web.UnixSite(runner, str(path))
+        await site.start()
+        os.chmod(path, 0o666)  # authentication is the per-run broker capability
+        sites.append(site)
+    return sites
+
+
+def _runtime():
+    binary = shutil.which('runsc')
+    if not binary:
+        raise WorkerIsolationError('gVisor runsc is required; unisolated fallback is disabled')
+    info = Path(binary).stat()
+    if info.st_uid != os.geteuid() or info.st_mode & 0o022:
+        raise WorkerIsolationError('gVisor must be installed in backend-owned storage')
+    return binary
+
+
+def prepare(argv, workspace, env, *, passthrough=()):
+    from broker import worker
+    worker.assert_worker_env_clean(env)
+    worker.verify_workspace_ownership(workspace)
+    workspace = Path(workspace).resolve()
+    rootfs = _trusted_directory(os.environ.get('LOMA_WORKER_ROOTFS', '/opt/loma-worker-rootfs'))
+    if rootfs == Path('/') or rootfs == workspace or rootfs in workspace.parents or workspace in rootfs.parents:
+        raise WorkerIsolationError('A separate secrets-free worker image is required')
+    if (rootfs / '.loma-worker-image').read_text().strip() != '1':
+        raise WorkerIsolationError('Unrecognized worker image')
+    runtime = _runtime()
+    identity = worker.workspace_identity(workspace)
+    if identity.uid is None or identity.uid == 0 or not identity.per_run:
+        raise WorkerIsolationError('Independent workers require per-run non-root identities')
+    for name in passthrough:
+        if name not in {'CLAUDE_CONFIG_DIR', 'ANTHROPIC_BASE_URL', 'ANTHROPIC_AUTH_TOKEN', 'CLAUDE_CODE_ENTRYPOINT', 'CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING'}:
+            raise WorkerIsolationError('Unsupported sandbox SDK passthrough')
+    if not argv or not all(isinstance(arg, str) and '\0' not in arg for arg in argv):
+        raise WorkerIsolationError('Invalid sandbox command')
+    executable = argv[0]
+    if not executable.startswith('/'):
+        executable = next((f'{directory}/{executable}' for directory in ('/usr/local/bin', '/usr/bin', '/bin')
+                           if (rootfs / directory.lstrip('/') / executable).is_file()), '')
+    if not executable or not (rootfs / executable.lstrip('/')).is_file():
+        raise WorkerIsolationError('Requested executable is missing from worker image')
+    mounts = [
+        {'destination': '/proc', 'type': 'proc', 'source': 'proc'},
+        {'destination': '/dev', 'type': 'tmpfs', 'source': 'tmpfs', 'options': ['nosuid', 'strictatime', 'mode=755', 'size=65536k']},
+        {'destination': '/tmp', 'type': 'tmpfs', 'source': 'tmpfs', 'options': ['nosuid', 'nodev', 'mode=1777', 'size=268435456']},
+        {'destination': '/run', 'type': 'tmpfs', 'source': 'tmpfs', 'options': ['nosuid', 'nodev', 'mode=755', 'size=1048576']},
+        {'destination': str(workspace), 'type': 'bind', 'source': str(workspace), 'options': ['rbind', 'rw', 'nosuid', 'nodev']},
+    ]
+    for name in ('broker', 'gateway'):
+        source = socket_root() / f'{name}.sock'
+        info = source.lstat()
+        if not stat.S_ISSOCK(info.st_mode) or info.st_uid != os.geteuid():
+            raise WorkerIsolationError('Sandbox broker transport unavailable')
+        mounts.append({'destination': f'/run/loma/{name}.sock', 'type': 'bind', 'source': str(source), 'options': ['bind', 'ro', 'nosuid', 'nodev', 'noexec']})
+    # Configuration is immutable to worker identities, unlike the workspace.
+    root = state_root()
+    bundle = root / ('run-' + secrets.token_hex(16))
+    bundle.mkdir(mode=0o700)
+    spec = {
+        'ociVersion': '1.0.2', 'root': {'path': str(rootfs), 'readonly': True},
+        'hostname': 'loma-worker', 'mounts': mounts,
+        'process': {
+            'terminal': False, 'user': {'uid': identity.uid, 'gid': identity.gid},
+            'args': ['/usr/local/bin/python3', '/usr/local/lib/loma_worker_entry.py', executable, *argv[1:]],
+            'cwd': str(workspace), 'env': [f'{k}={v}' for k, v in env.items()],
+            'noNewPrivileges': True,
+            'capabilities': {k: [] for k in ('bounding', 'effective', 'inheritable', 'permitted', 'ambient')},
+            'rlimits': [{'type': 'RLIMIT_CORE', 'hard': 0, 'soft': 0},
+                        {'type': 'RLIMIT_NOFILE', 'hard': 1024, 'soft': 1024},
+                        {'type': 'RLIMIT_CPU', 'hard': 600, 'soft': 600},
+                        {'type': 'RLIMIT_FSIZE', 'hard': 268435456, 'soft': 268435456}],
+        },
+        'linux': {
+            'cgroupsPath': f'/loma-workers/{bundle.name}',
+            'namespaces': [{'type': t} for t in ('pid', 'mount', 'network', 'ipc', 'uts')],
+            'resources': {'memory': {'limit': 2147483648}, 'pids': {'limit': 256},
+                          'cpu': {'quota': 200000, 'period': 100000}},
+        },
+    }
+    (bundle / 'config.json').write_text(json.dumps(spec))
+    (bundle / 'supervisor.json').write_text(json.dumps({'runtime': runtime, 'workspace': str(workspace), 'passthrough': list(passthrough)}))
+    runner = Path(__file__).with_name('sandbox_runner.py')
+    return [sys.executable, '-I', str(runner), str(bundle)]
+
+
+def launcher(workspace, real_cli, env, passthrough):
+    import shlex
+    command = prepare([real_cli], workspace, env, passthrough=passthrough)
+    bundle = Path(command[-1])
+    script = bundle / 'launch.sh'
+    script.write_text('#!/bin/sh\nexec ' + shlex.join(command) + ' "$@"\n')
+    script.chmod(0o700)
+    return script
+
+
+def cleanup(workspace):
+    root = state_root()
+    for bundle in root.glob('run-*'):
+        try:
+            control = json.loads((bundle / 'supervisor.json').read_text())
+            if control['workspace'] != str(Path(workspace).resolve()):
+                continue
+            if (bundle / 'stopped').exists():
+                shutil.rmtree(bundle)
+                continue
+            result = subprocess.run([control['runtime'], f'--root={root / "runtime"}', 'delete', '--force', bundle.name],
+                                    capture_output=True, timeout=30, env={'PATH': '/usr/local/bin:/usr/bin:/bin'})
+            if result.returncode:
+                # Retain identity/workspace on teardown failures; never reassign
+                # its uid while a detached sandbox might still hold open files.
+                raise WorkerIsolationError('Sandbox teardown failed; workspace retained')
+            shutil.rmtree(bundle)
+        except (OSError, ValueError, subprocess.TimeoutExpired) as exc:
+            raise WorkerIsolationError('Sandbox teardown failed; workspace retained') from exc
+
+
+async def ingress(port, workspace):
+    """Backend-only local endpoint for the dedicated OpenCode server."""
+    from broker.sandbox_entry import bridge
+    async def forward(reader, writer):
+        fd = None
+        try:
+            # Pin the socket inode before connecting. A worker-controlled symlink
+            # must never redirect this trusted relay to a backend/host socket.
+            path = Path(workspace) / '.loma-ingress.sock'
+            fd = os.open(path, os.O_PATH | os.O_NOFOLLOW)
+            info = os.fstat(fd)
+            if not stat.S_ISSOCK(info.st_mode) or info.st_nlink != 1 or info.st_uid != Path(workspace).stat().st_uid:
+                raise WorkerIsolationError('Invalid sandbox ingress socket')
+            await bridge(reader, writer, unix=f'/proc/self/fd/{fd}')
+        except (OSError, WorkerIsolationError):
+            writer.close()
+        finally:
+            if fd is not None:
+                os.close(fd)
+    return await asyncio.start_server(forward, '127.0.0.1', port, limit=65536)

--- a/broker/sandbox_entry.py
+++ b/broker/sandbox_entry.py
@@ -1,0 +1,90 @@
+"""Runs INSIDE the secrets-free worker image, never in the backend.
+
+With runsc --network=none there is no external network device. Two fixed Unix
+socket bridges make only the authenticated broker/gateway reachable. No CONNECT
+proxy, DNS resolver, configurable destination, or host TCP forwarding is exposed.
+"""
+import asyncio
+import os
+import signal
+import sys
+from urllib.parse import urlsplit
+
+
+async def pipe(reader, writer):
+    try:
+        while data := await reader.read(65536):
+            writer.write(data)
+            await writer.drain()
+    finally:
+        writer.close()
+
+
+async def bridge(reader, writer, *, unix=None, port=None):
+    tasks = []
+    peer = None
+    try:
+        if unix:
+            other, peer = await asyncio.wait_for(asyncio.open_unix_connection(unix), 10)
+        else:
+            other, peer = await asyncio.wait_for(asyncio.open_connection('127.0.0.1', port), 10)
+        tasks = [asyncio.create_task(pipe(reader, peer)), asyncio.create_task(pipe(other, writer))]
+        await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+    except (OSError, asyncio.TimeoutError):
+        pass
+    finally:
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        writer.close()
+        if peer:
+            peer.close()
+
+
+def local_port(url):
+    value = urlsplit(url)
+    if (value.scheme != 'http' or value.hostname != '127.0.0.1' or not value.port
+            or value.username or value.password or value.path or value.query or value.fragment):
+        raise ValueError('Only local sandbox transports are supported')
+    return value.port
+
+
+async def main(argv):
+    servers = []
+    try:
+        for name, default, socket_name in (
+            ('LOMA_BROKER_URL', 'http://127.0.0.1:3100', 'broker'),
+            ('LOMA_GATEWAY_URL', 'http://127.0.0.1:3101', 'gateway'),
+        ):
+            port = local_port(os.environ.get(name, default))
+            async def forward(reader, writer, path=f'/run/loma/{socket_name}.sock'):
+                await bridge(reader, writer, unix=path)
+            servers.append(await asyncio.start_server(forward, '127.0.0.1', port, limit=65536))
+        ingress = os.environ.get('LOMA_SANDBOX_INGRESS_PORT')
+        if ingress:
+            port = int(ingress)
+            if not 1024 <= port <= 65535:
+                raise ValueError('Invalid sandbox ingress port')
+            async def inward(reader, writer):
+                await bridge(reader, writer, port=port)
+            servers.append(await asyncio.start_unix_server(
+                inward, path=os.path.join(os.environ['HOME'], '.loma-ingress.sock')))
+        process = await asyncio.create_subprocess_exec(*argv, stdin=sys.stdin, stdout=sys.stdout, stderr=sys.stderr)
+        loop = asyncio.get_running_loop()
+        for sig in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+            def forward_signal(sig=sig):
+                if process.returncode is None:
+                    process.send_signal(sig)
+            loop.add_signal_handler(sig, forward_signal)
+        return await process.wait()
+    finally:
+        for server in servers:
+            server.close()
+        await asyncio.gather(*(server.wait_closed() for server in servers))
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        sys.exit(2)
+    sys.exit(asyncio.run(main(sys.argv[1:])))

--- a/broker/sandbox_runner.py
+++ b/broker/sandbox_runner.py
@@ -1,0 +1,63 @@
+"""Trusted launcher. Only backend-owned OCI bundles are accepted.
+
+Invoked with Python isolated mode; no imports from worker-controlled directories.
+Runtime failure never executes the command outside gVisor.
+"""
+import json
+import os
+from urllib.parse import urlsplit
+from pathlib import Path
+import signal
+import stat
+import subprocess
+import sys
+
+
+def main():
+    bundle = Path(sys.argv[1])
+    info = bundle.lstat()
+    if not stat.S_ISDIR(info.st_mode) or info.st_uid != os.geteuid() or info.st_mode & 0o077:
+        raise RuntimeError('Invalid sandbox control directory')
+    control = json.loads((bundle / 'supervisor.json').read_text())
+    spec = json.loads((bundle / 'config.json').read_text())
+    spec['process']['args'].extend(sys.argv[2:])
+    for name in control['passthrough']:
+        if name in os.environ:
+            value = os.environ[name]
+            if '\0' in value or '\n' in value or '\r' in value:
+                raise RuntimeError('Invalid SDK environment')
+            if name == 'CLAUDE_CONFIG_DIR':
+                Path(value).resolve().relative_to(Path(control['workspace']).resolve())
+            if name == 'ANTHROPIC_AUTH_TOKEN' and not value.startswith('loma_subproxy_'):
+                raise RuntimeError('Only subscription proxy references may enter a worker')
+            if name == 'ANTHROPIC_BASE_URL':
+                parsed = urlsplit(value)
+                if parsed.scheme != 'http' or parsed.hostname != '127.0.0.1' or not parsed.path.startswith('/sub/loma_subproxy_') or parsed.query or parsed.fragment or parsed.username or parsed.password:
+                    raise RuntimeError('Only the local subscription proxy is supported')
+            spec['process']['env'].append(f'{name}={value}')
+    (bundle / 'config.json').write_text(json.dumps(spec))
+    base = [control['runtime'], f'--root={bundle.parent / "runtime"}']
+    command = [*base, '--platform=systrap', '--network=none', '--host-uds=all',
+               '--directfs=false', '--gvisor-marker-file=true', '--file-access=shared', 'run', f'--bundle={bundle}', bundle.name]
+    child = subprocess.Popen(command, env={'PATH': '/usr/local/bin:/usr/bin:/bin'})
+    for sig in (signal.SIGTERM, signal.SIGINT, signal.SIGHUP):
+        def forward(sig, frame):
+            if child.poll() is None:
+                child.send_signal(sig)
+        signal.signal(sig, forward)
+    try:
+        return child.wait()
+    finally:
+        result = subprocess.run([*base, 'delete', '--force', bundle.name], capture_output=True, timeout=30,
+                                env={'PATH': '/usr/local/bin:/usr/bin:/bin'})
+        if result.returncode != 0:
+            raise RuntimeError('Sandbox teardown failed; workspace retained')
+        (bundle / 'stopped').touch(mode=0o600)
+
+
+if __name__ == '__main__':
+    try:
+        sys.exit(main())
+    except Exception:
+        print('Isolated worker could not start or stop safely.', file=sys.stderr)
+        sys.exit(125)

--- a/broker/service.py
+++ b/broker/service.py
@@ -1,0 +1,110 @@
+"""Run-scoped, opaque capabilities for explicit broker operations.
+
+Issuance and revocation are trusted controller APIs, deliberately NOT HTTP routes.
+The deployment is the tenant boundary in this single-tenant application. A worker
+cannot supply a principal, tenant, provider destination, or credential identifier.
+"""
+import hashlib
+import re
+import secrets
+from datetime import datetime, timedelta, timezone
+
+
+class Denied(Exception):
+    """Invalid capability, inactive account, or insufficient scope."""
+
+
+class Broker:
+    def __init__(self, db, deployment_id, operations):
+        if db is None or not isinstance(deployment_id, str) or not deployment_id.strip():
+            raise ValueError("Broker requires a database and deployment identity")
+        self.db = db
+        self.deployment_id = deployment_id
+        self.operations = dict(operations)
+
+    async def initialize(self):
+        # TTL is cleanup only. Every admission checks the deadline explicitly.
+        await self.db.execution_capabilities.create_index("expires_at", expireAfterSeconds=0)
+
+    async def _active(self, email):
+        user = await self.db.users.find_one({"email": email})
+        if not user or user.get("status") != "active":
+            raise Denied()
+
+    async def issue(self, *, user_email, grants, ttl_seconds=300, max_calls=20):
+        """Called ONLY by the trusted controller after authenticating the user.
+
+        Grants must come from controller policy/user approval, never model output.
+        Returns (run_id, opaque_capability); store only its hash in MongoDB.
+        Each issuance creates a new run, so resumed workers need fresh grants.
+        """
+        if (not isinstance(user_email, str) or not user_email
+                or type(ttl_seconds) is not int or not 1 <= ttl_seconds <= 7200
+                or type(max_calls) is not int or not 1 <= max_calls <= 1000
+                or not isinstance(grants, dict) or not grants or len(grants) > 20):
+            raise ValueError("Invalid execution grant")
+        await self._active(user_email)
+        scopes = []
+        for name, resources in grants.items():
+            operation = self.operations.get(name)
+            if (operation is None or not isinstance(resources, list)
+                    or not 1 <= len(resources) <= 100):
+                raise ValueError("Invalid operation grant")
+            for resource in resources:
+                if not operation.valid_resource(resource):
+                    raise ValueError("Invalid resource grant")
+                scopes.append({"operation": name, "resource": resource})
+        token = "loma_run_v1_" + secrets.token_urlsafe(32)
+        run_id = secrets.token_hex(16)
+        await self.db.execution_capabilities.insert_one({
+            "_id": self._digest(token), "deployment_id": self.deployment_id,
+            "run_id": run_id, "user_email": user_email, "scopes": scopes,
+            "expires_at": datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds),
+            "remaining_calls": max_calls, "revoked": False,
+        })
+        return run_id, token
+
+    @staticmethod
+    def _digest(token):
+        return hashlib.sha256(token.encode()).hexdigest()
+
+    async def revoke(self, run_id):
+        await self.db.execution_capabilities.update_many(
+            {"run_id": run_id, "deployment_id": self.deployment_id},
+            {"$set": {"revoked": True}},
+        )
+
+    async def execute(self, token, operation_name, resource, params=None):
+        if (not isinstance(token, str)
+                or not re.fullmatch(r"loma_run_v1_[A-Za-z0-9_-]{43}", token)
+                or not isinstance(operation_name, str)):
+            raise Denied()
+        operation = self.operations.get(operation_name)
+        if operation is None or not operation.valid_resource(resource):
+            raise Denied()
+        # Params are only defined for operations that declare support; any
+        # attempt to smuggle arguments into a param-less operation is denied.
+        if params is not None and not getattr(operation, "accepts_params", False):
+            raise Denied()
+        # Atomic admission: concurrent workers cannot overspend the call budget.
+        # Failed calls consume budget too; no refunds/retries that can evade limits.
+        grant = await self.db.execution_capabilities.find_one_and_update({
+            "_id": self._digest(token), "deployment_id": self.deployment_id,
+            "revoked": False, "expires_at": {"$gt": datetime.now(timezone.utc)},
+            "remaining_calls": {"$gt": 0},
+            "scopes": {"$elemMatch": {"operation": operation_name, "resource": resource}},
+        }, {"$inc": {"remaining_calls": -1}})
+        if not grant:
+            raise Denied()
+        # No cached approval: account removal/status changes apply to every call.
+        await self._active(grant["user_email"])
+        # Persist admission before I/O. A failed audit write prevents provider I/O.
+        # Never store arguments, capabilities, provider responses or exception text.
+        await self.db.execution_audit.insert_one({
+            "deployment_id": self.deployment_id, "run_id": grant["run_id"],
+            "operation": operation_name, "event": "admitted",
+            "at": datetime.now(timezone.utc),
+        })
+        if getattr(operation, "accepts_params", False):
+            return await operation.execute(self.db, grant["user_email"], resource, params)
+        return await operation.execute(self.db, grant["user_email"], resource)

--- a/broker/subscription_refresh.py
+++ b/broker/subscription_refresh.py
@@ -1,0 +1,195 @@
+"""Backend-only refresh for pooled CLI accounts. Never returns tokens to workers.
+
+Protocol constants match the installed Claude Code and Codex CLI clients. A live
+compatibility check is still required when upgrading those clients.
+"""
+import asyncio
+import base64
+import fcntl
+import json
+import math
+import os
+import stat
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import aiohttp
+
+from broker.service import Denied
+
+# Public OAuth client IDs, not secrets. Endpoints are never worker configurable.
+PROVIDERS = {
+    'claude': ('https://platform.claude.com/v1/oauth/token', '9d1c250a-e61b-44d9-88ed-5944d1962f5e'),
+    'codex': ('https://auth.openai.com/oauth/token', 'app_EMoamEEZ73f0CkXaXp7hrann'),
+}
+
+
+def _read(path):
+    fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
+    with os.fdopen(fd, 'rb') as source:
+        info = os.fstat(source.fileno())
+        if not stat.S_ISREG(info.st_mode) or info.st_nlink != 1 or info.st_size > 131072:
+            raise Denied()
+        raw = source.read(131073)
+    data = json.loads(raw)
+    if not isinstance(data, dict):
+        raise Denied()
+    return raw, data
+
+
+def _expiry(provider, data):
+    if provider == 'claude':
+        value = data.get('claudeAiOauth', {}).get('expiresAt')
+        return value / 1000 if isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value) else None
+    token = data.get('tokens', {}).get('access_token', '')
+    try:
+        payload = token.split('.')[1]
+        value = json.loads(base64.urlsafe_b64decode(payload + '=' * (-len(payload) % 4))).get('exp')
+        # This is a scheduling hint, NOT identity verification. Only backend-owned
+        # credentials are read and account admission is independently enforced.
+        return value if isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value) else None
+    except (ValueError, IndexError, AttributeError):
+        return None
+
+
+def _token(value):
+    if not isinstance(value, str) or not value or len(value) > 32768 or any(ord(c) < 32 for c in value):
+        raise Denied()
+    return value
+
+
+async def _exchange(provider, refresh, scopes):
+    endpoint, client_id = PROVIDERS[provider]
+    payload = {'grant_type': 'refresh_token', 'refresh_token': refresh, 'client_id': client_id}
+    if provider == 'claude' and scopes:
+        payload['scope'] = ' '.join(scopes)
+    async with aiohttp.ClientSession(trust_env=False, timeout=aiohttp.ClientTimeout(total=30)) as session:
+        async with session.post(endpoint, json=payload, allow_redirects=False) as response:
+            if response.status != 200:
+                raise Denied()
+            raw = bytearray()
+            async for chunk in response.content.iter_chunked(8192):
+                raw.extend(chunk)
+                if len(raw) > 65536:
+                    raise Denied()
+            result = json.loads(raw)
+            if not isinstance(result, dict):
+                raise Denied()
+            return result
+
+
+def _updated(provider, original, response):
+    data = dict(original)
+    access = _token(response.get('access_token'))
+    if provider == 'claude':
+        oauth = dict(data['claudeAiOauth'])
+        expires = response.get('expires_in')
+        if not isinstance(expires, (int, float)) or isinstance(expires, bool) or not math.isfinite(expires) or not 0 < expires <= 31_536_000:
+            raise Denied()
+        oauth.update({'accessToken': access, 'expiresAt': int((time.time() + expires) * 1000)})
+        if 'refresh_token' in response:
+            oauth['refreshToken'] = _token(response['refresh_token'])
+        data['claudeAiOauth'] = oauth
+    else:
+        tokens = dict(data['tokens'])
+        tokens['access_token'] = access
+        for name in ('refresh_token', 'id_token'):
+            if name in response:
+                tokens[name] = _token(response[name])
+        # Keep the account bound at setup; a response may not change it.
+        data['tokens'] = tokens
+        data['last_refresh'] = datetime.now(timezone.utc).isoformat()
+    return data
+
+
+def _persist(path, original_raw, updated):
+    # A login utility may have replaced the account while the request was in flight.
+    if _read(path)[0] != original_raw:
+        raise Denied()
+    tmp = None
+    try:
+        fd, tmp = tempfile.mkstemp(prefix='.refresh-', dir=path.parent)
+        with os.fdopen(fd, 'w') as target:
+            os.fchmod(target.fileno(), 0o600)
+            json.dump(updated, target)
+            target.flush()
+            os.fsync(target.fileno())
+        os.replace(tmp, path)
+        tmp = None
+        directory = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    finally:
+        if tmp is not None:
+            os.unlink(tmp)
+
+
+async def ensure_fresh(provider, credentials_path, *, rejected_access_token=None):
+    """Refresh expiring credentials, or recover a provider-rejected token.
+
+    Forced recovery is for an upstream HTTP 401 before streaming only. Comparing
+    the rejected access token under the account lock coalesces concurrent callers.
+    A persisted cooldown bounds refresh attempts even across backend processes.
+    """
+    fd = None
+    try:
+        if provider not in PROVIDERS:
+            raise Denied()
+        if rejected_access_token is not None:
+            _token(rejected_access_token)
+        path = Path(credentials_path)
+        _, current = _read(path)
+        expiry = _expiry(provider, current)
+        if rejected_access_token is None and (expiry is None or expiry > time.time() + 60):
+            return
+        fd = os.open(str(path) + '.refresh.lock', os.O_CREAT | os.O_RDWR | os.O_NOFOLLOW | os.O_NONBLOCK, 0o600)
+        info = os.fstat(fd)
+        if not stat.S_ISREG(info.st_mode) or info.st_nlink != 1:
+            raise Denied()
+        async with asyncio.timeout(40):
+            while True:
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    break
+                except BlockingIOError:
+                    await asyncio.sleep(0.05)
+            raw, current = _read(path)
+            expiry = _expiry(provider, current)
+            if rejected_access_token is None and (expiry is None or expiry > time.time() + 60):
+                return
+            oauth = current.get('claudeAiOauth' if provider == 'claude' else 'tokens', {})
+            if rejected_access_token is not None:
+                access = oauth.get('accessToken' if provider == 'claude' else 'access_token')
+                if _token(access) != rejected_access_token:
+                    # Another admitted request already refreshed this account.
+                    return True
+                attempted = current.get('_loma_recovery_at', 0)
+                if (not isinstance(attempted, (int, float)) or isinstance(attempted, bool)
+                        or not math.isfinite(attempted) or time.time() - attempted < 60):
+                    raise Denied()
+            refresh_value = oauth.get('refreshToken' if provider == 'claude' else 'refresh_token')
+            # Non-refreshable setup tokens remain usable until their actual expiry.
+            if not refresh_value and rejected_access_token is None and expiry is not None and expiry > time.time():
+                return
+            refresh = _token(refresh_value)
+            scopes = oauth.get('scopes', []) if provider == 'claude' else []
+            if not isinstance(scopes, list) or not all(isinstance(s, str) and len(s) < 200 for s in scopes):
+                raise Denied()
+            if rejected_access_token is not None:
+                attempted = dict(current, _loma_recovery_at=time.time())
+                _persist(path, raw, attempted)
+                raw, current = _read(path)
+            response = await _exchange(provider, refresh, scopes)
+            _persist(path, raw, _updated(provider, current, response))
+            return True
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        raise Denied() from None
+    finally:
+        if fd is not None:
+            os.close(fd)

--- a/broker/tool_policy.py
+++ b/broker/tool_policy.py
@@ -1,0 +1,351 @@
+"""Reviewed command schemas for backend CLI adapters.
+
+A registered tool is NOT permission to execute all of its commands. Unknown
+commands/flags fail closed until reviewed here. Local inputs must be uploaded
+in this request; the worker can never name an existing backend file. Utilities
+that render code or accept unrestricted local directories are not adapters.
+"""
+from dataclasses import dataclass
+from broker.service import Denied
+
+
+@dataclass(frozen=True)
+class Command:
+    values: str = ''
+    switches: str = ''
+    files: str = ''
+    csv_files: str = ''
+    positionals: int = 0
+    repeatable: str = ''
+    stdin: bool = False
+    outputs: str = ''
+    required: str = ''
+
+
+POLICY = {
+    'diagrams': {
+        'render': Command('type theme width height scale bg-color', outputs='output', stdin=True, required='output'),
+        'upload': Command('name', files='file', required='file'),
+        'embed': Command('doc-id image-id replace-start replace-end width height', required='doc-id image-id replace-start replace-end'),
+    },
+    'agreement_review': {
+        'download': Command('file-id', outputs='output-path', required='file-id output-path'),
+        'read': Command(files='file-path', required='file-path'),
+        'annotate': Command(files='file-path', outputs='output-path', stdin=True, required='file-path output-path'),
+        'upload': Command('folder-id name', files='file-path', required='file-path'),
+    },
+    'cdn_upload': {
+        'upload': Command('key', files='file'),
+        'upload-url': Command('url key'),
+    },
+    'apollo': {
+        'search': Command('title seniority location domain company_size keywords page per_page', repeatable='title seniority location domain company_size'),
+        'enrich': Command('name apollo_id email company domain linkedin_url', switches='reveal_emails reveal_phone'),
+        'bulk-enrich': Command('data', switches='reveal_emails reveal_phone'),
+        'org-search': Command('domain location company_size keywords page per_page', repeatable='domain location company_size'),
+        'org-enrich': Command('domain'),
+        'org-bulk-enrich': Command('domain', repeatable='domain'),
+        'org-get': Command('id'),
+        'org-job-postings': Command('id'),
+        'news-search': Command('keywords org_ids page per_page', repeatable='org_ids'),
+        'contacts-create': Command('data first_name last_name email title company account_id owner_id'),
+        'contacts-bulk-create': Command('data'),
+        'contacts-bulk-update': Command('data'),
+        'contacts-get': Command('id'),
+        'contacts-update': Command('id data'),
+        'contacts-search': Command('keywords page per_page'),
+        'contacts-update-stage': Command('id contact_stage_id'),
+        'contacts-update-owner': Command('id owner_id'),
+        'contact-stages': Command(),
+        'contact-lists': Command(),
+        'deals-create': Command('data name amount opportunity_stage_id account_id owner_id closed_date'),
+        'deals-get': Command('id'),
+        'deals-update': Command('id data'),
+        'deals-list': Command('page per_page'),
+        'deal-stages': Command(),
+        'sequences-search': Command('keywords page per_page'),
+        'sequences-add-contacts': Command('sequence_id contact_ids email_account_id', repeatable='contact_ids'),
+        'sequences-update-touch': Command('campaign_id touch_id status data'),
+        'tasks-create': Command('data contact_id account_id user_id type priority due_date note'),
+        'tasks-search': Command('keywords page per_page'),
+        'calls-create': Command('data contact_id account_id user_id disposition direction note duration'),
+        'calls-update': Command('data'),
+        'calls-search': Command('page per_page'),
+        'emails-search': Command('page per_page'),
+        'email-stats': Command('id'),
+        'email-accounts': Command(),
+        'custom-fields': Command(),
+        'custom-fields-create': Command('name field_type entity_type'),
+        'users': Command(),
+        'api-usage': Command(),
+        'api-health': Command(),
+    },
+    'dataroom': {
+        'create-room': Command(positionals=1),
+        'list-rooms': Command('search'),
+        'get-room': Command(positionals=1),
+        'delete-room': Command(positionals=1),
+        'update-room': Command('internal-name name permission-strategy tags bulk-download show-last-updated notifications', positionals=1),
+        'list-docs': Command('search'),
+        'add-doc': Command('folder', positionals=2),
+        'list-room-docs': Command(positionals=1),
+        'create-doc': Command('url', positionals=1),
+        'create-folder': Command('path', positionals=2),
+        'create-link': Command('type password name allow-list deny-list agreement-id domain slug expiry-days watermark-config show-banner allow-download', switches='enable-agreement enable-feedback no-email-protection no-email-auth no-watermark no-screenshot-protection no-notification', positionals=1),
+        'update-link': Command('expiry-days password allow-list deny-list agreement-id name watermark screenshot-protection email-protection email-auth notification allow-download watermark-config enable-agreement show-banner enable-feedback', positionals=1),
+        'delete-link': Command(positionals=1),
+        'get-link': Command(positionals=1),
+        'list-links': Command(positionals=1),
+        'viewers': Command(positionals=1),
+        'team-viewers': Command('search'),
+        'get-branding': Command(positionals=1),
+        'set-branding': Command('logo banner brand-color accent-color welcome-message', positionals=1),
+    },
+    'stitch': {
+        'download': Command('url', outputs='output', required='url output'),
+        'list-projects': Command(),
+        'create-project': Command('title'),
+        'get-project': Command('id'),
+        'list-screens': Command('project-id'),
+        'get-screen': Command('project-id screen-id'),
+        'generate': Command('project-id prompt device model'),
+        'edit': Command('project-id screen-ids prompt'),
+        'variants': Command('project-id screen-ids prompt count range'),
+    },
+    'gmail': {
+        'list-inbox': Command('limit query'),
+        'read-email': Command('message-id'),
+        'search': Command('query limit'),
+        'send-email': Command('to subject body cc html-body', files='html-body-file', csv_files='attachments'),
+        'create-draft': Command('to subject body cc thread-id in-reply-to html-body', files='html-body-file', csv_files='attachments'),
+    },
+    'google_drive': {
+        'list-files': Command('query limit'), 'read-file': Command('file-id'),
+        'search': Command('query limit'),
+        'upload-file': Command('name folder-id mime-type', files='file-path'),
+        'create-folder': Command('name parent-id'), 'copy-file': Command('file-id name folder-id'),
+    },
+    'google_calendar': {
+        'list-events': Command('limit time-min time-max'), 'get-event': Command('event-id'),
+        'create-event': Command('summary start end description attendees location'),
+        'update-event': Command('event-id summary start end description attendees location'),
+        'delete-event': Command('event-id'), 'search': Command('query limit'),
+    },
+    'google_sheets': {
+        'get-info': Command('spreadsheet-id'), 'list-sheets': Command('spreadsheet-id'),
+        'read-range': Command('spreadsheet-id range'), 'write-range': Command('spreadsheet-id range values'),
+        'copy-spreadsheet': Command('spreadsheet-id title'),
+    },
+    'google_slides': {
+        'get-info': Command('presentation-id'), 'list-slides': Command('presentation-id'),
+        'read-slide': Command('presentation-id slide-index'), 'create-presentation': Command('title'),
+        'add-slide': Command('presentation-id insertion-index layout'),
+        'replace-text': Command('presentation-id find replacement', switches='match-case'),
+    },
+    'google_docs_personal': {
+        'get-info': Command('document-id'), 'read-doc': Command('document-id'),
+        'create-doc': Command('title content'), 'append-text': Command('document-id text'),
+        'insert-text': Command('document-id text index'),
+        'replace-text': Command('document-id find replacement', switches='match-case'),
+        'copy-doc': Command('document-id title'),
+    },
+    'google_apps_script': {
+        'list-projects': Command('query limit'), 'get-content': Command('script-id'),
+        'create-project': Command('title parent-id'),
+        'update-content': Command('script-id files-json file-name', files='files-json-file code-file'),
+        'create-version': Command('script-id description'), 'list-versions': Command('script-id limit'),
+    },
+    'slack_user': {
+        'read-channel': Command('channel limit'), 'search': Command('query limit'),
+        'send-message': Command('channel text thread-ts file-title', files='file'),
+        'open-dm': Command('users'), 'react': Command('channel ts emoji'),
+        'unreact': Command('channel ts emoji'),
+        'upload-file': Command('channels title message', files='file'),
+    },
+    'notify': {
+        'send': Command('title body conversation-id link'), 'list': Command('limit'),
+    },
+    'grain': {
+        'search': Command(positionals=1), 'recent': Command(positionals=1),
+        'transcript': Command(switches='text', positionals=1),
+    },
+    'loma_skills': {
+        'list': Command(), 'search': Command('query', positionals=1),
+        'get': Command('slug'), 'dump': Command('slug'), 'file': Command('slug path'),
+        'asset': Command('slug path'),
+        'create': Command('slug', files='skill-md'),
+        'update-file': Command('slug path', files='content-file'),
+        'upload-asset': Command('slug path', files='file'),
+        'delete-file': Command('slug path'),
+        # import-dir intentionally absent: it reads a backend directory.
+    },
+    'ashby': {
+        'check-auth': Command(), 'list-jobs': Command('status'),
+        'get-job': Command(positionals=1), 'list-stages': Command('job-id'),
+        'list-candidates': Command('limit'), 'get-candidate': Command(positionals=1),
+        'list-applications': Command('job-id status'), 'get-application': Command(positionals=1),
+        'export-application': Command(positionals=1),
+        'export-job-applications': Command('job-id status limit'),
+        'list-departments': Command(), 'list-locations': Command(), 'list-openings': Command('limit'),
+        'create-job': Command('title team-id location-id default-interview-plan-id job-template-id'),
+        'update-job': Command('title team-id location-id default-interview-plan-id custom-requisition-id', positionals=1),
+        'set-job-status': Command('status', positionals=1),
+        'duplicate-job': Command('title', positionals=1),
+        'create-opening': Command('identifier description team-id location-ids employment-type job-ids'),
+        'add-job-to-opening': Command('opening-id job-id'),
+    },
+    'sentry': {'projects': Command(), 'daily': Command('days environment', positionals=1),
+               'slow': Command('days limit environment', positionals=1)},
+    'pylon': {
+        'issue': Command(positionals=1), 'messages': Command(positionals=1),
+        'threads': Command(positionals=1), 'teams': Command(),
+        'reply': Command('to cc', files='attachment', positionals=2, repeatable='to cc attachment', stdin=True),
+        'note': Command('thread message', files='attachment', positionals=1, repeatable='attachment', stdin=True),
+        'issues': Command('days state team'), 'update': Command('state status', positionals=1),
+        'create-thread': Command(positionals=2),
+    },
+    'grafana': {
+        'alerts list': Command('state'), 'alerts rules': Command(),
+        'alerts silence': Command('duration comment', positionals=1),
+        'alerts history': Command('range', positionals=1),
+        'query lag': Command('range time', positionals=1),
+        'query state': Command(positionals=1), 'query members': Command(positionals=1),
+        'query all-lag': Command(), 'query synthetics': Command('range', positionals=1),
+        'query synthetic-logs': Command('range start end', positionals=1),
+        'oncall current': Command('schedule'), 'oncall next': Command('schedule'),
+        'oncall schedules': Command(),
+    },
+    'slack_reader': {
+        'channels': Command('query'), 'history': Command('limit thread-ts', positionals=1),
+        'send': Command('text thread-ts file-title', switches='require-thread', files='file', positionals=1, stdin=True),
+    },
+    'zoho_books': {
+        'get-contact': Command('region', positionals=1),
+        'search-contacts': Command('region name status'),
+        'search-contacts-by-company': Command('region company status'),
+        'list-invoices': Command('region customer-id status'),
+        'get-invoice': Command('region', positionals=1),
+        'download-invoice-pdf': Command('region', positionals=1, outputs='output'),
+        'list-estimates': Command('region customer-id status'),
+        'get-estimate': Command('region', positionals=1),
+        'download-estimate-pdf': Command('region', positionals=1, outputs='output'),
+        'list-credit-notes': Command('region customer-id'),
+        'get-credit-note': Command('region', positionals=1),
+        'list-payments': Command('region customer-id'), 'get-payment': Command('region', positionals=1),
+        'list-recurring-invoices': Command('region customer-id'),
+        'send-invoice': Command('region', positionals=1, stdin=True),
+        'send-estimate': Command('region', positionals=1, stdin=True),
+    },
+    'telegram': {'send-message': Command('text'), 'status': Command()},
+    'posthog': {
+        'projects': Command('project'), 'definitions': Command('project search limit'),
+        'definition-properties': Command('project', positionals=1),
+        'events': Command('project from to limit filter', positionals=1, repeatable='filter'),
+    },
+    'github_pr_resolve': {
+        'resolve': Command('thread-id'), 'list-unresolved': Command('repo pr'),
+    },
+    'linear': {'velocity': Command('month'), 'bucket-split': Command('month')},
+    'phantombuster': {
+        'send': Command(positionals=2), 'message': Command(positionals=2),
+        'inbox': Command('type count'), 'status': Command(positionals=1),
+    },
+    'monetize_now': {
+        'search-accounts': Command(positionals=16), 'get-account': Command(positionals=1),
+        'get-account-by-custom-id': Command(positionals=1),
+        'list-accounts': Command('status page page-size sort'),
+        'get-contract': Command(positionals=1),
+        'list-contracts': Command('status account-id page page-size sort'),
+        'account-contracts': Command('status page page-size sort', positionals=1),
+        'get-bill-group': Command(positionals=1),
+        'account-bill-groups': Command('status page page-size sort', positionals=1),
+        'get-account-bill-group': Command(positionals=2), 'get-invoice': Command(positionals=1),
+        'account-invoices': Command('status bill-group-id page page-size sort', positionals=1),
+        'bill-group-invoices': Command('page page-size sort', positionals=2),
+        'get-subscription': Command(positionals=1),
+        'account-subscriptions': Command('billing-status page page-size sort', positionals=1),
+        'bill-group-subscriptions': Command('billing-status page page-size sort', positionals=1),
+    },
+}
+
+
+def command_spec(tool: str, argv: list[str]) -> tuple[Command, int]:
+    if not argv:
+        raise Denied()
+    name = " ".join(argv[:2]) if len(argv) >= 2 and " ".join(argv[:2]) in POLICY.get(tool, {}) else argv[0]
+    if name not in POLICY.get(tool, {}):
+        raise Denied()
+    return POLICY[tool][name], len(name.split())
+
+
+def output_paths(tool: str, argv: list[str]) -> list[str]:
+    spec, command_length = command_spec(tool, argv)
+    flags = {"--" + name for name in spec.outputs.split()}
+    paths = []
+    for index in range(command_length, len(argv)):
+        flag, sep, value = argv[index].partition("=")
+        if flag in flags:
+            if not sep:
+                if index + 1 >= len(argv):
+                    raise Denied()
+                value = argv[index + 1]
+            if not value or len(value) > 4096 or "\0" in value:
+                raise Denied()
+            paths.append(value)
+    return paths
+
+
+def prepare_argv(tool: str, argv: list[str], uploads: dict[str, str]) -> list[str]:
+    """Validate exact flags and map *only* local-file parameters to uploads."""
+    spec, command_length = command_spec(tool, argv)
+    values = set(spec.values.split())
+    switches = set(spec.switches.split())
+    files = set(spec.files.split()) | set(spec.outputs.split())
+    csv_files = set(spec.csv_files.split())
+    result = argv[:command_length]
+    seen = set()
+    used_uploads = set()
+    positional_count = 0
+    i = command_length
+    while i < len(argv):
+        arg = argv[i]
+        i += 1
+        if '\0' in arg:
+            raise Denied()
+        if not arg.startswith('--'):
+            positional_count += 1
+            if arg.startswith('-') or positional_count > spec.positionals:
+                raise Denied()
+            result.append(arg)
+            continue
+        name, sep, value = arg[2:].partition('=')
+        if (name in seen and name not in spec.repeatable.split()) or name not in values | switches | files | csv_files:
+            raise Denied()
+        seen.add(name)
+        if name in switches:
+            if sep:
+                raise Denied()
+            result.append('--' + name)
+            continue
+        if not sep:
+            if i >= len(argv):
+                raise Denied()
+            value = argv[i]
+            i += 1
+        if '\0' in value or value.startswith('--'):
+            raise Denied()
+        if name in files | csv_files:
+            parts = value.split(',') if name in csv_files else [value]
+            # Empty optional file values mean no file, not a backend path.
+            if value:
+                parts = [part.strip() for part in parts]
+                if any(part not in uploads for part in parts):
+                    raise Denied()
+                used_uploads.update(parts)
+                value = ','.join(uploads[part] for part in parts)
+        result.extend(['--' + name, value])
+    if not set(spec.required.split()).issubset(seen):
+        raise Denied()
+    if set(uploads) != used_uploads:
+        raise Denied()
+    return result

--- a/broker/worker.py
+++ b/broker/worker.py
@@ -1,0 +1,830 @@
+"""Per-run worker isolation: private workspaces and scrubbed environments.
+
+Every agent runtime subprocess (Claude CLI, OpenCode server, Codex app-server)
+and every agent-accessible terminal must be spawned through this module. The
+boundary implemented here is a hardened subprocess:
+
+- a fresh private workspace directory per run (0700, optionally chowned to a
+  dedicated non-root worker uid/gid when the backend runs as root),
+- an explicitly constructed minimal environment. The backend environment is
+  never inherited: workers receive only the allowlist built by
+  ``build_worker_env`` (no DB connection strings, no encryption/signing keys,
+  no provider API keys, no messaging tokens),
+- ``setsid`` + resource limits (CPU time, address space, file size, open
+  files, process count, no core dumps) via ``preexec_fn`` where the platform
+  supports it, and optional bubblewrap wrapping when available,
+- a wall-clock watchdog that kills the whole process group.
+
+This is an in-process boundary, not a substitute for kernel-level isolation.
+Production deployments must additionally run workers under a hardened
+container runtime (gVisor/Kata/Firecracker), with no host mounts, no
+docker socket, no cloud metadata access, and network policy that only allows
+the broker/gateway and approved model endpoints. See
+``docs/execution-security.md``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ctypes
+import fcntl
+import logging
+import os
+import re
+import resource
+import secrets
+import shutil
+import stat
+import tempfile
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+class WorkerIsolationError(RuntimeError):
+    """A worker could not be prepared or spawned within the isolation rules."""
+
+
+# Environment variable names that must NEVER appear in a worker environment.
+# This is a defense-in-depth check on top of allowlist-only construction.
+FORBIDDEN_ENV_NAMES = frozenset({
+    "OBSERVABILITY_MONGODB_URI",
+    "MONGODB_URI",
+    "OAUTH_ENCRYPTION_KEY",
+    "BACKEND_PROXY_SECRET",
+    "SLACK_BOT_TOKEN",
+    "SLACK_APP_TOKEN",
+    "SLACK_SIGNING_SECRET",
+    "ANTHROPIC_API_KEY",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "OPENAI_API_KEY",
+    "OPENAI_AUTH_TOKEN",
+    "OPENROUTER_API_KEY",
+    "OPENCODE_API_KEY",
+    "GOOGLE_OAUTH_CLIENT_ID",
+    "GOOGLE_OAUTH_CLIENT_SECRET",
+    "SENTRY_ACCESS_TOKEN",
+    "TELEGRAM_BOT_TOKEN",
+    "GITHUB_WEBHOOK_SECRET",
+    "LINEAR_WEBHOOK_SECRET",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+})
+
+# Any extra env key matching this pattern is rejected unless explicitly named
+# in _EXTRA_ALLOWED_SENSITIVE (worker-safe, worker-scoped values).
+_SENSITIVE_NAME_RE = re.compile(
+    r"(SECRET|TOKEN|PASSWORD|PASSWD|PRIVATE|API_KEY|APIKEY|CREDENTIAL|"
+    r"ACCESS_KEY|SIGNING|MONGODB|DATABASE_URL|_DSN)", re.IGNORECASE,
+)
+
+# Worker-scoped values that intentionally look sensitive but are safe:
+# the run capability is *designed* to be handed to the worker, and in
+# subscription-proxy mode ANTHROPIC_AUTH_TOKEN carries a revocable gateway
+# proxy token (never the real subscription credential). Backend-held values
+# under these names are still rejected by the value-level check below.
+_EXTRA_ALLOWED_SENSITIVE = frozenset({
+    "LOMA_RUN_CAPABILITY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "OPENCODE_SERVER_PASSWORD",
+})
+
+# Names whose BACKEND values must never appear in a worker env under any
+# key, even where the name itself is legitimate for worker-scoped values.
+_VALUE_DENYLIST_EXTRA = frozenset({
+    "ANTHROPIC_AUTH_TOKEN",
+    "OPENCODE_SERVER_PASSWORD",
+})
+
+# Baseline vars copied from the backend env when present (never secret).
+_PASSTHROUGH_BASE = ("LANG", "LC_ALL", "TZ")
+
+
+def worker_root() -> Path:
+    """Root directory holding all per-run workspaces.
+
+    Defaults under the system temp dir so generated-file detection (which
+    only recognizes temp paths) keeps working for worker outputs.
+    """
+    root = os.environ.get("LOMA_WORKER_ROOT", "").strip()
+    if root:
+        return Path(root)
+    return Path(tempfile.gettempdir()) / "loma-workers"
+
+
+def _worker_uid_gid() -> tuple[int | None, int | None]:
+    """Dedicated shared non-root uid/gid for workers, when configured."""
+    try:
+        uid = int(os.environ.get("LOMA_WORKER_UID", "") or -1)
+        gid = int(os.environ.get("LOMA_WORKER_GID", "") or -1)
+    except ValueError:
+        raise WorkerIsolationError("LOMA_WORKER_UID/LOMA_WORKER_GID must be integers")
+    if uid <= 0:
+        return None, None
+    if os.geteuid() != 0:
+        if os.geteuid() != uid or os.getegid() != (gid if gid > 0 else uid):
+            raise WorkerIsolationError("Cannot enforce the configured worker identity")
+        return None, None
+    return uid, (gid if gid > 0 else uid)
+
+
+# ── Per-run worker identity ──────────────────────────────────────────────
+#
+# With only the single shared worker uid, concurrent runs of different users
+# are the SAME Unix identity: 0700 directory modes do not stop one run's
+# process from reading another run's workspace. When the backend runs as
+# root and LOMA_WORKER_UID_RANGE (e.g. "200000-200999") is set, every
+# workspace instead gets its own uid from the range; two concurrent runs can
+# then never read each other's files. Without a range (or without root) we
+# fall back to the shared uid and enforce strict 0700 ownership — a weaker,
+# documented boundary (see docs/execution-security.md).
+
+
+@dataclass(frozen=True)
+class WorkerIdentity:
+    uid: int | None
+    gid: int | None
+    per_run: bool = False
+
+
+_identity_lock = threading.Lock()
+_workspace_identities: dict[str, WorkerIdentity] = {}
+
+
+def _uid_range() -> tuple[int, int] | None:
+    spec = os.environ.get("LOMA_WORKER_UID_RANGE", "").strip()
+    if not spec:
+        return None
+    match = re.fullmatch(r"(\d{4,10})-(\d{4,10})", spec)
+    if not match:
+        raise WorkerIsolationError(
+            "LOMA_WORKER_UID_RANGE must look like '200000-200999'")
+    low, high = int(match.group(1)), int(match.group(2))
+    if low < 1000 or high < low or high - low > 65535:
+        raise WorkerIsolationError("LOMA_WORKER_UID_RANGE is not a sane uid range")
+    return low, high
+
+
+def _uids_in_use(low: int, high: int) -> set[int]:
+    """Uids from the range currently allocated (registry + on-disk owners).
+
+    Scanning existing workspace owners guards against reusing a uid still
+    attached to a live workspace after a backend restart.
+    """
+    used = {
+        identity.uid for identity in _workspace_identities.values()
+        if identity.uid is not None
+    }
+    root = worker_root()
+    if root.is_dir():
+        for entry in root.iterdir():
+            try:
+                owner = entry.stat().st_uid
+            except OSError:
+                continue
+            if low <= owner <= high:
+                used.add(owner)
+    # A process can outlive workspace cleanup (including a detached child).
+    # Do not recycle its uid into a new user's run.
+    for entry in Path("/proc").iterdir():
+        if not entry.name.isdecimal():
+            continue
+        try:
+            owner = entry.stat().st_uid
+        except FileNotFoundError:
+            continue
+        if low <= owner <= high:
+            used.add(owner)
+    return used
+
+
+def _allocate_identity() -> WorkerIdentity:
+    """Pick the identity for a new workspace (call under _identity_lock)."""
+    uid_range = _uid_range()
+    if uid_range is not None:
+        if os.geteuid() != 0:
+            # An operator explicitly asked for per-run identities; running
+            # without the privilege to enforce them must not silently
+            # degrade to the shared-uid boundary.
+            raise WorkerIsolationError(
+                "LOMA_WORKER_UID_RANGE requires the backend to run as root")
+        low, high = uid_range
+        used = _uids_in_use(low, high)
+        for candidate in range(low, high + 1):
+            if candidate not in used:
+                return WorkerIdentity(uid=candidate, gid=candidate, per_run=True)
+        raise WorkerIsolationError("No free worker uid: all range uids are in use")
+    uid, gid = _worker_uid_gid()
+    return WorkerIdentity(uid=uid, gid=gid, per_run=False)
+
+
+def workspace_identity(workspace: Path | str) -> WorkerIdentity:
+    """The Unix identity every process of this workspace must run as."""
+    key = str(Path(workspace).resolve())
+    with _identity_lock:
+        identity = _workspace_identities.get(key)
+    if identity is not None:
+        return identity
+    # Not a registered workspace (legacy/manual path): shared configuration.
+    uid, gid = _worker_uid_gid()
+    return WorkerIdentity(uid=uid, gid=gid, per_run=False)
+
+
+def verify_workspace_ownership(workspace: Path | str) -> None:
+    """Fail closed if a workspace is not private to its assigned identity.
+
+    This is the load-bearing check for the shared-uid fallback: with one
+    worker uid the only boundary between runs is that each workspace stays
+    0700 and owned by exactly the expected identity.
+    """
+    identity = workspace_identity(workspace)
+    expected_uid = identity.uid if identity.uid is not None else os.geteuid()
+    for path in (Path(workspace), Path(workspace) / "tmp"):
+        try:
+            info = os.stat(path)
+        except OSError as exc:
+            raise WorkerIsolationError(f"Workspace path missing: {path}") from exc
+        if not stat.S_ISDIR(info.st_mode):
+            raise WorkerIsolationError(f"Workspace path is not a directory: {path}")
+        if info.st_uid != expected_uid:
+            raise WorkerIsolationError(
+                f"Workspace {path} is owned by uid {info.st_uid}, expected {expected_uid}")
+        if stat.S_IMODE(info.st_mode) & 0o077:
+            raise WorkerIsolationError(
+                f"Workspace {path} is group/world accessible")
+
+
+def create_workspace(prefix: str = "run") -> Path:
+    """Create a fresh private workspace for one run.
+
+    Layout: ``<workspace>/`` is the worker cwd and HOME, ``<workspace>/tmp``
+    is its TMPDIR, ``<workspace>/tools`` holds broker-backed tool shims.
+    Each workspace is bound to a worker identity: a per-run uid when
+    LOMA_WORKER_UID_RANGE is configured (backend running as root), else the
+    shared LOMA_WORKER_UID.
+    """
+    root = worker_root()
+    root.mkdir(parents=True, exist_ok=True)
+    os.chmod(root, 0o711)  # traversable, not listable, for non-root workers
+    workspace = root / f"{prefix}-{secrets.token_hex(8)}"
+
+    # File lock also serializes independent backend processes on this host.
+    lock_fd = os.open(root / ".identity.lock", os.O_CREAT | os.O_RDWR | os.O_NOFOLLOW, 0o600)
+    with os.fdopen(lock_fd, "w") as allocation_lock, _identity_lock:
+        fcntl.flock(allocation_lock, fcntl.LOCK_EX)
+        identity = _allocate_identity()
+        workspace.mkdir(mode=0o700)
+        (workspace / "tmp").mkdir(mode=0o700)
+        (workspace / "tools").mkdir(mode=0o700)
+        if identity.uid is not None:
+            for p in (workspace, workspace / "tmp", workspace / "tools"):
+                os.chown(p, identity.uid, identity.gid)
+        _workspace_identities[str(workspace.resolve())] = identity
+    return workspace
+
+
+def grant_worker_access(path: Path | str, recursive: bool = True,
+                        workspace: Path | str | None = None) -> None:
+    """Make a path owned by a worker identity (when privilege drop is active).
+
+    Needed for state the runtime CLIs themselves must read/write inside the
+    sandbox. Pass the run's ``workspace`` so ownership goes to that run's
+    identity; without it the shared configured uid is used. No-op when
+    privilege drop is not active.
+    """
+    if workspace is not None:
+        identity = workspace_identity(workspace)
+        uid, gid = identity.uid, identity.gid
+    else:
+        uid, gid = _worker_uid_gid()
+    if uid is None:
+        return
+    path = Path(path)
+    try:
+        os.chown(path, uid, gid)
+        if recursive and path.is_dir():
+            for child in path.rglob("*"):
+                os.chown(child, uid, gid, follow_symlinks=False)
+    except OSError:
+        logger.warning("Could not grant worker access to %s", path)
+
+
+def cleanup_workspace(workspace: Path | str) -> None:
+    """Best-effort removal of a run workspace after the run ends."""
+    workspace = Path(workspace)
+    try:
+        # Only ever delete inside the worker root.
+        workspace.resolve().relative_to(worker_root().resolve())
+    except ValueError:
+        logger.error("Refusing to delete non-workspace path %s", workspace)
+        return
+    from broker import sandbox
+    if sandbox.enabled():
+        sandbox.cleanup(workspace)
+    if os.environ.get("LOMA_KEEP_WORKSPACES", "").lower() in {"1", "true", "yes"}:
+        return
+    shutil.rmtree(workspace, ignore_errors=True)
+    # Release the workspace's per-run uid only after its files are gone.
+    with _identity_lock:
+        _workspace_identities.pop(str(workspace.resolve()), None)
+
+
+def _tool_path_dirs() -> list[str]:
+    """PATH entries for the worker: standard bins plus runtime CLI locations."""
+    dirs: list[str] = []
+    for exe in ("python3", "node", "claude", "opencode", "codex", "npx"):
+        found = shutil.which(exe)
+        if found:
+            parent = str(Path(found).parent)
+            if parent not in dirs:
+                dirs.append(parent)
+    for standard in ("/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"):
+        if standard not in dirs:
+            dirs.append(standard)
+    return dirs
+
+
+def build_worker_env(
+    workspace: Path | str,
+    extra: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Construct the ONLY environment a worker process may receive.
+
+    Allowlist-only. ``extra`` is for runtime-specific, non-secret settings
+    (e.g. CLAUDE_CONFIG_DIR, XDG_CONFIG_HOME, LOMA_BROKER_URL,
+    LOMA_RUN_CAPABILITY). Keys with secret-looking names are rejected unless
+    explicitly worker-scoped, and known backend secret values are rejected
+    outright wherever they appear.
+    """
+    workspace = Path(workspace)
+    env: dict[str, str] = {
+        "PATH": ":".join(_tool_path_dirs()),
+        "HOME": str(workspace),
+        "PWD": str(workspace),
+        "TMPDIR": str(workspace / "tmp"),
+        "TERM": "xterm-256color",
+        "LOMA_ISOLATED_WORKER": "1",
+    }
+    for name in _PASSTHROUGH_BASE:
+        value = os.environ.get(name)
+        if value:
+            env[name] = value
+
+    for key, value in (extra or {}).items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            raise WorkerIsolationError("Worker env entries must be strings")
+        if key in FORBIDDEN_ENV_NAMES:
+            raise WorkerIsolationError(f"Refusing to pass backend secret env var to worker: {key}")
+        if _SENSITIVE_NAME_RE.search(key) and key not in _EXTRA_ALLOWED_SENSITIVE:
+            raise WorkerIsolationError(f"Refusing sensitive-looking env var in worker env: {key}")
+        env[key] = value
+
+    assert_worker_env_clean(env)
+    return env
+
+
+def assert_worker_env_clean(env: dict[str, str]) -> None:
+    """Fail closed if a worker env contains backend secret names or values."""
+    for name in FORBIDDEN_ENV_NAMES:
+        if name in env:
+            raise WorkerIsolationError(f"Worker env contains forbidden variable {name}")
+    # Value-level check: no backend secret value may be smuggled under any name.
+    backend_secret_values = {
+        value for name in FORBIDDEN_ENV_NAMES | _VALUE_DENYLIST_EXTRA
+        if (value := os.environ.get(name, "").strip())
+    }
+    if not backend_secret_values:
+        return
+    for key, value in env.items():
+        # No exemptions: even worker-scoped keys may never carry a value
+        # equal to a backend secret.
+        for secret_value in backend_secret_values:
+            if secret_value and secret_value in value:
+                raise WorkerIsolationError(
+                    f"Worker env variable {key} contains a backend secret value"
+                )
+
+
+# ── Resource limits ───────────────────────────────────────────────────────
+
+_RLIMIT_DEFAULTS = {
+    "LOMA_WORKER_CPU_SECONDS": 3600,           # per-process CPU time
+    "LOMA_WORKER_AS_BYTES": 8 * 1024 ** 3,     # virtual memory
+    "LOMA_WORKER_FSIZE_BYTES": 2 * 1024 ** 3,  # max created file size
+    "LOMA_WORKER_NOFILE": 4096,
+    "LOMA_WORKER_NPROC": 512,
+}
+
+
+def _limit(name: str) -> int:
+    try:
+        return int(os.environ.get(name, str(_RLIMIT_DEFAULTS[name])))
+    except ValueError:
+        return _RLIMIT_DEFAULTS[name]
+
+
+def worker_preexec_fn(setsid: bool = True,
+                      workspace: Path | str | None = None):
+    """Build the ``preexec_fn`` applied in the child before exec.
+
+    Applies setsid, umask, rlimits, and (when configured and running as root)
+    drops privileges to the workspace's worker identity (per-run uid when
+    allocated, else the shared configured uid). Pass ``setsid=False`` for
+    children that are already session leaders (e.g. after pty.fork).
+    """
+    if workspace is not None:
+        identity = workspace_identity(workspace)
+        uid, gid = identity.uid, identity.gid
+    else:
+        uid, gid = _worker_uid_gid()
+    limits = [
+        (resource.RLIMIT_CORE, (0, 0)),
+        (resource.RLIMIT_CPU, (_limit("LOMA_WORKER_CPU_SECONDS"),) * 2),
+        (resource.RLIMIT_FSIZE, (_limit("LOMA_WORKER_FSIZE_BYTES"),) * 2),
+        (resource.RLIMIT_NOFILE, (_limit("LOMA_WORKER_NOFILE"),) * 2),
+    ]
+    as_bytes = _limit("LOMA_WORKER_AS_BYTES")
+    if as_bytes > 0:
+        limits.append((resource.RLIMIT_AS, (as_bytes, as_bytes)))
+    nproc = _limit("LOMA_WORKER_NPROC")
+    # Load libc before fork; never permit setuid binaries to regain privilege.
+    libc = ctypes.CDLL(None, use_errno=True)
+
+    def _preexec():  # pragma: no cover - runs in the forked child
+        if setsid:
+            os.setsid()
+        if libc.prctl(38, 1, 0, 0, 0) != 0:  # PR_SET_NO_NEW_PRIVS
+            raise WorkerIsolationError("Could not disable privilege escalation")
+        os.umask(0o077)
+        for which, limit in limits:
+            try:
+                resource.setrlimit(which, limit)
+            except (ValueError, OSError):
+                pass
+        if uid is not None:
+            try:
+                resource.setrlimit(resource.RLIMIT_NPROC, (nproc, nproc))
+            except (ValueError, OSError):
+                pass
+            os.setgroups([])
+            os.setgid(gid)
+            os.setuid(uid)
+
+    return _preexec
+
+
+# ── Optional bubblewrap wrapping ─────────────────────────────────────────
+
+def bwrap_available() -> bool:
+    requested = os.environ.get("LOMA_WORKER_BWRAP", "").lower() in {"1", "true", "yes"}
+    if requested and shutil.which("bwrap") is None:
+        raise WorkerIsolationError("Requested worker isolation is unavailable: bubblewrap is missing")
+    return requested
+
+
+def build_bwrap_argv(argv: list[str], workspace: Path | str) -> list[str]:
+    """Wrap a worker command with bubblewrap: read-only system, private
+    workspace bind, unshared pid/ipc/uts namespaces, no other host paths.
+
+    Network stays shared so the worker can reach the local broker/gateway;
+    egress restriction is a network-policy concern (see docs).
+    """
+    workspace = str(workspace)
+    wrapper = [
+        "bwrap",
+        "--die-with-parent",
+        "--unshare-pid", "--unshare-ipc", "--unshare-uts",
+        "--proc", "/proc",
+        "--dev", "/dev",
+        "--tmpfs", "/tmp",
+    ]
+    for ro in ("/usr", "/bin", "/lib", "/lib64", "/sbin", "/etc/ssl",
+               "/etc/resolv.conf", "/etc/hosts", "/etc/nsswitch.conf",
+               "/etc/ca-certificates"):
+        if os.path.exists(ro):
+            wrapper += ["--ro-bind", ro, ro]
+    wrapper += ["--bind", workspace, workspace, "--chdir", workspace, "--"]
+    return wrapper + list(argv)
+
+
+# ── Spawning ─────────────────────────────────────────────────────────────
+
+async def spawn_worker(
+    argv: list[str],
+    *,
+    workspace: Path | str,
+    env: dict[str, str],
+    stdin=asyncio.subprocess.DEVNULL,
+    stdout=asyncio.subprocess.PIPE,
+    stderr=asyncio.subprocess.PIPE,
+    wall_time_seconds: int | None = None,
+) -> asyncio.subprocess.Process:
+    """Spawn a sandboxed worker subprocess.
+
+    The environment is validated (fail closed) and passed verbatim — nothing
+    is inherited from the backend process. The child gets its own session and
+    resource limits; an optional wall-clock watchdog kills the process group.
+    """
+    assert_worker_env_clean(env)
+    verify_workspace_ownership(workspace)
+    from broker import sandbox
+    isolated = sandbox.enabled()
+    ingress_server = None
+    if isolated:
+        ingress_port = env.get('LOMA_SANDBOX_INGRESS_PORT')
+        if ingress_port:
+            ingress_server = await sandbox.ingress(int(ingress_port), workspace)
+        try:
+            argv = sandbox.prepare(argv, workspace, env)
+        except BaseException:
+            if ingress_server:
+                ingress_server.close()
+            raise
+    elif bwrap_available():
+        argv = build_bwrap_argv(argv, workspace)
+    try:
+        process = await asyncio.create_subprocess_exec(
+            *argv, cwd=str(workspace),
+            env={'PATH': '/usr/local/bin:/usr/bin:/bin'} if isolated else env,
+            stdin=stdin, stdout=stdout, stderr=stderr,
+            preexec_fn=None if isolated else worker_preexec_fn(workspace=workspace),
+            start_new_session=isolated,
+        )
+    except BaseException:
+        if ingress_server:
+            ingress_server.close()
+        raise
+    if ingress_server:
+        async def close_ingress():
+            await process.wait()
+            ingress_server.close()
+            await ingress_server.wait_closed()
+        asyncio.get_running_loop().create_task(close_ingress())
+    if wall_time_seconds and wall_time_seconds > 0:
+        asyncio.get_running_loop().create_task(
+            _wall_time_watchdog(process, wall_time_seconds)
+        )
+    return process
+
+
+async def _wall_time_watchdog(process: asyncio.subprocess.Process, seconds: int) -> None:
+    try:
+        await asyncio.wait_for(process.wait(), timeout=seconds)
+    except asyncio.TimeoutError:
+        logger.warning("Worker pid=%s exceeded wall time %ss; killing", process.pid, seconds)
+        terminate_worker(process)
+
+
+def terminate_worker(process: asyncio.subprocess.Process) -> None:
+    """Kill a worker and its whole process group."""
+    import signal
+
+    if process.returncode is not None:
+        return
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        try:
+            process.kill()
+        except ProcessLookupError:
+            pass
+
+
+# ── Launcher script for SDK-spawned CLIs ─────────────────────────────────
+
+def write_cli_launcher(
+    workspace: Path | str,
+    real_cli: str,
+    env: dict[str, str],
+    passthrough: tuple[str, ...] = (),
+) -> Path:
+    """Write a launcher the Claude Agent SDK spawns instead of ``claude``.
+
+    The SDK merges ``os.environ`` into its subprocess env, so a plain
+    ``options.env`` override cannot prevent backend-secret inheritance.
+    The launcher re-execs the real CLI through ``env -i`` with only the
+    validated worker env plus explicitly named passthrough variables that
+    the SDK itself must set (e.g. CLAUDE_CODE_ENTRYPOINT).
+    """
+    workspace = Path(workspace)
+    assert_worker_env_clean(env)
+    verify_workspace_ownership(workspace)
+    for name in passthrough:
+        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name):
+            raise WorkerIsolationError(f"Invalid passthrough var name: {name}")
+        if name in FORBIDDEN_ENV_NAMES or (
+            _SENSITIVE_NAME_RE.search(name) and name not in _EXTRA_ALLOWED_SENSITIVE
+        ):
+            raise WorkerIsolationError(f"Refusing sensitive passthrough var: {name}")
+
+    from broker import sandbox
+    if sandbox.enabled():
+        return sandbox.launcher(workspace, real_cli, env, passthrough)
+
+    def _sh_quote(value: str) -> str:
+        return "'" + value.replace("'", "'\\''") + "'"
+
+    # When the backend runs as root with a worker identity configured, the
+    # launcher also drops privileges (to the workspace's per-run uid when
+    # allocated) before exec'ing the CLI, so even SDK-spawned workers never
+    # run as root.
+    identity = workspace_identity(workspace)
+    uid, gid = identity.uid, identity.gid
+    drop = ""
+    if uid is not None:
+        if not shutil.which("setpriv"):
+            raise WorkerIsolationError("Cannot enforce SDK worker identity: setpriv is missing")
+        drop = f"setpriv --no-new-privs --reuid {uid} --regid {gid} --clear-groups "
+
+    lines = [
+        "#!/bin/sh",
+        "# Managed by Loma — scrubs the environment before exec'ing the agent CLI.",
+        "ulimit -c 0 2>/dev/null",
+        f"ulimit -t {_limit('LOMA_WORKER_CPU_SECONDS')} 2>/dev/null",
+        f"ulimit -n {_limit('LOMA_WORKER_NOFILE')} 2>/dev/null",
+        "exec /usr/bin/env -i \\",
+    ]
+    for key, value in env.items():
+        lines.append(f"  {key}={_sh_quote(value)} \\")
+    for name in passthrough:
+        # Forward the SDK-set value if present (never a backend secret name).
+        lines.append(f"  {name}=\"${{{name}}}\" \\")
+    command = build_bwrap_argv([real_cli], workspace) if bwrap_available() else [real_cli]
+    lines.append(f"  {drop}{' '.join(_sh_quote(arg) for arg in command)} \"$@\"")
+
+    launcher = workspace / "loma-cli-launcher.sh"
+    launcher.write_text("\n".join(lines) + "\n")
+    os.chmod(launcher, 0o755)
+    if uid is not None:
+        os.chown(launcher, uid, gid)
+    return launcher
+
+
+# ── Broker-backed tool shims ─────────────────────────────────────────────
+
+_SHIM_TEMPLATE = '''#!/usr/bin/env python3
+"""Broker-backed shim for the {tool!r} Loma tool (generated per run).
+
+Runs inside an isolated worker with no backend credentials. Forwards the
+invocation to the execution broker, which authenticates the run capability
+and executes the real tool server-side with the run owner's identity.
+"""
+import base64
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+TOOL = {tool!r}
+STDIN_COMMANDS = {stdin_commands!r}
+MAX_UPLOAD_BYTES = 1024 * 1024
+
+
+def _capability(argv):
+    for i, arg in enumerate(argv):
+        if arg.startswith("--auth-token="):
+            return arg.split("=", 1)[1]
+        if arg == "--auth-token" and i + 1 < len(argv):
+            return argv[i + 1]
+    return os.environ.get("LOMA_RUN_CAPABILITY", "")
+
+
+def main():
+    argv = sys.argv[1:]
+    broker_url = os.environ.get("LOMA_BROKER_URL", "http://127.0.0.1:3100").rstrip("/")
+    capability = _capability(argv)
+    if not capability:
+        print(json.dumps({{"error": "No run capability is available in this "
+                          "environment; personal tools are disabled for this run."}}))
+        return 1
+
+    files = {{}}
+    total = 0
+    workspace = os.environ.get("HOME", "")
+    input_flags = {{"--attachments", "--file", "--file-path", "--content-file",
+                   "--skill-md", "--attachment", "--html-body-file", "--files-json-file", "--code-file"}}
+    candidates = []
+    for index, arg in enumerate(argv):
+        flag, sep, value = arg.partition("=")
+        if flag not in input_flags:
+            continue
+        if not sep:
+            value = argv[index + 1] if index + 1 < len(argv) else ""
+        candidates.extend(value.split(",") if flag == "--attachments" else [value])
+    for arg in candidates:
+        arg = arg.strip()
+        try:
+            if (workspace and arg and os.path.isfile(arg)
+                    and os.path.commonpath([os.path.realpath(arg), os.path.realpath(workspace)]) == os.path.realpath(workspace)
+                    and len(files) < 8):
+                with open(arg, "rb") as fh:
+                    content = fh.read(MAX_UPLOAD_BYTES + 1)
+                size = len(content)
+                if size <= MAX_UPLOAD_BYTES and total + size <= MAX_UPLOAD_BYTES:
+                    files[arg] = {{"encoding": "base64", "data": base64.b64encode(content).decode("ascii")}}
+                    total += size
+        except (OSError, UnicodeDecodeError, ValueError):
+            continue
+
+    stdin_text = ""
+    clean = []
+    skip = False
+    for arg in argv:
+        if skip:
+            skip = False
+            continue
+        if arg in ("--auth-token", "--user-email"):
+            skip = True
+        elif not arg.startswith(("--auth-token=", "--user-email=")):
+            clean.append(arg)
+    if clean and clean[0] in STDIN_COMMANDS and not sys.stdin.isatty():
+        stdin_text = sys.stdin.read(200001)
+        if len(stdin_text.encode("utf-8")) > 200000:
+            print(json.dumps({{"error": "Tool input is too large"}}))
+            return 1
+    payload = json.dumps({{
+        "operation": "tool.invoke",
+        "resource": TOOL,
+        "params": {{"argv": argv, "files": files, "stdin": stdin_text}},
+    }}).encode()
+    request = urllib.request.Request(
+        broker_url + "/v1/invoke", data=payload,
+        headers={{"Authorization": "Bearer " + capability,
+                  "Content-Type": "application/json"}},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=180) as response:
+            body = json.loads(response.read().decode())
+    except urllib.error.HTTPError as exc:
+        try:
+            body = json.loads(exc.read().decode())
+        except Exception:
+            body = {{"error": "Broker request failed"}}
+        print(json.dumps(body))
+        return 1
+    except Exception:
+        print(json.dumps({{"error": "Could not reach the Loma execution broker."}}))
+        return 1
+
+    if isinstance(body, dict) and "stdout" in body:
+        for output_path, artifact in body.get("artifacts", {{}}).items():
+            try:
+                target = os.path.abspath(output_path)
+                root = os.path.realpath(workspace)
+                if os.path.commonpath([os.path.realpath(target), root]) != root:
+                    raise ValueError("Output must be inside this workspace")
+                if artifact.get("encoding") != "base64":
+                    raise ValueError("Invalid output encoding")
+                content = base64.b64decode(artifact["data"], validate=True)
+                if len(content) > 1500000:
+                    raise ValueError("Output too large")
+                fd = os.open(target, os.O_CREAT | os.O_WRONLY | os.O_TRUNC | os.O_NOFOLLOW, 0o600)
+                with os.fdopen(fd, "wb") as fh:
+                    fh.write(content)
+            except (OSError, ValueError, KeyError):
+                print(json.dumps({{"error": "Could not safely save the generated artifact"}}))
+                return 1
+        sys.stdout.write(body.get("stdout") or "")
+        stderr_text = body.get("stderr") or ""
+        if stderr_text:
+            sys.stderr.write(stderr_text)
+        return int(body.get("exit_code") or 0)
+    print(json.dumps(body))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+'''
+
+
+def populate_tool_shims(workspace: Path | str, tool_names: list[str]) -> None:
+    """Write broker-backed shims into ``<workspace>/tools/<name>.py``.
+
+    Agent prompts reference tools as ``python3 tools/<name>.py``; with the
+    worker cwd set to its workspace, these shims replace the real tools,
+    which now only run server-side via the broker.
+    """
+    tools_dir = Path(workspace) / "tools"
+    tools_dir.mkdir(mode=0o700, exist_ok=True)
+    for tool in tool_names:
+        if not re.fullmatch(r"[a-z0-9_]{1,64}", tool):
+            raise WorkerIsolationError(f"Invalid tool shim name: {tool}")
+        shim = tools_dir / f"{tool}.py"
+        from broker.tool_policy import POLICY
+        stdin_commands = sorted(name for name, spec in POLICY.get(tool, {}).items() if spec.stdin)
+        from broker import sandbox
+        if tool == 'pptx_creator' and sandbox.enabled():
+            shim.write_text("#!/usr/bin/env python3\nimport runpy\nrunpy.run_path('/opt/loma-render/tools/pptx_creator.py', run_name='__main__')\n")
+        else:
+            shim.write_text(_SHIM_TEMPLATE.format(tool=tool, stdin_commands=stdin_commands))
+        os.chmod(shim, 0o755)
+    identity = workspace_identity(workspace)
+    if identity.uid is not None:
+        os.chown(tools_dir, identity.uid, identity.gid)
+        for shim_file in tools_dir.iterdir():
+            os.chown(shim_file, identity.uid, identity.gid)

--- a/dashboard/src/app/agents/page.tsx
+++ b/dashboard/src/app/agents/page.tsx
@@ -121,6 +121,7 @@ export default function AgentsPage() {
   const { user, hasRole } = useUser();
   const [agents, setAgents] = useState<AgentIdentity[]>([]);
   const [skills, setSkills] = useState<Skill[]>([]);
+  const [skillsError, setSkillsError] = useState<string | null>(null);
   const [integrations, setIntegrations] = useState<Integration[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -145,7 +146,10 @@ export default function AgentsPage() {
     loadAgents();
     fetchSkills()
       .then((data) => setSkills(data.skills || []))
-      .catch(() => setSkills([]));
+      .catch(() => {
+        setSkills([]);
+        setSkillsError("Skills could not be loaded. Reload the page to try again.");
+      });
     fetchIntegrations()
       .then((list) => setIntegrations(list.filter((i) => i.status === "connected")))
       .catch(() => setIntegrations([]));
@@ -386,6 +390,7 @@ export default function AgentsPage() {
                 />
               </div>
 
+              {skillsError && <p role="alert" className="text-sm text-destructive">{skillsError}</p>}
               {skills.length > 0 && (
                 <div className="grid gap-1.5">
                   <Label>Skills</Label>

--- a/dashboard/src/app/api/whoami/route.ts
+++ b/dashboard/src/app/api/whoami/route.ts
@@ -1,4 +1,5 @@
 import { auth } from "@/auth";
+import { signProxyIdentity } from "@/lib/proxy-identity";
 
 export const runtime = "nodejs";
 
@@ -16,8 +17,11 @@ export async function GET() {
   if (!email) {
     return new Response(null, { status: 401 });
   }
-  return new Response(null, {
-    status: 200,
-    headers: { "X-Auth-Email": email },
-  });
+  try {
+    return new Response(null, { status: 200, headers: {
+      ...await signProxyIdentity(email), "Cache-Control": "no-store",
+    } });
+  } catch {
+    return new Response(null, { status: 503 });
+  }
 }

--- a/dashboard/src/app/integrations/manage/page.tsx
+++ b/dashboard/src/app/integrations/manage/page.tsx
@@ -16,13 +16,11 @@ import {
 import {
   fetchClaudeAuthStatus,
   disconnectClaude,
-  getClaudeLoginTerminalToken,
   type ClaudeAuthStatus,
 } from "../../../lib/claude-auth-api";
 import {
   fetchCodexAuthStatus,
   disconnectCodex,
-  getCodexLoginTerminalToken,
   type CodexAuthStatus,
 } from "../../../lib/codex-auth-api";
 import {
@@ -56,6 +54,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, Di
 import { Separator } from "@/components/ui/separator";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { RiCloseLine, RiFileCopyLine, RiArrowDownSLine, RiArrowRightSLine } from "@remixicon/react";
+import GrainWebhookPanel from "../../../components/GrainWebhookPanel";
 import ApiKeysPanel from "../../../components/ApiKeysPanel";
 
 const INTEGRATION_TABS = ["org", "system", "custom", "personal", "api-keys"] as const;
@@ -441,7 +440,7 @@ export default function IntegrationsPage() {
   const [disconnectingOrg, setDisconnectingOrg] = useState<string | null>(null);
   const [webhookUrls, setWebhookUrls] = useState<Record<string, string>>({});
 
-  const { isAdmin } = useUser();
+  const { isAdmin, user } = useUser();
 
   const [showCustomModal, setShowCustomModal] = useState(false);
   const [customForm, setCustomForm] = useState({
@@ -461,12 +460,10 @@ export default function IntegrationsPage() {
 
   const [claudeAuth, setClaudeAuth] = useState<ClaudeAuthStatus | null>(null);
   const [showClaudeTerminal, setShowClaudeTerminal] = useState(false);
-  const [claudeAutoCommand, setClaudeAutoCommand] = useState<string | undefined>();
   const [disconnectingClaude, setDisconnectingClaude] = useState(false);
 
   const [codexAuth, setCodexAuth] = useState<CodexAuthStatus | null>(null);
   const [showCodexTerminal, setShowCodexTerminal] = useState(false);
-  const [codexAutoCommand, setCodexAutoCommand] = useState<string | undefined>();
   const [disconnectingCodex, setDisconnectingCodex] = useState(false);
 
   const [telegramStatus, setTelegramStatus] = useState<TelegramStatus | null>(null);
@@ -745,15 +742,9 @@ export default function IntegrationsPage() {
     }
   };
 
-  const handleConnectClaude = async () => {
+  const handleConnectClaude = () => {
     setError(null);
-    try {
-      const { autoCommand } = await getClaudeLoginTerminalToken();
-      setClaudeAutoCommand(autoCommand);
-      setShowClaudeTerminal(true);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to start Claude login");
-    }
+    setShowClaudeTerminal(true);
   };
 
   const handleDisconnectClaude = async () => {
@@ -771,15 +762,9 @@ export default function IntegrationsPage() {
     }
   };
 
-  const handleConnectCodex = async () => {
+  const handleConnectCodex = () => {
     setError(null);
-    try {
-      const { autoCommand } = await getCodexLoginTerminalToken();
-      setCodexAutoCommand(autoCommand);
-      setShowCodexTerminal(true);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to start Codex login");
-    }
+    setShowCodexTerminal(true);
   };
 
   const handleDisconnectCodex = async () => {
@@ -1201,9 +1186,9 @@ export default function IntegrationsPage() {
       ) : (
         <Tabs value={activeTab} onValueChange={handleTabChange}>
           <TabsList>
-            <TabsTrigger value="org">Org</TabsTrigger>
+            <TabsTrigger value="org">Organization-managed</TabsTrigger>
             <TabsTrigger value="system">System</TabsTrigger>
-            <TabsTrigger value="custom">Custom</TabsTrigger>
+            <TabsTrigger value="custom">Personal connectors</TabsTrigger>
             <TabsTrigger value="personal">Personal</TabsTrigger>
             <TabsTrigger value="api-keys">API Keys</TabsTrigger>
           </TabsList>
@@ -1408,6 +1393,7 @@ export default function IntegrationsPage() {
 
           {/* Custom MCP Connectors */}
           <TabsContent value="custom">
+            <p className="text-sm text-muted-foreground mb-3">These connectors belong to your account and are not shared with other users.</p>
             <div className="flex justify-end mb-2">
               <Button size="sm" onClick={() => setShowCustomModal(true)}>
                 Add custom connector
@@ -1766,6 +1752,7 @@ export default function IntegrationsPage() {
                       </Button>
                     )}
                   </div>
+                  {grainConn?.status === "connected" && <GrainWebhookPanel key={user?.email} />}
                   {grainConn?.status === "connected" && grainConn?.connected_at && (
                     <>
                       <Separator className="my-5" />
@@ -1783,7 +1770,7 @@ export default function IntegrationsPage() {
                   <DialogTitle>Login with Claude Code</DialogTitle>
                   <DialogDescription>Complete the OAuth flow in the terminal below</DialogDescription>
                 </DialogHeader>
-                <WebTerminal autoCommand={claudeAutoCommand} tokenEndpoint="/api/terminal/token" />
+                <WebTerminal tokenEndpoint="/api/claude-auth/terminal-token" />
                 <DialogFooter>
                   <Button variant="outline" onClick={handleClaudeTerminalDone}>Done</Button>
                 </DialogFooter>
@@ -1796,7 +1783,7 @@ export default function IntegrationsPage() {
                   <DialogTitle>Login with ChatGPT</DialogTitle>
                   <DialogDescription>Approve the device code at chatgpt.com, then finish below</DialogDescription>
                 </DialogHeader>
-                <WebTerminal autoCommand={codexAutoCommand} tokenEndpoint="/api/terminal/token" />
+                <WebTerminal tokenEndpoint="/api/codex-auth/terminal-token" />
                 <DialogFooter>
                   <Button variant="outline" onClick={handleCodexTerminalDone}>Done</Button>
                 </DialogFooter>

--- a/dashboard/src/components/GrainWebhookPanel.tsx
+++ b/dashboard/src/components/GrainWebhookPanel.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { fetchGrainWebhook, rotateGrainWebhook, revokeGrainWebhook,
+  type GrainWebhookStatus, type GrainWebhookCredential } from "@/lib/oauth-api";
+import { Button } from "@/components/ui/button";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
+
+export default function GrainWebhookPanel() {
+  const [status, setStatus] = useState<GrainWebhookStatus | null>(null);
+  const [credential, setCredential] = useState<GrainWebhookCredential | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+  const [confirm, setConfirm] = useState<"rotate" | "revoke" | null>(null);
+  useEffect(() => {
+    let active = true;
+    fetchGrainWebhook().then(value => { if (active) setStatus(value); })
+      .catch(() => { if (active) setError("Could not load webhook settings. Reload to retry."); });
+    return () => { active = false; };
+  }, []);
+
+  async function change(action: "rotate" | "revoke") {
+    setBusy(true);
+    setError("");
+    setCredential(null);
+    try {
+      if (action === "rotate") {
+        const issued = await rotateGrainWebhook();
+        setStatus({ enabled: true, path: issued.path, expires_at: issued.expires_at });
+        setCredential(issued);
+      } else {
+        await revokeGrainWebhook();
+        setStatus(value => value ? { ...value, enabled: false, expires_at: null } : null);
+      }
+      setConfirm(null);
+    } catch {
+      // Never surface arbitrary response bodies beside one-time credentials.
+      setError("Could not update the webhook. Reload its status before retrying.");
+    } finally { setBusy(false); }
+  }
+
+  return <div className="mt-4 space-y-3 border-t pt-4">
+    <div>
+      <h3 className="text-xs font-semibold">Personal recording automation</h3>
+      <p className="mt-1 text-xs text-muted-foreground">
+        Deliver recording IDs through your automation sender. Transcripts remain private to you.
+        This does not register a webhook automatically with Grain.
+      </p>
+    </div>
+    <p className="text-xs text-muted-foreground" role="status">
+      {!status ? "Loading settings..." : status.enabled
+        ? `Enabled until ${new Date(status.expires_at!).toLocaleString()}` : "Not enabled"}
+    </p>
+    {error && <Alert variant="destructive"><AlertDescription>{error}</AlertDescription></Alert>}
+    <div className="flex gap-2">
+      <Button size="xs" variant="outline" disabled={busy || !status} onClick={() => setConfirm("rotate")}>
+        {status?.enabled ? "Rotate webhook credential" : "Enable webhook"}
+      </Button>
+      {status?.enabled && <Button size="xs" variant="destructive" disabled={busy} onClick={() => setConfirm("revoke")}>Revoke</Button>}
+    </div>
+    <Dialog open={confirm !== null} onOpenChange={open => { if (!open && !busy) setConfirm(null); }}>
+      <DialogContent><DialogHeader>
+        <DialogTitle>{confirm === "revoke" ? "Revoke personal webhook?" : "Issue personal webhook credential?"}</DialogTitle>
+        <DialogDescription>Existing credentials stop working immediately. Update your automation sender after rotation.</DialogDescription>
+      </DialogHeader><DialogFooter>
+        <Button variant="outline" disabled={busy} onClick={() => setConfirm(null)}>Cancel</Button>
+        <Button disabled={busy} onClick={() => confirm && change(confirm)}>{busy ? "Saving..." : "Confirm"}</Button>
+      </DialogFooter></DialogContent>
+    </Dialog>
+    <Dialog open={credential !== null} onOpenChange={open => { if (!open) setCredential(null); }}>
+      <DialogContent><DialogHeader>
+        <DialogTitle>Save your webhook credential</DialogTitle>
+        <DialogDescription>Shown once. Store it securely in your sender, never in a URL or shared chat. Closing clears it from this page.</DialogDescription>
+      </DialogHeader>
+      {credential && <div className="space-y-3 text-xs">
+        <p>POST to your externally reachable Loma backend origin with this path:</p>
+        <code className="block break-all select-all">{credential.path}</code>
+        <p>Authorization header:</p>
+        <code className="block break-all select-all">{credential.authorization}</code>
+        <p>JSON body:</p><code className="block select-all">{'{"recording_id":"YOUR_RECORDING_ID"}'}</code>
+        <p>Expires {new Date(credential.expires_at).toLocaleString()}.</p>
+      </div>}
+      <DialogFooter><Button onClick={() => setCredential(null)}>I saved it securely</Button></DialogFooter>
+      </DialogContent>
+    </Dialog>
+  </div>;
+}

--- a/dashboard/src/lib/claude-auth-api.ts
+++ b/dashboard/src/lib/claude-auth-api.ts
@@ -20,7 +20,7 @@ export async function fetchClaudeAuthStatus(): Promise<ClaudeAuthStatus> {
   return res.json();
 }
 
-export async function getClaudeLoginTerminalToken(): Promise<{ token: string; autoCommand: string }> {
+export async function getClaudeLoginTerminalToken(): Promise<{ token: string }> {
   const res = await fetch(`${API_BASE}/api/claude-auth/terminal-token`, { method: "POST" });
   if (!res.ok) {
     const err = await res.json().catch(() => ({ error: "Unknown error" }));

--- a/dashboard/src/lib/codex-auth-api.ts
+++ b/dashboard/src/lib/codex-auth-api.ts
@@ -21,7 +21,7 @@ export async function fetchCodexAuthStatus(): Promise<CodexAuthStatus> {
   return res.json();
 }
 
-export async function getCodexLoginTerminalToken(): Promise<{ token: string; autoCommand: string }> {
+export async function getCodexLoginTerminalToken(): Promise<{ token: string }> {
   const res = await fetch(`${API_BASE}/api/codex-auth/terminal-token`, { method: "POST" });
   if (!res.ok) {
     const err = await res.json().catch(() => ({ error: "Unknown error" }));

--- a/dashboard/src/lib/integration-api.ts
+++ b/dashboard/src/lib/integration-api.ts
@@ -14,6 +14,7 @@ export interface ExtraFieldDef {
 }
 
 export interface Integration {
+  scope?: "personal" | "organization";
   provider: string;
   display_name: string;
   description: string;

--- a/dashboard/src/lib/oauth-api.ts
+++ b/dashboard/src/lib/oauth-api.ts
@@ -96,3 +96,29 @@ export async function disconnectCustomMcp(provider: string): Promise<void> {
   });
   if (!res.ok) throw await apiError(res, "Failed to disconnect");
 }
+
+// Owner-bound custom Grain automation. Secrets are returned only on rotation.
+export interface GrainWebhookStatus {
+  enabled: boolean;
+  expires_at: string | null;
+  path: string;
+}
+export interface GrainWebhookCredential {
+  authorization: string;
+  expires_at: string;
+  path: string;
+}
+export async function fetchGrainWebhook(): Promise<GrainWebhookStatus> {
+  const res = await fetch(`${API_BASE}/api/integrations/grain/webhook`, { cache: "no-store" });
+  if (!res.ok) throw await apiError(res, "Failed to load personal webhook");
+  return res.json();
+}
+export async function rotateGrainWebhook(): Promise<GrainWebhookCredential> {
+  const res = await fetch(`${API_BASE}/api/integrations/grain/webhook`, { method: "PUT" });
+  if (!res.ok) throw await apiError(res, "Failed to configure personal webhook");
+  return res.json();
+}
+export async function revokeGrainWebhook(): Promise<void> {
+  const res = await fetch(`${API_BASE}/api/integrations/grain/webhook`, { method: "DELETE" });
+  if (!res.ok) throw await apiError(res, "Failed to revoke personal webhook");
+}

--- a/dashboard/src/lib/proxy-identity.ts
+++ b/dashboard/src/lib/proxy-identity.ts
@@ -1,0 +1,17 @@
+/** Purpose-bound assertions for the trusted dashboard-to-backend hop. */
+export async function signProxyIdentity(email: string): Promise<Record<string, string>> {
+  const secret = process.env.BACKEND_PROXY_SECRET;
+  if (!secret || secret.length < 32 || !email || /[\r\n\0]/.test(email)) {
+    throw new Error("Backend proxy authentication is not configured");
+  }
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+  const bytes = new TextEncoder();
+  const key = await crypto.subtle.importKey(
+    "raw", bytes.encode(secret), { name: "HMAC", hash: "SHA-256" }, false, ["sign"],
+  );
+  const signed = await crypto.subtle.sign(
+    "HMAC", key, bytes.encode(`loma-proxy-identity-v1\n${timestamp}\n${email}`),
+  );
+  const signature = Array.from(new Uint8Array(signed), b => b.toString(16).padStart(2, "0")).join("");
+  return { "X-Auth-Email": email, "X-Auth-Timestamp": timestamp, "X-Auth-Signature": signature };
+}

--- a/dashboard/src/middleware.ts
+++ b/dashboard/src/middleware.ts
@@ -1,5 +1,6 @@
 import { auth } from "./auth";
 import { NextResponse } from "next/server";
+import { signProxyIdentity } from "./lib/proxy-identity";
 
 // Paths under /api that must NOT require auth or get the X-User-Email header.
 // /api/whoami is the nginx auth_request target; its own handler reads the session.
@@ -12,7 +13,7 @@ const BYPASS_PREFIXES = ["/webhook", "/metrics"];
 // 307 them to /login and silently break Add to Home Screen on iOS.
 const PUBLIC_ASSET_PREFIXES = ["/manifest.webmanifest", "/icons/", "/sw.js", "/favicon"];
 
-export default auth((req) => {
+export default auth(async (req) => {
   const { pathname } = req.nextUrl;
 
   if (
@@ -37,7 +38,14 @@ export default auth((req) => {
   // (which rewrites() forwards to) can resolve the caller's role.
   if (isApi) {
     const headers = new Headers(req.headers);
-    headers.set("X-User-Email", req.auth?.user?.email || "");
+    try {
+      const assertion = await signProxyIdentity(req.auth?.user?.email || "");
+      headers.set("X-User-Email", assertion["X-Auth-Email"]);
+      headers.set("X-Auth-Timestamp", assertion["X-Auth-Timestamp"]);
+      headers.set("X-Auth-Signature", assertion["X-Auth-Signature"]);
+    } catch {
+      return NextResponse.json({ error: "Authentication unavailable" }, { status: 503 });
+    }
     return NextResponse.next({ request: { headers } });
   }
 

--- a/deploy/nginx/conf.d/loma.conf
+++ b/deploy/nginx/conf.d/loma.conf
@@ -66,6 +66,8 @@ server {
     location /api/ {
         auth_request /_whoami;
         auth_request_set $auth_email $upstream_http_x_auth_email;
+        auth_request_set $auth_timestamp $upstream_http_x_auth_timestamp;
+        auth_request_set $auth_signature $upstream_http_x_auth_signature;
         # This location sets X-User-Email, so nginx will not inherit the
         # proxy_set_header directives from the server block. Repeat the common
         # headers here, including WebSocket upgrade headers for /api/terminal/ws.
@@ -76,6 +78,8 @@ server {
         proxy_set_header X-Forwarded-Host  $host;
         proxy_set_header Upgrade           $http_upgrade;
         proxy_set_header Connection        $connection_upgrade;
+        proxy_set_header X-Auth-Timestamp $auth_timestamp;
+        proxy_set_header X-Auth-Signature $auth_signature;
         proxy_set_header X-User-Email $auth_email;   # overwrites any client value
         proxy_pass http://loma_backend;
     }

--- a/deploy/nginx/templates/loma-tls.conf.template
+++ b/deploy/nginx/templates/loma-tls.conf.template
@@ -71,6 +71,8 @@ server {
     location /api/ {
         auth_request /_whoami;
         auth_request_set $auth_email $upstream_http_x_auth_email;
+        auth_request_set $auth_timestamp $upstream_http_x_auth_timestamp;
+        auth_request_set $auth_signature $upstream_http_x_auth_signature;
         # This location sets X-User-Email, so nginx will not inherit the
         # proxy_set_header directives from the server block. Repeat the common
         # headers here, including WebSocket upgrade headers for /api/terminal/ws.
@@ -81,6 +83,8 @@ server {
         proxy_set_header X-Forwarded-Host  $host;
         proxy_set_header Upgrade           $http_upgrade;
         proxy_set_header Connection        $connection_upgrade;
+        proxy_set_header X-Auth-Timestamp $auth_timestamp;
+        proxy_set_header X-Auth-Signature $auth_signature;
         proxy_set_header X-User-Email $auth_email;   # overwrites any client value
         proxy_pass http://loma_backend;
     }

--- a/deploy/worker-isolation-ci.example.yml
+++ b/deploy/worker-isolation-ci.example.yml
@@ -1,0 +1,43 @@
+name: Worker Isolation
+on:
+  pull_request:
+    paths:
+      - 'broker/**'
+      - 'agent/**'
+      - 'api/terminal_routes.py'
+      - 'Dockerfile'
+      - 'requirements.txt'
+      - 'tests/test_gvisor_execution.py'
+      - '.github/workflows/worker-isolation.yml'
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  gvisor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install test dependencies
+        run: pip install -r requirements.txt pytest pytest-asyncio
+      - name: Install authenticated gVisor distribution
+        run: |
+          curl -fsSL https://gvisor.dev/archive.key | sudo gpg --dearmor -o /usr/share/keyrings/gvisor.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/gvisor.gpg] https://storage.googleapis.com/gvisor/releases release main" | sudo tee /etc/apt/sources.list.d/gvisor.list
+          sudo apt-get update
+          sudo apt-get install -y runsc
+          runsc --version
+      - name: Build secrets-free worker image
+        run: |
+          docker build --target worker-base -t loma-worker-ci .
+          id=$(docker create loma-worker-ci)
+          trap 'docker rm "$id"' EXIT
+          sudo mkdir -p /opt/loma-ci-rootfs
+          docker export "$id" | sudo tar -xpf - -C /opt/loma-ci-rootfs
+      - name: Exercise real sandbox and broker transport
+        run: |
+          sudo env PATH="$PATH" LOMA_TEST_GVISOR=1 LOMA_WORKER_ROOTFS=/opt/loma-ci-rootfs \
+            "$(command -v python)" -m pytest -q tests/test_gvisor_execution.py

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
     env_file: ./dashboard/.env
     environment:
       BACKEND_URL: http://loma-backend:3000
+      BACKEND_PROXY_SECRET: ${BACKEND_PROXY_SECRET:-${OAUTH_ENCRYPTION_KEY}}
     # Loopback only — reached externally through the nginx proxy, not directly.
     ports:
       - "127.0.0.1:${DASHBOARD_HOST_PORT:-3001}:3001"
@@ -62,6 +63,7 @@ services:
     env_file: .env
     environment:
       BACKEND_URL: http://loma-backend:3000
+      BACKEND_PROXY_SECRET: ${BACKEND_PROXY_SECRET:-${OAUTH_ENCRYPTION_KEY}}
     depends_on:
       - loma-backend
     restart: unless-stopped

--- a/docs/execution-security.md
+++ b/docs/execution-security.md
@@ -1,0 +1,295 @@
+# Execution isolation
+
+## Status
+
+**P0 is not verified and this PR remains draft.** The default worker path now
+uses separate gVisor OCI sandboxes, a secrets-free image and broker-only socket
+transports. See [the current worker implementation and rollout gates](worker-sandbox.md).
+Real-runtime CI could not be installed with the available GitHub credential;
+local namespaces are unavailable. Personal OpenCode provider adapters are now implemented, but live
+vendor compatibility is still unresolved. Unit tests do not close these gates.
+
+## Architecture
+
+```
+backend (trusted)                          worker (untrusted, per run)
+─────────────────────────────              ───────────────────────────
+broker/controller.py  ── issues ──────►  run capability (opaque, TTL,
+  per-run capability + workspace           call budget, revocable)
+broker/service.py + broker/http.py  ◄──  tools/<name>.py shims call
+  POST /v1/invoke (loopback)               tool.invoke via the broker;
+  executes real tools server-side          the capability is the worker's
+  with the run owner's identity            broker credential
+broker/gateway.py (loopback)        ◄──  MCP + model traffic; the gateway
+  injects org/user/provider secrets        injects real credentials
+  server-side, never into the worker       server-side
+```
+
+### Development subprocess boundary (not the production default)
+
+Every runtime subprocess and terminal is spawned through `broker/worker.py`:
+
+- **Fresh private workspace per run** (0700) under `LOMA_WORKER_ROOT`;
+  HOME/TMPDIR/cwd point inside it; it is deleted when the run ends.
+- **No backend environment inheritance.** Workers receive only an
+  allowlist-built minimal env (PATH/HOME/TMPDIR/TERM/locale + explicitly
+  validated runtime settings). A denylist of backend secret names AND their
+  values is enforced fail-closed at build and spawn time. For the Claude
+  Agent SDK (which merges `os.environ` into its CLI subprocess), a generated
+  launcher re-execs the CLI through `env -i` with the scrubbed allowlist.
+- **Non-root, per-run identity.** With `LOMA_WORKER_UID_RANGE` set (e.g.
+  `200000-200999`) and the backend running as root, every workspace is
+  bound to its own uid from the range: two concurrent runs of different
+  users are different Unix identities and cannot read or write each other's
+  workspaces, temp files, or shims. Uids are allocated at workspace
+  creation under a process-shared file lock, cross-checked against workspace
+  owners and live process uids (including detached children), and released only after the workspace is
+  deleted. Exhausting the range, configuring a range without root, or a
+  malformed range fails closed.
+  **Fallback (weaker boundary):** without a range, workers drop to the
+  single shared `LOMA_WORKER_UID`/`LOMA_WORKER_GID`. Concurrent runs then
+  share one uid, so directory modes cannot separate them — a compromised
+  run could read a concurrent run's workspace. The fallback enforces strict
+  0700 ownership verification of every workspace before spawn (fail closed
+  on foreign owner or group/world access bits), which protects against
+  backend-side tampering but NOT against a live same-uid sibling worker.
+  Deployments that run concurrent multi-user workloads must configure the
+  uid range (or provide kernel-level per-worker sandboxes).
+- **Resource limits**: CPU time, address space, file size, open files,
+  process count, no core dumps (`RLIMIT_*`), Linux no-new-privileges, own session/process group,
+  wall-clock watchdog, umask 077. Optional bubblewrap wrapping
+  (`LOMA_WORKER_BWRAP=1`) adds mount/pid/ipc/uts namespace isolation where
+  bubblewrap is installed. Explicitly requesting bubblewrap now fails closed
+  if it is unavailable; both SDK launchers and terminals apply the same wrapper.
+  The blanket `/opt` mount is removed. A configured privilege drop cannot silently
+  revert to the backend identity.
+- Runs are revoked and workers/workspaces torn down at run end; pool clients
+  and Codex workers are single-use (one conversation per process).
+
+### Broker (implemented)
+
+- `tool.invoke` accepts only commands and exact flags enumerated in
+  `broker/tool_policy.py`. Registration or an integration grant alone does not
+  authorize an arbitrary command. Unknown commands/flags, duplicate flags, local
+  directory imports and unreviewed renderer utilities fail closed before I/O.
+  File arguments must refer to inline uploads from the same request, never an
+  existing backend path. Scalar text is not rewritten as a file. CLI output is
+  bounded while reading, and cancellation/timeouts terminate the tool process
+  group and remove its uploaded inputs. Identity tokens are explicitly redacted.
+- Direct organization-integration CLI entrypoints require authenticated user
+  credentials and independently check active status, ownership and team/user
+  sharing before dispatch, even when an environment API key exists. No cache is
+  used for this authorization. The broker injects its authenticated owner's
+  identity for these commands as well as personal tools.
+- Skill CLI reads now require an active authenticated user and hide other users'
+  personal skills; direct reads and writes enforce personal ownership.
+- `model.request` — admission for the model gateway. Providers configured
+  with server-side keys (Anthropic/OpenAI/OpenRouter/OpenCode Zen) are
+  reached via `/model/<provider>/…` on the gateway; the worker authenticates
+  with its run capability and the real key is injected server-side. Model routes
+  allow only inference and model catalog operations, not arbitrary provider APIs.
+- `grain.transcript` — unchanged personal-OAuth read-only adapter.
+- `mcp.request` binds each proxy to a run capability and rechecks account status,
+  integration ownership/sharing and personal connection availability per call.
+- MCP grants are pinned to the exact registered endpoint and supported transport
+  methods. Worker-controlled suffixes and queries are denied. URL validation uses
+  the parsed authority rather than a string-prefix check.
+- MCP: HTTP MCP servers are re-pointed at `/mcp/<proxy-token>` on the
+  gateway; real upstream URLs and auth headers stay in backend memory,
+  proxy tokens are revoked with the owning client/run. **Stdio MCP servers
+  are disabled in worker configs (fail closed)** — their env vars would
+  carry credentials into the worker; they are logged as disabled and never
+  silently fall back to org credentials.
+- Grants come from controller policy at issue time: personal tools for the
+  authenticated owner, integration tools filtered by integration sharing
+  rules, configured model providers. Runs without an authenticated owner
+  (anonymous webhooks) receive **no capability**: every brokered call is
+  denied. Controller/broker startup failure also fails closed.
+- Capabilities: opaque, stored as SHA-256 digests, ≤2h TTL (default 1h),
+  bounded call budget, atomic admission, active-account recheck per call,
+  revoked at run end. Broker + gateway bind to loopback only.
+
+## Command compatibility
+
+The reviewed command schemas cover the original Google/personal tools plus
+Telegram, real PostHog event commands, Ashby, Grafana command groups, Sentry,
+Pylon commands, Zoho Books, MonetizeNow, PhantomBuster, Linear and GitHub thread
+operations. Only explicitly declared flags may repeat. Unlisted commands and
+credential-bearing plugins still fail closed. PPTX rendering now runs inside
+the independent worker; this is not full plugin feature parity.
+
+Uploads support bounded UTF-8 text and explicitly tagged, strictly validated
+base64 binary inputs. Worker paths are replaced by request-owned backend paths.
+Reviewed output flags are rewritten to request-owned files and returned as bounded
+base64 artifacts; workers refuse output paths outside their workspace. Symlinks,
+hardlinks and special files are rejected. Stdin is forwarded only for explicitly
+approved commands, including Pylon notes/replies, Slack bot messages and Zoho email
+commands. Zoho invoice/estimate PDF downloads use the artifact channel.
+
+## Deployment requirements
+
+The independent runsc/image/socket implementation is described in
+[worker-sandbox.md](worker-sandbox.md). A namespace/cgroup-capable host and the
+real-runtime validation remain required. The old subprocess environment is
+available only through explicit development settings. It is not an acceptable
+production fallback. Multi-host transports are not implemented.
+
+## Known caveats
+
+- Claude and Codex now use fresh worker configuration and run-bound subscription
+  proxy references. Real credentials are read only by the backend gateway, which
+  restricts subscription calls to inference routes and rechecks run admission.
+  Anonymous proxy registration and credential-file fallback do not exist.
+  Backend refresh now renews expiring Claude tokens and expiry-bearing Codex
+  access tokens with pinned provider endpoints, a per-account process-shared lock,
+  bounded responses and atomic 0600 credential replacement. Revocation is checked
+  again after refresh. Non-refreshable expired tokens fail closed. Opaque tokens without expiry metadata can now recover from a pre-stream 401
+  with one bounded, backend-only refresh/retry; non-refreshable tokens require reconnecting. **Live vendor compatibility remains unverified**, including
+  subscription-only OpenCode plugins. No refresh token enters a worker. Codex uses a custom Responses provider
+  as described in the [official configuration reference](https://learn.chatgpt.com/docs/config-file/config-reference).
+- OpenCode no longer stages provider auth.json into workers or catalog storage.
+  Gateway-configured API providers remain supported; personal Claude/Codex subscription providers now use reviewed standard SDK
+  adapters, without credential-reading plugins. Vendor compatibility is not verified. Existing legacy catalog auth files cause
+  a startup error and require operator cleanup. Managed servers use separate
+  random passwords so another worker cannot anonymously query their API.
+- OpenCode/Codex warm-session and prewarm optimizations that shared server
+  processes across runs are disabled/removed; each run pays a worker start.
+  Conversation continuity is carried by the textual conversation context.
+- Fixed-argv admin utilities (`claude auth status/logout`, `codex logout`
+  in auth/usage routes) still run backend-side; they execute no
+  model-driven code. Background `claude -p` utility calls (titles/topics)
+  require a current authenticated run and use the same subscription proxy with
+  fresh configuration and a scratch workspace. Unscoped calls use the caller's
+  deterministic fallback, never ambient account credentials.
+- Tool outputs that are files are produced server-side; the existing file
+  delivery path serves them. Worker-side files can be passed INTO tools
+  only via the bounded inline upload in the shim.
+- `OPENCODE_SERVER_URL` (operator-managed external server) bypasses the
+  managed worker spawn in development mode only. It is rejected by the
+  independent sandbox path.
+
+## Validation
+
+`tests/test_worker_isolation.py`, `tests/test_tool_invoke.py`,
+`tests/test_broker_gateway.py`, `tests/test_runtime_isolation.py`, and
+`tests/test_adversarial_worker.py` cover: no backend secrets in worker envs
+(including real subprocess env dumps and /proc scrapes), launcher scrub,
+privilege-drop file isolation (cross-user artifact reads and backend config
+reads fail), forged/expired/revoked capability rejection over HTTP,
+fail-closed authorization on datastore errors, identity-flag stripping,
+sharing-rule admission filtering, MCP gateway admission, model-key
+injection, and source-level guards that the legacy env-inheriting execution
+path stays gone. These are synthetic tests: they do not replace deployed
+adversarial end-to-end verification under the production runtime/network
+policy, which remains a release gate.
+
+## Current implementation validation
+
+The additional synthetic subscription tests exercise proxy admission, credential
+injection, route limits, revocation, malformed auth, fresh runtime configuration,
+binary input validation and per-server OpenCode authentication. They deliberately
+make no calls using real provider credentials. The local environment rejects
+namespace creation (`unshare: Operation not permitted`) and has no container
+runtime; it cannot supply the production isolation release evidence.
+
+## Trusted proxy identity and account setup
+
+The backend now requires a short-lived HMAC identity assertion from the dashboard
+or task-MCP sidecar in addition to `X-User-Email`. Nginx forwards the assertion
+from its authenticated whoami subrequest and overwrites client-supplied headers.
+The signature is purpose-bound; active-account and role checks still run after
+verification. Unsigned internal requests fail before database lookup.
+
+Compose supplies `BACKEND_PROXY_SECRET` to the dashboard and task-MCP sidecar,
+falling back to the existing `OAUTH_ENCRYPTION_KEY`. The backend uses the same
+selection. Non-Compose deployments must explicitly configure the matching key
+in all three services. Assertions expire after 60 seconds and require synchronized
+clocks. This control does not replace worker network isolation.
+
+Account setup terminals now execute only `claude auth login` or
+`codex login --device-auth`, with a one-use owner-bound grant and minimal
+environment. They run as trusted credential setup utilities, never as an arbitrary
+backend shell or model invocation. The UI no longer sends a shell command to a
+generic terminal. Interactive agent terminals remain isolated workers.
+
+The backend tightens the mounted dotenv file to 0600 before starting runtimes;
+environment edits preserve that mode. Preview-generated secrets are also private.
+Read-only secret mounts and all other backend files still require the production
+sandbox boundary described above.
+
+### Remaining release gates
+
+The independent sandbox, subscription recovery and personal provider adapters are
+implemented. Their current evidence and host prerequisites are listed in
+[worker-sandbox.md](worker-sandbox.md). These supersede earlier staged status notes.
+Real gVisor execution and live vendor compatibility have not passed verification.
+The standalone `scripts/verify_worker_isolation.sh` runs the real-runtime suite
+without requiring workflow installation, on a disposable capable host.
+
+Preview deployment and browser/OAuth validation are explicitly skipped at the
+requester's direction, not passed. That waiver does not waive independent sandbox
+or vendor compatibility checks. Generic credential-bearing plugins and stdio MCP
+remain intentionally disabled; enabling them would violate credential separation.
+
+### Reproducible local verification
+
+Run the backend suite without inherited model or signing-key configuration:
+
+```bash
+env -u AGENT_DEFAULT_MODEL -u BACKEND_PROXY_SECRET -u OAUTH_ENCRYPTION_KEY python3 -m pytest -q
+```
+
+Request-signing tests supply synthetic keys through scoped fixtures. They must
+not depend on local credentials; missing production configuration still fails
+closed. The integration-access suite explicitly imports the signing fixture used
+by its shared request helper so it also works in a clean CI environment.
+
+
+## Additional adapter and personal webhook implementation
+
+Apollo and Dataroom commands have static schemas, including declared repeatable
+flags. Stitch generation and bounded download, CDN upload/download, and agreement
+read/annotate/upload/download are covered. Explicit output paths are required for
+new download/annotation adapters; they use request-owned artifact transport.
+Agreement OAuth uses the authenticated caller, not a credential-free utility grant.
+Document archive expansion and downloads are bounded. Public URL fetches accept
+only public HTTPS destinations through the connector's checked DNS answers, deny
+redirects and enforce body-size/time limits. Unknown commands remain denied.
+
+### Personal Grain webhook setup
+
+After connecting personal Grain OAuth, the authenticated user can call
+`PUT /api/integrations/grain/webhook`. The response returns a relative webhook
+path and a one-time Authorization header. Configure the automation sender to POST
+`{"recording_id": "..."}` to that path with that header. This is an authenticated
+custom automation endpoint, not automatic registration with Grain's vendor API.
+The stored credential is a SHA-256 digest; it expires after 90 days. Repeating PUT
+rotates it immediately; DELETE on the same API path revokes it. Never put the
+credential in the URL or webhook body.
+
+The webhook derives the owner from the stored subscription and fetches through
+that owner's current personal OAuth connection. Account status, expiry, rotation
+and disconnection are checked. Delivery retries are idempotent per owner/recording.
+Transcripts go to `personal_grain_events`, **not** organization-wide changestreams.
+`GET /api/integrations/grain/recordings` returns the current user's latest 50 events.
+The legacy organization webhook remains disabled; it has no verified personal
+owner. The personal Grain card now exposes status, enable/rotate and revoke controls.
+A one-time credential dialog clears the value on dismissal and never persists it
+in browser storage. GET status returns only owner-scoped, non-secret metadata.
+Automatic vendor registration and additional downstream consumers are not provided.
+
+No preview deployment testing was performed for these additions, as requested.
+Unit and local subprocess checks are not evidence of independent worker isolation
+or real vendor subscription compatibility.
+
+
+### Legacy credential directories and background utilities
+
+Before proxy-backed Claude/Codex execution, account directories are made private
+and reclaimed by the trusted backend identity. Non-root backends fail closed if
+they cannot secure a legacy worker-owned directory; symlink directories are
+rejected. Stop all workers from older deployments before upgrading: permission
+changes cannot revoke already-open file descriptors. Background utility calls
+also revoke their proxy and wait for process termination before deleting scratch
+state, including cancellation/error paths. This closes a credential-directory
+fallback, not the independent worker containment requirement.

--- a/docs/integration-migration.md
+++ b/docs/integration-migration.md
@@ -1,0 +1,59 @@
+# Personal integration migration
+
+## Implemented on this branch
+
+- Organization credential connect/disconnect require admin access.
+- Custom connectors are owner-scoped, including legacy records. URL deduplication
+  is per owner; new provider IDs are owner-namespaced. They no longer enter the
+  shared runtime configuration. Custom OAuth authorization requires ownership.
+- CLI broker calls, direct organization CLI entrypoints and MCP gateway calls
+  recheck authorization. Lookup errors deny access, including when credentials
+  are supplied through environment variables. Direct CLI invocations now require
+  `--user-email` and `--auth-token`. Unconfigured integrations receive no grants.
+- Broker CLI commands have explicit command/flag contracts and request-scoped
+  upload validation. Unreviewed commands are disabled; see the compatibility
+  list in `execution-security.md`. Full adapter coverage is not complete.
+- Skill CLI reads and writes enforce active-user identity and personal ownership;
+  root/subcommand argument placement preserves the supplied identity.
+- MCP proxies require a live run capability. Codex and OpenCode resolve caller
+  configuration and sharing exclusions, as does Claude. Personal initialization
+  errors do not start a shared fallback client.
+- Grain CLI search/recent/transcript require authenticated personal OAuth. No
+  environment or organization token fallback is used. Missing/expired/revoked
+  connections fail explicitly; refresh uses the existing trusted OAuth service.
+- Grain legacy webhook enrichment returns 503: it has no verified personal
+  subscription owner. Re-enable only after owner-bound subscriptions exist.
+- Skill folder moves enforce personal ownership and admin-only workspace edits.
+  The skills picker returns owned personal plus workspace/system skills to all
+  authenticated roles, including chatter. UI load failures display an error.
+
+## Migration inventory
+
+| Integration family | Current access path | Next action |
+| --- | --- | --- |
+| Google, Slack personal | Personal OAuth CLI | Reviewed CLI command schemas implemented; complete typed provider adapters and binary artifact transfer |
+| Grain | Personal OAuth CLI; personal MCP when configured | Validate consent/refresh in browser; introduce owner-bound webhook subscriptions |
+| HubSpot, Notion | Personal OAuth MCP overrides | Validate provider scopes, refresh, reconnect and runtime compatibility |
+| Custom remote MCP | Owner-only configuration, optional personal OAuth | Validate destinations and MCP transport/session behavior in deployment |
+| GitHub, Linear, Apollo, Ashby, Pylon, PostHog, Sentry, Grafana | Organization-managed connectors/tools where configured | Choose personal OAuth or explicitly administered service identities per provider |
+| Billing, CDN and automation providers | Organization-managed credentials where configured | Preserve explicit admin ownership; assess least-privilege scopes before migration |
+| Claude/Codex subscription pools and OpenCode auth | Runtime-specific account material | Credential-free runtime protocol migration remains a P0 blocker |
+
+The inventory is based on repository configuration, not a live account census.
+OAuth support and scopes must be verified with each provider before migration.
+UI labels distinguish organization-managed connections and personal connectors;
+organization sharing rules remain visible through the existing sharing dialog.
+
+## Release gates still open
+
+- Per-worker isolation, restricted network egress and server-side subscription auth.
+- Complete reviewed adapter coverage for disabled commands and replace the
+  remaining trusted CLI bridge with typed provider adapters where appropriate.
+- Validate simultaneous runs, cancellation, resume, artifacts and provider refresh
+  in the deployed topology, not only mocked tests.
+- Repair preview capacity without deleting other users' data. Local disk capacity
+  is not evidence of capacity on the remote preview host.
+- Browser OAuth/account linking/replay checks and visual regression checks.
+
+Keep PR #157 draft until these gates are resolved or explicitly split into
+separately reviewed releases. This document does not claim P0 completion.

--- a/docs/preview-deployments.md
+++ b/docs/preview-deployments.md
@@ -62,6 +62,18 @@ so they run with two guards to avoid disturbing production:
   Slack testing, put a **separate** Slack app's `SLACK_APP_TOKEN` in the preview
   secrets and set `LOMA_ENABLE_SLACK=true`.)
 
+## Disk hygiene
+
+Each deploy runs `docker compose up -d --build`, so every PR synchronize
+produces fresh image layers. `preview_up.sh` prunes dangling images and stale
+(>72h) build cache before each build, and `preview_down.sh` removes the
+stack's locally-built images (`--rmi local`) at teardown. If the box was
+already full before these guards existed, one manual
+`docker system prune -f` (NOT `-a --volumes`, which would delete active
+previews' data) by an operator may be needed once; after that the per-deploy
+pruning keeps usage bounded. `preview_up.sh` refuses to build with <4GiB free
+so failures are explicit instead of a mid-build ENOSPC.
+
 ## One-time setup (preview box + GitHub)
 
 **Preview EC2**

--- a/docs/worker-sandbox.md
+++ b/docs/worker-sandbox.md
@@ -1,0 +1,128 @@
+# Independent worker runtime
+
+## Status and rollout gate
+
+The default execution path now creates a separate OCI/gVisor sandbox for each
+worker process. This implementation has unit and transport tests, **not a passing
+real-runtime validation yet**. Do not mark the PR merge-ready on unit results.
+The local implementation environment refuses namespace creation. The GitHub
+credential available to the implementer cannot create/update Actions workflows.
+`deploy/worker-isolation-ci.example.yml` is a **non-executing template** for a
+repository administrator to install after review. It runs
+`tests/test_gvisor_execution.py` on a disposable CI host without production
+credentials. Preview deployment testing remains waived, not passed.
+
+## Boundary and configuration
+
+- `LOMA_WORKER_SANDBOX=runsc` is the default and the shipping image setting.
+  Missing runtime, image, per-run identity, sockets, namespace support or cgroup
+  permissions causes execution failure. There is no unconfined fallback.
+- A separate `worker-base` image stage contains runtimes, public dependencies and
+  the renderer. It does not copy the application repository, account directories,
+  `.env` or backend secrets. Its snapshot is the worker's read-only root filesystem.
+- Each worker gets only its own writable workspace and the two broker/gateway
+  Unix sockets. It does not mount the backend root, Docker socket, provider
+  account directories, or neighboring workspaces.
+- gVisor runs with `--network=none`, a private network namespace, empty workload
+  capabilities, `noNewPrivileges`, process/memory/CPU limits and read-only rootfs.
+  Private loopback bridges forward only to the mounted broker/gateway sockets.
+  Raw shell networking, metadata endpoints and host services are not reachable.
+- The trusted runner/bundle stays outside worker-writable directories. SDK command
+  arguments remain container arguments and cannot add runsc options. SDK proxy
+  references are validated; provider secrets are not inherited by runsc or workers.
+- OpenCode ingress uses a per-workspace Unix socket. The backend pins and validates
+  that socket inode before connecting, rejecting worker-controlled symlinks.
+  External `OPENCODE_SERVER_URL` overrides are refused in isolated mode.
+- Cleanup explicitly force-deletes the sandbox before workspace/UID release.
+  Teardown failure retains the workspace and allocation rather than reusing it.
+  Keeping workspace files for debugging does not bypass sandbox teardown.
+
+Relevant settings: `LOMA_WORKER_ROOTFS`, `LOMA_SANDBOX_STATE`,
+`LOMA_SANDBOX_SOCKETS`, `LOMA_WORKER_UID_RANGE`. Control/image paths must be
+trusted, non-shared-writable directories. Broker/gateway URLs must use
+`http://127.0.0.1:<port>` in this single-host implementation. Multi-host workers
+and custom external endpoints are not supported by this transport.
+
+Local unit tests explicitly set **both** `LOMA_ENV=development` and
+`LOMA_WORKER_SANDBOX=development`. This retains the prior subprocess path solely
+for unit testing and single-user development. Do not set these in production.
+
+## Host prerequisites
+
+The host must permit gVisor to create mount/PID/network namespaces and enforce OCI
+cgroups. Installing runsc in an otherwise restricted container is insufficient.
+The existing default Compose stack has not been validated for these privileges;
+a platform owner must supply and review the outer-container policy or run the
+trusted backend on an appropriately isolated worker host. Do not fix startup by
+changing to development mode, host networking or mounting the host root.
+
+Build the `worker-base` Docker stage, export it into a trusted rootfs directory,
+and set `LOMA_WORKER_ROOTFS` when testing outside the shipping image. The supplied
+CI template contains exact disposable-host commands. No production host was
+modified during implementation.
+
+The design uses the official [gVisor OCI runtime](https://gvisor.dev/docs/user_guide/quick_start/oci/)
+and [network isolation](https://gvisor.dev/docs/user_guide/networking/). Runtime
+flags and the `--force` teardown behavior were checked against upstream source.
+
+## Rendering and feature compatibility
+
+- `tools/pptx_creator.py` executes inside the independent worker, not the
+  credential-bearing backend. Blank composition requires no proprietary master
+  deck. Preset/master-deck composition also accepts a caller-uploaded asset pack via
+  `python3 tools/pptx_creator.py --library-dir "$HOME/library" generate ...`.
+  The library directory must resolve inside this worker's HOME, including symlink
+  resolution. Supply `master/slide-index.json`, its referenced source decks and
+  assets. A synthetic library generation test passes without any backend assets.
+  The proprietary original pack is not supplied or synthesized by this branch. Outputs default to the
+  worker's `HOME/artifacts` directory.
+- Diagram rendering uses a fixed public HTTPS renderer with bounded, no-redirect
+  downloads; parsing/rendering does not execute on the credential-bearing backend.
+  Diagram uploads/embedding use the authenticated personal Google broker adapter.
+- OpenCode now has personal `loma-claude` and `loma-codex` provider adapters,
+  using the standard bundled AI SDK packages and run-bound gateway references.
+  The model picker and configuration use only the authenticated owner's connected
+  native CLI accounts; neither reads another user's or a pooled account as a
+  fallback. This replaces credential-reading auth plugins for these two providers.
+  Live protocol compatibility is still unverified; configuration tests are not
+  vendor acceptance tests. Arbitrary credential-bearing plugins/stdio MCP remain
+  denied and are not claimed as restored feature parity. Do not put pooled account files back in workers to
+  enable them. Generic shell downloads/clone operations also require an approved
+  broker adapter rather than re-enabling network access.
+
+## Rejected-token recovery
+
+A subscription inference request rejected with HTTP 401 **before streaming** may
+refresh and retry once. Backend locking coalesces concurrent refreshes; persisted
+cooldowns bound forced attempts across processes. Run/proxy admission is checked
+before refresh and again before replay. No timeout, disconnect, 403, 429, 5xx or
+partially streamed response is automatically replayed. Failed/non-refreshable
+credentials require reconnecting, with no API-billing or organization fallback.
+
+## Required review evidence
+
+Before rollout: install/run the real-runtime CI test, exercise all three installed
+CLI versions with mock provider transports, verify worker cancellation and reboot
+cleanup on the target host, and perform authorized vendor compatibility checks.
+The current evidence does not close these gates. A preview-testing waiver is not
+a substitute for a supported execution host or an implemented plugin adapter.
+
+
+## Standalone validation without workflow installation
+
+On a disposable root-capable host, install runsc and export the `worker-base`
+image using the commands in `deploy/worker-isolation-ci.example.yml`, then run:
+
+```bash
+sudo bash scripts/verify_worker_isolation.sh /opt/loma-ci-rootfs
+```
+
+The command refuses missing runtime/image/namespace support, removes inherited
+credentials from the test controller environment, and opts into (not skips) the
+real tests. Coverage includes host/sibling visibility, blocked network access,
+broker transport, startup of the installed Claude/Codex/OpenCode executables,
+and force deletion of detached worker processes. This is not preview deployment
+and does not exercise live vendor credentials or claim inference compatibility.
+No successful result is recorded yet. The regular unit suite continues to skip
+these five tests explicitly. Failed runtime teardown also returns failure instead
+of reporting a successful run with residual sandbox state.

--- a/integrations/access.py
+++ b/integrations/access.py
@@ -1,0 +1,37 @@
+"""Shared, fail-closed integration authorization for trusted callers."""
+
+
+def allows_user(integration: dict, email: str, team_ids=()) -> bool:
+    if not email or integration.get('status') != 'active':
+        return False
+    # Legacy custom connectors are private too: never assume org ownership.
+    if integration.get('scope') == 'personal' or integration.get('is_custom'):
+        return integration.get('connected_by') == email
+    shared = integration.get('shared_with') or {'mode': 'everyone'}
+    if shared.get('mode') == 'everyone':
+        return True
+    if shared.get('mode') != 'specific':
+        return False
+    return email in (shared.get('users') or []) or bool(
+        set(team_ids) & set(shared.get('teams') or [])
+    )
+
+
+async def can_access(db, integration: dict, email: str) -> bool:
+    if db is None or not email:
+        return False
+    teams = []
+    if (integration.get('shared_with') or {}).get('teams'):
+        async for team in db.teams.find({'members': email}, {'team_id': 1}):
+            teams.append(team['team_id'])
+    return allows_user(integration, email, teams)
+
+
+async def require_provider(db, provider: str, email: str) -> None:
+    from broker.service import Denied
+    try:
+        doc = await db.integrations.find_one({'provider': provider}) if db is not None else None
+        if not doc or not await can_access(db, doc, email):
+            raise Denied()
+    except Exception as exc:
+        raise Denied() from exc

--- a/mcp-servers/loma-tasks/server.py
+++ b/mcp-servers/loma-tasks/server.py
@@ -24,6 +24,8 @@ Run: python server.py   (deps: aiohttp, motor — same as the backend)
 
 import asyncio
 import hashlib
+import hmac
+import time
 import json
 import logging
 import os
@@ -140,7 +142,14 @@ async def _backend(request: web.Request, method: str, path: str, *,
                    json_body=None, params=None):
     """Call the Loma backend as the authenticated user."""
     session: ClientSession = request.app["http"]
-    headers = {"X-User-Email": request["user_email"]}
+    secret = os.environ.get("BACKEND_PROXY_SECRET") or os.environ.get("OAUTH_ENCRYPTION_KEY", "")
+    if len(secret) < 32:
+        raise ToolError("Backend authentication unavailable")
+    email = request["user_email"]
+    timestamp = str(int(time.time()))
+    signature = hmac.new(secret.encode(),
+        f"loma-proxy-identity-v1\n{timestamp}\n{email}".encode(), hashlib.sha256).hexdigest()
+    headers = {"X-User-Email": email, "X-Auth-Timestamp": timestamp, "X-Auth-Signature": signature}
     try:
         async with session.request(
             method, f"{BACKEND_URL}{path}", headers=headers,

--- a/observability/observer.py
+++ b/observability/observer.py
@@ -4,6 +4,8 @@ import logging
 import uuid
 from datetime import datetime, timezone
 
+from utils.secret_redaction import redact_secrets
+
 logger = logging.getLogger(__name__)
 
 MAX_CONTENT_LEN = 10_000
@@ -18,6 +20,7 @@ STATUS_INTERRUPTED = "interrupted"
 
 def _truncate(text: str, max_len: int = MAX_CONTENT_LEN) -> tuple[str, bool]:
     """Truncate text and return (text, was_truncated)."""
+    text = redact_secrets(text)
     if len(text) <= max_len:
         return text, False
     return text[:max_len], True
@@ -26,7 +29,7 @@ def _truncate(text: str, max_len: int = MAX_CONTENT_LEN) -> tuple[str, bool]:
 def _safe_json(obj, max_len: int = MAX_CONTENT_LEN) -> tuple[str, bool]:
     """Serialize obj to JSON string, truncated."""
     try:
-        s = json.dumps(obj, ensure_ascii=False, default=str)
+        s = json.dumps(redact_secrets(obj), ensure_ascii=False, default=str)
     except (TypeError, ValueError):
         s = str(obj)
     return _truncate(s, max_len)
@@ -38,7 +41,7 @@ class ConversationObserver:
     def __init__(self, db, metadata: dict, conversation_id: str | None = None):
         self.db = db
         self.conversation_id = conversation_id or str(uuid.uuid4())
-        self.metadata = metadata
+        self.metadata = redact_secrets(metadata)
         self.start_time: datetime | None = None
         self.turn_count = 0
         self.turn_offset = 0  # offset for resumed conversations
@@ -143,6 +146,7 @@ class ConversationObserver:
 
     async def record_text(self, turn_number: int, text: str):
         """Record a text block for a given turn."""
+        text = redact_secrets(text)
         turn_number = turn_number + self.turn_offset
         truncated_text, was_truncated = _truncate(text)
         turn_doc_update = {
@@ -223,7 +227,7 @@ class ConversationObserver:
             doc = {
                 "conversation_id": self.conversation_id,
                 "timestamp": datetime.now(timezone.utc),
-                **artifact_data,
+                **redact_secrets(artifact_data),
             }
             await self.db.artifacts.update_one(
                 {
@@ -238,6 +242,7 @@ class ConversationObserver:
 
     async def record_tool_result(self, tool_use_id: str, is_error: bool, output: str):
         """Record a tool result, attaching it to the turn that made the call."""
+        output = redact_secrets(output)
         output_str, output_truncated = _truncate(output)
         tool_result = {
             "tool_use_id": tool_use_id,
@@ -323,6 +328,7 @@ class ConversationObserver:
 
     async def finish(self, final_response: str = ""):
         """Mark conversation as completed and trigger confidence assessment."""
+        final_response = redact_secrets(final_response)
         self._stop_heartbeat()
         now = datetime.now(timezone.utc)
         duration_ms = int((now - self.start_time).total_seconds() * 1000) if self.start_time else None
@@ -387,6 +393,7 @@ class ConversationObserver:
 
     async def record_error(self, error: str):
         """Mark conversation as errored."""
+        final_response = redact_secrets(final_response)
         self._stop_heartbeat()
         now = datetime.now(timezone.utc)
         duration_ms = int((now - self.start_time).total_seconds() * 1000) if self.start_time else None
@@ -419,6 +426,7 @@ class ConversationObserver:
 
     async def mark_interrupted(self, reason: str = "Server shutdown"):
         """Mark conversation as interrupted (e.g., due to server shutdown)."""
+        final_response = redact_secrets(final_response)
         self._stop_heartbeat()
         now = datetime.now(timezone.utc)
         duration_ms = int((now - self.start_time).total_seconds() * 1000) if self.start_time else None

--- a/observability/org_learnings.py
+++ b/observability/org_learnings.py
@@ -98,21 +98,18 @@ LEARNING B:
 Answer ONLY "yes" or "no". If they cover the same topic and teach the same lesson, answer "yes" even if one has more detail than the other."""
 
     try:
-        from agent.pool import background_cli_env
-        proc = await asyncio.create_subprocess_exec(
-            "claude", "-p", prompt,
-            "--model", HAIKU_MODEL,
-            "--max-turns", "1",
-            "--allowedTools", "",
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env=background_cli_env(),
+        from agent.pool import run_background_cli
+        returncode, stdout, stderr = await run_background_cli(
+            ["claude", "-p", prompt,
+             "--model", HAIKU_MODEL,
+             "--max-turns", "1",
+             "--allowedTools", ""],
+            timeout=HAIKU_TIMEOUT,
         )
-        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=HAIKU_TIMEOUT)
 
-        if proc.returncode != 0:
+        if returncode != 0:
             err_msg = stderr.decode().strip()[:200] if stderr else "unknown"
-            logger.warning("[ORG-LEARNINGS] Haiku CLI failed (rc=%d): %s", proc.returncode, err_msg)
+            logger.warning("[ORG-LEARNINGS] Haiku CLI failed (rc=%d): %s", returncode, err_msg)
             return False
 
         answer = stdout.decode().strip().lower()

--- a/observability/review_quality.py
+++ b/observability/review_quality.py
@@ -85,22 +85,19 @@ async def assess_review_quality(
     )
 
     try:
-        from agent.pool import background_cli_env
-        proc = await asyncio.create_subprocess_exec(
-            "claude", "-p", prompt,
-            "--model", "claude-opus-4-8",
-            "--max-turns", "1",
-            "--output-format", "json",
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env=background_cli_env(),
+        from agent.pool import run_background_cli
+        returncode, stdout, stderr = await run_background_cli(
+            ["claude", "-p", prompt,
+             "--model", "claude-opus-4-8",
+             "--max-turns", "1",
+             "--output-format", "json"],
+            timeout=60,
         )
-        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=60)
 
-        if proc.returncode != 0:
+        if returncode != 0:
             logger.error(
                 "[REVIEW-QUALITY] CLI failed (rc=%d): %s",
-                proc.returncode, stderr.decode()[:200],
+                returncode, stderr.decode()[:200],
             )
             return None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,6 @@ pywebpush>=2.0
 google-auth>=2.22.0
 google-api-python-client>=2.100.0
 boto3>=1.28.0
+
+# Worker-local presentation rendering (no provider credentials)
+python-pptx==1.0.2

--- a/scheduler/engine.py
+++ b/scheduler/engine.py
@@ -125,12 +125,12 @@ def _add_job_for_flow(flow: dict):
                 timezone=flow.get("timezone", "UTC"),
             )
         else:
-            trigger = CronTrigger.from_crontab(
-                _fix_crontab_dow(flow["cron"]),
+            minute, hour, day, month, day_of_week = _fix_crontab_dow(flow["cron"]).split()
+            trigger = CronTrigger(
+                minute=minute, hour=hour, day=day, month=month, day_of_week=day_of_week,
                 timezone=flow.get("timezone", "UTC"),
+                start_date=flow.get("start_time"), end_date=flow.get("end_time"),
             )
-            if flow.get("end_time"):
-                trigger.end_date = flow["end_time"]
 
         _scheduler.add_job(
             execute_flow,

--- a/scripts/check_worker_clis.py
+++ b/scripts/check_worker_clis.py
@@ -1,0 +1,27 @@
+"""Build-time CLI startup check using an unprivileged identity and clean HOME."""
+import os
+import shutil
+import subprocess
+import tempfile
+
+CLIS = ("opencode", "claude", "codex")
+
+
+def check_clis():
+    if os.geteuid() != 0:
+        raise RuntimeError("Run this image-build check as root so privilege dropping is tested")
+    with tempfile.TemporaryDirectory(prefix="loma-cli-smoke-") as home:
+        os.chown(home, 65534, 65534)
+        env = {"PATH": "/usr/local/bin:/usr/bin:/bin", "HOME": home,
+               "XDG_CONFIG_HOME": home + "/config", "XDG_DATA_HOME": home + "/data"}
+        for cli in CLIS:
+            binary = shutil.which(cli, path=env["PATH"])
+            if not binary:
+                raise RuntimeError(f"Missing CLI on worker PATH: {cli}")
+            subprocess.run([binary, "--version"], env=env, cwd=home,
+                           user=65534, group=65534, extra_groups=(),
+                           check=True, timeout=60)
+
+
+if __name__ == "__main__":
+    check_clis()

--- a/scripts/preview_down.sh
+++ b/scripts/preview_down.sh
@@ -17,7 +17,9 @@ DIR="${STATE_DIR}/pr-${PR}"
 export COMPOSE_PROJECT_NAME="loma-pr-${PR}"
 
 if [ -d "$DIR" ]; then
-  ( cd "$DIR" && docker compose down -v --remove-orphans ) || true
+  # --rmi local also removes the images built for this stack; without it every
+  # torn-down preview leaves its full image chain behind until the box fills up.
+  ( cd "$DIR" && docker compose down -v --remove-orphans --rmi local ) || true
 fi
 
 # Drop the isolated Mongo database (best effort).

--- a/scripts/preview_up.sh
+++ b/scripts/preview_up.sh
@@ -12,6 +12,7 @@
 # Safety: previews run with the scheduler and Slack Socket Mode OFF so they never
 # double-fire scheduled flows or double-consume the production Slack app's events.
 set -euo pipefail
+umask 077
 
 PR="${1:?usage: preview_up.sh <PR_NUMBER>}"
 [[ "$PR" =~ ^[0-9]+$ ]] || { echo "PR number must be numeric: $PR" >&2; exit 2; }
@@ -76,7 +77,25 @@ OBSERVABILITY_DB_NAME=loma_pr_${PR}
 LOMA_SETUP_TOKEN=${setup_value}
 EOF
 
+chmod 600 .env dashboard/.env "$SECRET_CACHE"
+
 echo "[preview] up ${COMPOSE_PROJECT_NAME} (backend=${BACKEND_HOST_PORT} dashboard=${DASHBOARD_HOST_PORT} nginx=${NGINX_HOST_PORT})"
+
+# --- Reclaim space before building ---
+# Every `up --build` on every PR synchronize creates fresh image layers, and
+# teardown historically kept images, so dangling layers + build cache grow
+# until the box hits ENOSPC mid-build. Prune only unreferenced data: dangling
+# images and build cache unused for 72h. Never containers or volumes.
+docker image prune -f >/dev/null 2>&1 || true
+docker builder prune -f --filter 'until=72h' >/dev/null 2>&1 || true
+avail_kb=$(df -Pk /var/lib/docker 2>/dev/null | awk 'NR==2 {print $4}' || echo 0)
+if [ "${avail_kb:-0}" -lt $(( 4 * 1024 * 1024 )) ]; then
+  echo "[preview] ERROR: less than 4GiB free on the docker filesystem after pruning" \
+       "(${avail_kb}KiB available). The build would fail with ENOSPC;" \
+       "an operator needs to free space on the preview box." >&2
+  exit 4
+fi
+
 docker compose up -d --build
 
 # --- Front-proxy vhost: route the PR subdomain to this stack's nginx ---

--- a/scripts/verify_worker_isolation.sh
+++ b/scripts/verify_worker_isolation.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Run only on a disposable host. No provider credentials or preview deployment.
+set -euo pipefail
+if [[ $# -ne 1 || $1 != /* ]]; then
+  echo 'Usage: verify_worker_isolation.sh /absolute/path/to/exported-worker-rootfs' >&2
+  exit 2
+fi
+if [[ $(id -u) -ne 0 ]]; then
+  echo 'Real isolation verification needs root on a disposable namespace/cgroup-capable host.' >&2
+  exit 2
+fi
+command -v runsc >/dev/null || { echo 'Install authenticated gVisor runsc first.' >&2; exit 2; }
+[[ -f "$1/.loma-worker-image" ]] || { echo 'Supply the exported worker-base image, not the host root.' >&2; exit 2; }
+unshare --mount --pid --net --fork true || { echo 'Host does not permit the required namespaces.' >&2; exit 2; }
+cd "$(dirname "$0")/.."
+python=$(command -v python3)
+# Do not inherit host personal/provider credentials into even the test controller.
+exec env -i PATH="$PATH" HOME=/root LANG=C.UTF-8 \
+  LOMA_TEST_GVISOR=1 LOMA_WORKER_ROOTFS="$1" \
+  "$python" -m pytest -q tests/test_gvisor_execution.py

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+"""Unit tests use explicit unisolated development mode, never deployment defaults.
+
+Tests of the OCI boundary override this fixture to exercise runsc configuration.
+Real sandbox execution is an opt-in integration test on an isolation-capable host.
+"""
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def local_worker_development_mode(monkeypatch):
+    monkeypatch.setenv('LOMA_ENV', 'development')
+    monkeypatch.setenv('LOMA_WORKER_SANDBOX', 'development')

--- a/tests/test_adversarial_worker.py
+++ b/tests/test_adversarial_worker.py
@@ -1,0 +1,302 @@
+"""Adversarial synthetic tests: malicious code inside a worker.
+
+Each test runs REAL subprocesses that behave like compromised agent code
+(env dumps, backend-file reads, cross-user reads, credential harvesting)
+and asserts every attempt fails. All secrets are synthetic.
+"""
+
+import asyncio
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from broker.service import Broker, Denied
+from broker.worker import (
+    FORBIDDEN_ENV_NAMES,
+    build_worker_env,
+    create_workspace,
+    spawn_worker,
+)
+
+FAKE_SECRETS = {
+    "OBSERVABILITY_MONGODB_URI": "mongodb://synthetic-backend/loma",
+    "OAUTH_ENCRYPTION_KEY": "synthetic-master-key-1234567890abcdef",
+    "ANTHROPIC_API_KEY": "synthetic-anthropic-value",
+    "OPENAI_API_KEY": "synthetic-openai-value",
+    "SLACK_BOT_TOKEN": "synthetic-slack-bot-value",
+}
+
+IS_ROOT = os.geteuid() == 0
+NOBODY_UID = 65534
+
+
+@pytest.fixture
+def hostile_backend(monkeypatch, tmp_path):
+    """A backend with planted synthetic secrets and a per-test worker root."""
+    for key, value in FAKE_SECRETS.items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.setenv("LOMA_WORKER_ROOT", str(tmp_path / "workers"))
+    monkeypatch.delenv("LOMA_WORKER_UID", raising=False)
+    monkeypatch.delenv("LOMA_WORKER_GID", raising=False)
+    return tmp_path
+
+
+async def run_in_worker(workspace, code: str, extra_env: dict | None = None):
+    env = build_worker_env(workspace, extra=extra_env)
+    process = await spawn_worker(
+        ["python3", "-c", code], workspace=workspace, env=env,
+    )
+    stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=30)
+    return process.returncode, stdout.decode(), stderr.decode()
+
+
+@pytest.mark.asyncio
+async def test_malicious_env_dump_finds_no_secrets(hostile_backend):
+    workspace = create_workspace()
+    code = (
+        "import os, json\n"
+        "loot = {k: v for k, v in os.environ.items()}\n"
+        "print(json.dumps(loot))\n"
+    )
+    rc, out, err = await run_in_worker(workspace, code)
+    assert rc == 0, err
+    loot = json.loads(out)
+    for name in FORBIDDEN_ENV_NAMES:
+        assert name not in loot
+    for value in FAKE_SECRETS.values():
+        assert value not in out
+
+
+@pytest.mark.asyncio
+async def test_malicious_proc_environ_scrape_finds_no_secrets(hostile_backend):
+    """Scraping the worker's own /proc for inherited secrets yields nothing."""
+    workspace = create_workspace()
+    code = (
+        "data = open('/proc/self/environ','rb').read().decode(errors='replace')\n"
+        "print(data)\n"
+    )
+    rc, out, err = await run_in_worker(workspace, code)
+    assert rc == 0, err
+    for value in FAKE_SECRETS.values():
+        assert value not in out
+
+
+@pytest.mark.asyncio
+async def test_malicious_provider_credential_harvest_fails(hostile_backend):
+    """Direct provider-credential access: no key in env, no key material in
+    the workspace, and nothing at the conventional key variables."""
+    workspace = create_workspace()
+    code = (
+        "import os, glob, json\n"
+        "keys = [os.environ.get(k) for k in ('ANTHROPIC_API_KEY','OPENAI_API_KEY',"
+        "'OPENROUTER_API_KEY','OPENCODE_API_KEY')]\n"
+        "files = glob.glob(os.path.expanduser('~/**/*key*'), recursive=True)\n"
+        "files += glob.glob(os.path.expanduser('~/**/auth.json'), recursive=True)\n"
+        "print(json.dumps({'keys': keys, 'files': files}))\n"
+    )
+    rc, out, err = await run_in_worker(workspace, code)
+    assert rc == 0, err
+    result = json.loads(out)
+    assert result["keys"] == [None, None, None, None]
+    assert result["files"] == []
+
+
+@pytest.mark.skipif(not IS_ROOT, reason="privilege-drop checks require root")
+@pytest.mark.asyncio
+async def test_malicious_backend_config_read_fails_for_nonroot_worker(
+    hostile_backend, monkeypatch,
+):
+    """A worker running as the dedicated non-root uid cannot read backend
+    config files (simulated .env with synthetic secrets, mode 0600 root)."""
+    backend_env_file = hostile_backend / "backend" / ".env"
+    backend_env_file.parent.mkdir()
+    backend_env_file.write_text("OAUTH_ENCRYPTION_KEY=" + FAKE_SECRETS["OAUTH_ENCRYPTION_KEY"])
+    os.chmod(backend_env_file, 0o600)
+    os.chmod(backend_env_file.parent, 0o700)
+
+    monkeypatch.setenv("LOMA_WORKER_UID", str(NOBODY_UID))
+    workspace = create_workspace()
+    code = (
+        f"import os\n"
+        f"assert os.geteuid() == {NOBODY_UID}, os.geteuid()\n"
+        f"try:\n"
+        f"    open({str(backend_env_file)!r}).read()\n"
+        f"    print('LEAKED')\n"
+        f"except PermissionError:\n"
+        f"    print('DENIED')\n"
+    )
+    rc, out, err = await run_in_worker(workspace, code)
+    assert rc == 0, err
+    assert out.strip() == "DENIED"
+
+
+@pytest.mark.skipif(not IS_ROOT, reason="privilege-drop checks require root")
+@pytest.mark.asyncio
+async def test_malicious_cross_user_artifact_read_fails(hostile_backend, monkeypatch):
+    """Worker B (non-root) cannot read another user's workspace/artifacts."""
+    # Victim workspace: created for a different run, owned by root (backend).
+    monkeypatch.delenv("LOMA_WORKER_UID", raising=False)
+    victim = create_workspace(prefix="victim")
+    (victim / "artifact.pdf").write_bytes(b"victim-report-contents")
+    os.chmod(victim / "artifact.pdf", 0o600)
+
+    # Attacker worker: dropped to the dedicated non-root uid.
+    monkeypatch.setenv("LOMA_WORKER_UID", str(NOBODY_UID))
+    attacker = create_workspace(prefix="attacker")
+    code = (
+        f"import os\n"
+        f"try:\n"
+        f"    data = open({str(victim / 'artifact.pdf')!r}, 'rb').read()\n"
+        f"    print('LEAKED:' + data.decode())\n"
+        f"except (PermissionError, FileNotFoundError):\n"
+        f"    print('DENIED')\n"
+        f"try:\n"
+        f"    os.listdir({str(victim)!r})\n"
+        f"    print('LISTED')\n"
+        f"except PermissionError:\n"
+        f"    print('LIST-DENIED')\n"
+    )
+    rc, out, err = await run_in_worker(attacker, code)
+    assert rc == 0, err
+    assert "LEAKED" not in out
+    assert "DENIED" in out and "LIST-DENIED" in out
+
+
+# ── Forged/expired/replayed capabilities against the broker HTTP surface ──
+
+
+class _Caps:
+    def __init__(self):
+        self.docs = {}
+        self.create_index = None
+
+    async def insert_one(self, doc):
+        import copy
+        self.docs[doc["_id"]] = copy.deepcopy(doc)
+
+    async def find_one_and_update(self, query, update):
+        import copy
+        doc = self.docs.get(query["_id"])
+        if not doc or doc["revoked"] or doc["remaining_calls"] <= 0:
+            return None
+        if doc["expires_at"] <= query["expires_at"]["$gt"]:
+            return None
+        if query["scopes"]["$elemMatch"] not in doc["scopes"]:
+            return None
+        old = copy.deepcopy(doc)
+        doc["remaining_calls"] -= 1
+        return old
+
+    async def update_many(self, query, update):
+        for doc in self.docs.values():
+            if all(doc.get(k) == v for k, v in query.items()):
+                doc.update(update["$set"])
+
+
+@pytest.mark.asyncio
+async def test_forged_and_stolen_capabilities_rejected_over_http():
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock
+
+    from aiohttp.test_utils import TestClient, TestServer
+
+    from broker.http import create_app
+
+    operation = SimpleNamespace(
+        valid_resource=lambda r: r == "notify",
+        execute=AsyncMock(return_value={"exit_code": 0, "stdout": "", "stderr": ""}),
+    )
+    db = SimpleNamespace(
+        users=SimpleNamespace(find_one=AsyncMock(return_value={"status": "active"})),
+        execution_capabilities=_Caps(),
+        execution_audit=SimpleNamespace(insert_one=AsyncMock()),
+    )
+    broker = Broker(db, "dep-adv", {"tool.invoke": operation})
+    run_id, real = await broker.issue(user_email="owner@example.test",
+                                      grants={"tool.invoke": ["notify"]})
+
+    async with TestClient(TestServer(create_app(broker))) as client:
+        # Forged tokens (right shape, wrong secret) and malformed tokens.
+        for forged in ("loma_run_v1_" + "z" * 43, "Bearer x", real[:-1], ""):
+            response = await client.post(
+                "/v1/invoke",
+                headers={"Authorization": f"Bearer {forged}"},
+                json={"operation": "tool.invoke", "resource": "notify"},
+            )
+            assert response.status == 403
+
+        # A revoked (stolen-then-killed) capability is dead everywhere.
+        await broker.revoke(run_id)
+        response = await client.post(
+            "/v1/invoke",
+            headers={"Authorization": f"Bearer {real}"},
+            json={"operation": "tool.invoke", "resource": "notify"},
+        )
+        assert response.status == 403
+    operation.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_expired_capability_rejected():
+    from datetime import datetime, timedelta, timezone
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock
+
+    operation = SimpleNamespace(valid_resource=lambda r: True, execute=AsyncMock())
+    db = SimpleNamespace(
+        users=SimpleNamespace(find_one=AsyncMock(return_value={"status": "active"})),
+        execution_capabilities=_Caps(),
+        execution_audit=SimpleNamespace(insert_one=AsyncMock()),
+    )
+    broker = Broker(db, "dep-adv", {"tool.invoke": operation})
+    _, token = await broker.issue(user_email="owner@example.test",
+                                  grants={"tool.invoke": ["notify"]}, ttl_seconds=1)
+    doc = list(db.execution_capabilities.docs.values())[0]
+    doc["expires_at"] = datetime.now(timezone.utc) - timedelta(seconds=1)
+    with pytest.raises(Denied):
+        await broker.execute(token, "tool.invoke", "notify")
+    operation.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_broker_fails_closed_when_authz_lookup_errors():
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock
+
+    operation = SimpleNamespace(valid_resource=lambda r: True, execute=AsyncMock())
+    caps = _Caps()
+    db = SimpleNamespace(
+        users=SimpleNamespace(find_one=AsyncMock(return_value={"status": "active"})),
+        execution_capabilities=caps,
+        execution_audit=SimpleNamespace(insert_one=AsyncMock()),
+    )
+    broker = Broker(db, "dep-adv", {"tool.invoke": operation})
+    _, token = await broker.issue(user_email="owner@example.test",
+                                  grants={"tool.invoke": ["notify"]})
+
+    async def boom(*args, **kwargs):
+        raise RuntimeError("db unavailable")
+
+    caps.find_one_and_update = boom
+    with pytest.raises(RuntimeError):
+        await broker.execute(token, "tool.invoke", "notify")
+    operation.execute.assert_not_awaited()
+
+    # User-status lookup failure after admission also blocks execution.
+    caps2 = _Caps()
+    db2 = SimpleNamespace(
+        users=SimpleNamespace(find_one=AsyncMock(side_effect=RuntimeError("db down"))),
+        execution_capabilities=caps2,
+        execution_audit=SimpleNamespace(insert_one=AsyncMock()),
+    )
+    broker2 = Broker(db2, "dep-adv", {"tool.invoke": operation})
+    db2.users.find_one.side_effect = None
+    db2.users.find_one.return_value = {"status": "active"}
+    _, token2 = await broker2.issue(user_email="owner@example.test",
+                                    grants={"tool.invoke": ["notify"]})
+    db2.users.find_one.side_effect = RuntimeError("db down")
+    with pytest.raises(RuntimeError):
+        await broker2.execute(token2, "tool.invoke", "notify")
+    operation.execute.assert_not_awaited()

--- a/tests/test_background_subscription_boundary.py
+++ b/tests/test_background_subscription_boundary.py
@@ -1,0 +1,51 @@
+import os
+from types import SimpleNamespace
+from unittest.mock import Mock, AsyncMock
+
+import pytest
+
+from agent import pool
+from broker import controller
+from broker.credential_files import protect_account_directory
+from broker.service import Denied
+
+
+@pytest.mark.asyncio
+async def test_unscoped_background_call_never_borrows_account(monkeypatch):
+    account = Mock(side_effect=AssertionError('must not borrow credentials'))
+    spawn = AsyncMock()
+    monkeypatch.setattr(pool, 'get_pool', account)
+    monkeypatch.setattr(controller, 'current_run', SimpleNamespace(get=lambda: None))
+    monkeypatch.setattr(pool.worker_mod, 'spawn_worker', spawn)
+    result = await pool.run_background_cli(['claude', '-p', 'synthetic'], timeout=1)
+    assert result[0] == 1
+    account.assert_not_called()
+    spawn.assert_not_awaited()
+
+
+def test_legacy_account_permissions_are_private(tmp_path):
+    path = tmp_path / 'account'
+    path.mkdir(mode=0o755)
+    protect_account_directory(path)
+    assert path.stat().st_mode & 0o777 == 0o700
+    assert path.stat().st_uid == os.geteuid()
+
+
+def test_account_symlink_not_followed(tmp_path):
+    target = tmp_path / 'target'
+    target.mkdir(mode=0o755)
+    alias = tmp_path / 'alias'
+    alias.symlink_to(target)
+    with pytest.raises(Denied):
+        protect_account_directory(alias)
+    assert target.stat().st_mode & 0o777 == 0o755
+
+
+@pytest.mark.skipif(os.geteuid() != 0, reason='requires synthetic uid ownership')
+def test_legacy_worker_owned_directory_is_reclaimed(tmp_path):
+    path = tmp_path / 'account'
+    path.mkdir()
+    os.chown(path, 299999, 299999)
+    protect_account_directory(path)
+    assert path.stat().st_uid == 0
+    assert path.stat().st_mode & 0o777 == 0o700

--- a/tests/test_broker_artifact_transport.py
+++ b/tests/test_broker_artifact_transport.py
@@ -1,0 +1,139 @@
+"""Real local subprocess tests of request-owned input and output channels."""
+import base64
+import io
+import json
+import runpy
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from broker.operations import ToolInvoke
+from broker.service import Denied
+from broker.worker import populate_tool_shims
+
+
+@pytest.fixture
+def sandbox_tool(tmp_path, monkeypatch):
+    from broker import operations
+    tools = tmp_path / 'tools'
+    tools.mkdir()
+    monkeypatch.setattr(operations, 'PROJECT_ROOT', tmp_path)
+    monkeypatch.setattr('tools._auth_token.create_user_auth_token', lambda email: 'synthetic')
+    db = SimpleNamespace(integrations=SimpleNamespace(find_one=AsyncMock(return_value={'status': 'active'})))
+    return tools, db
+
+
+@pytest.mark.asyncio
+async def test_binary_artifact_roundtrip_uses_only_request_owned_paths(sandbox_tool):
+    tools, db = sandbox_tool
+    (tools / 'zoho_books.py').write_text('''import sys,json
+from pathlib import Path
+out = sys.argv[sys.argv.index('--output') + 1]
+Path(out).write_bytes(bytes(range(256)))
+print(json.dumps({'output':out}))
+''')
+    target = '/workspace/report.pdf'
+    result = await ToolInvoke().execute(db, 'owner@example.test', 'zoho_books', {
+        'argv': ['download-invoice-pdf', 'synthetic', '--region', 'in', '--output', target]})
+    assert result['exit_code'] == 0
+    assert base64.b64decode(result['artifacts'][target]['data']) == bytes(range(256))
+    assert target in result['stdout']
+    assert 'loma-broker-files-' not in result['stdout']
+    assert not Path(target).exists()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('kind', ['symlink', 'fifo'])
+async def test_output_channel_does_not_read_special_files(sandbox_tool, kind):
+    tools, db = sandbox_tool
+    (tools / 'zoho_books.py').write_text('''import sys,os
+out = sys.argv[sys.argv.index('--output') + 1]
+''' + ("os.symlink('/example/nonexistent', out)" if kind == 'symlink' else 'os.mkfifo(out)'))
+    with pytest.raises((Denied, OSError)):
+        await ToolInvoke().execute(db, 'owner@example.test', 'zoho_books', {
+            'argv': ['download-invoice-pdf', 'synthetic', '--region', 'in', '--output', '/workspace/output']})
+
+
+@pytest.mark.asyncio
+async def test_stdin_roundtrip_and_identity_stripping(sandbox_tool):
+    tools, db = sandbox_tool
+    (tools / 'pylon.py').write_text('import sys\nprint(sys.stdin.read())')
+    result = await ToolInvoke().execute(db, 'owner@example.test', 'pylon', {
+        'argv': ['note', 'synthetic', '--user-email', 'other@example.test', '--auth-token', 'forged'],
+        'stdin': '<p>example note</p>'})
+    assert result['exit_code'] == 0
+    assert result['stdout'].strip() == '<p>example note</p>'
+
+
+@pytest.mark.asyncio
+async def test_stdin_is_denied_on_commands_without_explicit_support(monkeypatch):
+    spawn = AsyncMock()
+    monkeypatch.setattr('asyncio.create_subprocess_exec', spawn)
+    with pytest.raises(Denied):
+        await ToolInvoke().execute(None, 'owner@example.test', 'notify', {
+            'argv': ['list'], 'stdin': 'unexpected'})
+    spawn.assert_not_called()
+
+
+def test_worker_saves_artifact_without_modifying_outside_paths(tmp_path, monkeypatch):
+    populate_tool_shims(tmp_path, ['zoho_books'])
+    monkeypatch.setenv('HOME', str(tmp_path))
+    monkeypatch.setenv('LOMA_RUN_CAPABILITY', 'synthetic')
+    monkeypatch.setattr(sys, 'argv', ['zoho_books.py', 'download-invoice-pdf', 'synthetic'])
+    data = bytes(range(256))
+    target = tmp_path / 'output.pdf'
+    payload = {'exit_code': 0, 'stdout': '', 'artifacts': {str(target): {
+        'encoding': 'base64', 'data': base64.b64encode(data).decode()}}}
+    class Response:
+        def __enter__(self): return self
+        def __exit__(self, *args): pass
+        def read(self): return json.dumps(payload).encode()
+    monkeypatch.setattr('urllib.request.urlopen', lambda *a, **kw: Response())
+    shim = runpy.run_path(str(tmp_path / 'tools' / 'zoho_books.py'))
+    assert shim['main']() == 0
+    assert target.read_bytes() == data
+    outside = tmp_path.parent / (tmp_path.name + '-outside.pdf')
+    payload['artifacts'] = {str(outside): payload['artifacts'][str(target)]}
+    assert shim['main']() == 1
+    assert not outside.exists()
+
+
+def test_worker_only_reads_stdin_for_declared_commands(tmp_path, monkeypatch):
+    populate_tool_shims(tmp_path, ['pylon'])
+    monkeypatch.setenv('HOME', str(tmp_path))
+    monkeypatch.setenv('LOMA_RUN_CAPABILITY', 'synthetic')
+    monkeypatch.setattr(sys, 'argv', ['pylon.py', 'note', 'synthetic'])
+    monkeypatch.setattr(sys, 'stdin', io.StringIO('example note'))
+    class Response:
+        def __enter__(self): return self
+        def __exit__(self, *args): pass
+        def read(self): return b'{"stdout":"","exit_code":0}'
+    def urlopen(request, **kw):
+        assert json.loads(request.data)['params']['stdin'] == 'example note'
+        return Response()
+    monkeypatch.setattr('urllib.request.urlopen', urlopen)
+    shim = runpy.run_path(str(tmp_path / 'tools' / 'pylon.py'))
+    assert shim['main']() == 0
+
+
+@pytest.mark.asyncio
+async def test_agreement_identity_and_binary_output_roundtrip(sandbox_tool):
+    tools, db = sandbox_tool
+    (tools / 'agreement_review.py').write_text('''import sys,json
+from pathlib import Path
+assert sys.argv[1] == 'download'
+assert sys.argv[sys.argv.index('--user-email')+1] == 'owner@example.test'
+assert sys.argv[sys.argv.index('--auth-token')+1] == 'synthetic'
+output = sys.argv[sys.argv.index('--output-path')+1]
+Path(output).write_bytes(bytes(range(256)))
+print(json.dumps({'file_path': output}))
+''')
+    result = await ToolInvoke().execute(db, 'owner@example.test', 'agreement_review', {
+        'argv': ['download', '--file-id', 'sample', '--output-path', '/workspace/review.docx',
+                 '--user-email', 'forged@example.test', '--auth-token', 'forged']})
+    assert result['exit_code'] == 0
+    assert base64.b64decode(result['artifacts']['/workspace/review.docx']['data']) == bytes(range(256))
+    assert 'loma-broker-files-' not in result['stdout']

--- a/tests/test_broker_gateway.py
+++ b/tests/test_broker_gateway.py
@@ -1,0 +1,268 @@
+"""Credential-injection gateway tests: MCP proxying and model brokering.
+
+All synthetic: upstreams are local test servers, credentials are fakes.
+"""
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from broker.gateway import (
+    McpProxyRegistry,
+    configured_model_providers,
+    create_gateway_app,
+    gateway_base_url,
+)
+from broker.service import Denied
+
+CAPABILITY = "loma_run_v1_" + "a" * 43
+
+
+class FakeBroker:
+    """Admits only CAPABILITY for model.request; optionally errors."""
+
+    def __init__(self, fail_with: Exception | None = None):
+        self.fail_with = fail_with
+        self.calls = []
+
+    async def execute(self, token, operation, resource, params=None):
+        self.calls.append((token, operation, resource))
+        if self.fail_with is not None:
+            raise self.fail_with
+        if token != CAPABILITY or operation not in {"model.request", "mcp.request"}:
+            raise Denied()
+        return {"ok": True}
+
+
+async def make_upstream(recorder: list):
+    async def handler(request):
+        recorder.append({
+            "path": request.path_qs,
+            "headers": dict(request.headers),
+            "body": (await request.read()).decode(),
+        })
+        return web.json_response({"upstream": "ok"})
+
+    app = web.Application()
+    app.router.add_route("*", "/{tail:.*}", handler)
+    server = TestServer(app)
+    await server.start_server()
+    return server
+
+
+# ── Registry ─────────────────────────────────────────────────────────────
+
+
+def test_registry_tokens_are_unguessable_and_revocable():
+    registry = McpProxyRegistry()
+    token = registry.register("linear", "https://mcp.example.test/sse", {"Authorization": "Bearer org-key"})
+    assert token.startswith("loma_mcpproxy_") and len(token) > 30
+    assert registry.lookup(token)["headers"] == {"Authorization": "Bearer org-key"}
+    registry.revoke(token)
+    with pytest.raises(Denied):
+        registry.lookup(token)
+
+
+def test_registry_rejects_plain_http_upstreams():
+    registry = McpProxyRegistry()
+    with pytest.raises(Denied):
+        registry.register("x", "http://mcp.example.test/sse", {})
+    # Loopback upstreams are allowed (local test/dev servers).
+    registry.register("y", "http://127.0.0.1:9/x", {})
+
+
+def test_registry_expiry(monkeypatch):
+    registry = McpProxyRegistry()
+    token = registry.register("x", "https://mcp.example.test", {}, ttl_seconds=0)
+    with pytest.raises(Denied):
+        registry.lookup(token)
+
+
+# ── MCP proxy ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_mcp_proxy_injects_credentials_and_strips_client_auth():
+    seen = []
+    upstream = await make_upstream(seen)
+    try:
+        registry = McpProxyRegistry()
+        token = registry.register(
+            "linear", str(upstream.make_url("/mcp")), {"Authorization": "Bearer org-secret"}, capability=CAPABILITY,
+        )
+        app = create_gateway_app(FakeBroker(), registry)
+        async with TestClient(TestServer(app)) as client:
+            response = await client.post(
+                f"/mcp/{token}",
+                json={"jsonrpc": "2.0", "method": "tools/list"},
+                headers={"Authorization": "Bearer worker-supplied",
+                         "Cookie": "steal=me", "X-Api-Key": "nope"},
+            )
+            assert response.status == 200
+            assert await response.json() == {"upstream": "ok"}
+        request = seen[0]
+        assert request["headers"]["Authorization"] == "Bearer org-secret"
+        assert "Cookie" not in request["headers"]
+        assert "X-Api-Key" not in request["headers"]
+        assert "tools/list" in request["body"]
+    finally:
+        await upstream.close()
+
+
+@pytest.mark.asyncio
+async def test_mcp_proxy_denies_unknown_and_revoked_tokens():
+    registry = McpProxyRegistry()
+    token = registry.register("x", "https://mcp.example.test", {"Authorization": "Bearer k"})
+    registry.revoke(token)
+    app = create_gateway_app(FakeBroker(), registry)
+    async with TestClient(TestServer(app)) as client:
+        for bad in (token, "loma_mcpproxy_forged", "anything"):
+            response = await client.post(f"/mcp/{bad}", json={})
+            assert response.status == 403
+            body = await response.json()
+            assert "org-secret" not in str(body)
+
+
+# ── Model proxy ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_model_proxy_requires_valid_capability(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-synthetic")
+    broker = FakeBroker()
+    app = create_gateway_app(broker, McpProxyRegistry())
+    async with TestClient(TestServer(app)) as client:
+        # Missing / forged bearer -> denied before any upstream contact.
+        for headers in ({}, {"Authorization": "Bearer forged"},
+                        {"x-api-key": "sk-ant-synthetic"}):
+            response = await client.post("/model/anthropic/v1/messages", headers=headers, json={})
+            assert response.status == 403
+
+
+@pytest.mark.asyncio
+async def test_model_proxy_fails_closed_on_broker_errors(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-synthetic")
+    app = create_gateway_app(FakeBroker(fail_with=RuntimeError("db down")), McpProxyRegistry())
+    async with TestClient(TestServer(app)) as client:
+        response = await client.post(
+            "/model/anthropic/v1/messages",
+            headers={"Authorization": f"Bearer {CAPABILITY}"}, json={},
+        )
+        assert response.status == 503
+
+
+@pytest.mark.asyncio
+async def test_model_proxy_denies_unknown_or_unconfigured_providers(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    app = create_gateway_app(FakeBroker(), McpProxyRegistry())
+    async with TestClient(TestServer(app)) as client:
+        for provider in ("evil", "openai"):
+            response = await client.post(
+                f"/model/{provider}/v1/chat/completions",
+                headers={"Authorization": f"Bearer {CAPABILITY}"}, json={},
+            )
+            assert response.status == 403
+
+
+@pytest.mark.asyncio
+async def test_model_proxy_injects_server_side_key(monkeypatch):
+    seen = []
+    upstream = await make_upstream(seen)
+    try:
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-synthetic")
+        import broker.gateway as gateway_mod
+        monkeypatch.setitem(
+            gateway_mod.MODEL_PROVIDERS, "anthropic",
+            {**gateway_mod.MODEL_PROVIDERS["anthropic"],
+             "upstream": str(upstream.make_url("")).rstrip("/")},
+        )
+        broker = FakeBroker()
+        app = create_gateway_app(broker, McpProxyRegistry())
+        async with TestClient(TestServer(app)) as client:
+            response = await client.post(
+                "/model/anthropic/v1/messages",
+                headers={"Authorization": f"Bearer {CAPABILITY}",
+                         "anthropic-version": "2023-06-01"},
+                json={"model": "claude-x", "messages": []},
+            )
+            assert response.status == 200
+        request = seen[0]
+        # The worker's capability never reaches the provider; the real key does.
+        assert request["headers"]["x-api-key"] == "sk-ant-synthetic"
+        assert CAPABILITY not in str(request["headers"])
+        assert request["headers"]["anthropic-version"] == "2023-06-01"
+        assert request["path"] == "/v1/messages"
+        assert broker.calls == [(CAPABILITY, "model.request", "anthropic")]
+    finally:
+        await upstream.close()
+
+
+def test_configured_model_providers_reads_env(monkeypatch):
+    for key in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "OPENROUTER_API_KEY", "OPENCODE_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+    assert configured_model_providers() == set()
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-synthetic")
+    assert configured_model_providers() == {"openai"}
+
+
+def test_gateway_base_url_defaults_to_loopback(monkeypatch):
+    monkeypatch.delenv("LOMA_GATEWAY_HOST", raising=False)
+    monkeypatch.delenv("LOMA_GATEWAY_PORT", raising=False)
+    assert gateway_base_url() == "http://127.0.0.1:3101"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('capability', [None, 'invalid'])
+async def test_mcp_proxy_requires_live_bound_capability(capability):
+    seen = []
+    upstream = await make_upstream(seen)
+    try:
+        registry = McpProxyRegistry()
+        token = registry.register('linear', str(upstream.make_url('/mcp')), {}, capability=capability)
+        async with TestClient(TestServer(create_gateway_app(FakeBroker(), registry))) as client:
+            response = await client.post(f'/mcp/{token}', json={'method': 'tools/list'})
+            assert response.status == 403
+        assert seen == []
+    finally:
+        await upstream.close()
+
+
+@pytest.mark.asyncio
+async def test_mcp_proxy_rechecks_authorization_outage_before_upstream():
+    seen = []
+    upstream = await make_upstream(seen)
+    try:
+        registry = McpProxyRegistry()
+        token = registry.register('linear', str(upstream.make_url('/mcp')), {}, capability=CAPABILITY)
+        broker = FakeBroker(fail_with=RuntimeError('unavailable'))
+        async with TestClient(TestServer(create_gateway_app(broker, registry))) as client:
+            response = await client.post(f'/mcp/{token}', json={'method': 'tools/list'})
+            assert response.status == 503
+        assert seen == []
+    finally:
+        await upstream.close()
+
+
+@pytest.mark.parametrize('url', [None, 42, 'http://localhost.example.test/mcp',
+    'http://127.0.0.1.example.test/mcp', 'http://localhost@example.test/mcp',
+    'https://user:password@example.test/mcp', 'https://example.test/mcp#fragment',
+    'https://example.test:invalid/mcp', 'https://example.test/space here'])
+def test_mcp_registry_uses_parsed_authority_not_string_prefix(url):
+    with pytest.raises(Denied):
+        McpProxyRegistry().register('sample', url, {})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('method,suffix', [('POST', '/extra'), ('GET', '?override=1'), ('PUT', ''), ('PATCH', '')])
+async def test_mcp_endpoint_scope_cannot_expand(method, suffix):
+    seen = []
+    upstream = await make_upstream(seen)
+    try:
+        registry = McpProxyRegistry()
+        token = registry.register('sample', str(upstream.make_url('/mcp')), {}, capability=CAPABILITY)
+        async with TestClient(TestServer(create_gateway_app(FakeBroker(), registry))) as client:
+            response = await client.request(method, f'/mcp/{token}{suffix}')
+            assert response.status == 403
+        assert not seen
+    finally:
+        await upstream.close()

--- a/tests/test_cli_security_boundary.py
+++ b/tests/test_cli_security_boundary.py
@@ -1,0 +1,308 @@
+"""Synthetic authorization and command-contract tests; no provider calls."""
+import ast
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import Mock, AsyncMock
+
+import pytest
+
+from broker.operations import INTEGRATION_TOOLS, ToolInvoke
+from broker.service import Denied
+from broker.tool_policy import POLICY, prepare_argv
+from tools import _integration_access as access
+from tools import loma_skills
+
+EMAIL = 'owner@example.test'
+
+
+@pytest.mark.parametrize('argv', [[], ['--user-email', EMAIL],
+    ['--user-email', EMAIL, '--auth-token'],
+    ['--user-email', EMAIL, '--auth-token', 'sample', '--user-email=other'],
+    ['--user-email=', '--auth-token=sample']])
+def test_identity_must_be_complete_and_unambiguous(argv):
+    with pytest.raises(access.IntegrationAccessDenied):
+        access.split_identity(argv)
+
+
+def test_identity_flags_can_be_anywhere():
+    assert access.split_identity(['query', '--auth-token=sample', '--user-email', EMAIL, '--sql', 'select 1']) == (
+        EMAIL, 'sample', ['query', '--sql', 'select 1'])
+
+
+@pytest.fixture
+def cli_db(monkeypatch):
+    monkeypatch.setenv('OBSERVABILITY_MONGODB_URI', 'mongodb://example.test')
+    monkeypatch.setattr(access, 'verify_user_auth_token', lambda token, email: token == 'sample')
+    db = SimpleNamespace(users=SimpleNamespace(find_one=Mock(return_value={'status': 'active'})),
+        integrations=SimpleNamespace(find_one=Mock(return_value={'status': 'active'})),
+        teams=SimpleNamespace(find=Mock(return_value=[])))
+    client = Mock()
+    client.__getitem__ = Mock(return_value=db)
+    constructor = Mock(return_value=client)
+    monkeypatch.setattr('pymongo.MongoClient', constructor)
+    return db, client, constructor
+
+
+@pytest.mark.parametrize('status', [None, 'pending', 'rejected', 'disabled'])
+def test_inactive_user_cannot_use_environment_key(cli_db, monkeypatch, status):
+    db, client, _ = cli_db
+    monkeypatch.setenv('POSTHOG_API_KEY', 'synthetic-placeholder')
+    db.users.find_one.return_value = {'status': status}
+    with pytest.raises(access.IntegrationAccessDenied):
+        access.require_cli_access('posthog', EMAIL, 'sample')
+    db.integrations.find_one.assert_not_called()
+    client.close.assert_called_once()
+
+
+def test_invalid_identity_does_not_connect_to_database(cli_db):
+    _, _, constructor = cli_db
+    with pytest.raises(access.IntegrationAccessDenied):
+        access.require_cli_access('posthog', EMAIL, 'invalid')
+    constructor.assert_not_called()
+
+
+@pytest.mark.parametrize('doc', [None, {'status': 'inactive'},
+    {'status': 'active', 'scope': 'personal', 'connected_by': 'other'},
+    {'status': 'active', 'shared_with': {'mode': 'specific', 'users': ['other']}}])
+def test_connection_restrictions(cli_db, doc):
+    db, client, _ = cli_db
+    db.integrations.find_one.return_value = doc
+    with pytest.raises(access.IntegrationAccessDenied):
+        access.require_cli_access('posthog', EMAIL, 'sample')
+    client.close.assert_called_once()
+
+
+def test_team_access_and_revocation_rechecked(cli_db):
+    db, _, _ = cli_db
+    db.integrations.find_one.return_value = {'status': 'active', 'shared_with': {'mode': 'specific', 'teams': ['t1']}}
+    db.teams.find.return_value = [{'team_id': 't1'}]
+    access.require_cli_access('posthog', EMAIL, 'sample')
+    db.teams.find.return_value = []
+    with pytest.raises(access.IntegrationAccessDenied):
+        access.require_cli_access('posthog', EMAIL, 'sample')
+
+
+def test_database_failure_denies_without_error_details(cli_db):
+    db, client, _ = cli_db
+    db.integrations.find_one.side_effect = RuntimeError('synthetic database failure')
+    with pytest.raises(access.IntegrationAccessDenied, match='denied or unavailable'):
+        access.require_cli_access('posthog', EMAIL, 'sample')
+    client.close.assert_called_once()
+
+
+@pytest.mark.parametrize('tool', sorted(INTEGRATION_TOOLS))
+def test_every_direct_integration_entrypoint_authorizes_before_dispatch(tool):
+    source = Path(__file__).resolve().parents[1] / 'tools' / f'{tool}.py'
+    tree = ast.parse(source.read_text())
+    block = next(n for n in tree.body if isinstance(n, ast.If) and '__name__' in ast.unparse(n.test))
+    assert isinstance(block.body[0], ast.ImportFrom)
+    assert block.body[0].module == '_integration_access'
+    assert ast.unparse(block.body[1]).startswith('authorize_cli(')
+
+
+@pytest.mark.parametrize('tool,argv', [
+    ('loma_skills', ['import-dir', '--source', '/example']),
+    ('google_drive', ['upload-file', '--file-path', '/example/private']),
+    ('gmail', ['send-email', '--attachments=/example/private']),
+    ('gmail', ['create-draft', '--html-body-file', '/example/private']),
+    ('google_apps_script', ['update-content', '--code-file', '/example/private']),
+    ('slack_user', ['upload-file', '--file', '/example/private']),
+    ('notify', ['send', '--title', 'a', '--title', 'b']),
+    ('notify', ['send', '--tit', 'a']),
+    ('notify', ['send', '--title', '--unexpected']),
+    ('notify', ['send', '--title', 'a\0b']),
+    ('notify', ['send', 'extra']),
+    ('diagrams', ['render']), ('pptx_creator', ['create']),
+])
+def test_unsafe_or_unreviewed_command_is_denied(tool, argv):
+    with pytest.raises(Denied):
+        prepare_argv(tool, argv, {})
+
+
+def test_files_are_rewritten_only_in_file_parameters():
+    mapped = prepare_argv('gmail', ['send-email', '--body', '/workspace/a',
+        '--attachments=/workspace/a,/workspace/b'],
+        {'/workspace/a': '/trusted/input-0', '/workspace/b': '/trusted/input-1'})
+    assert mapped == ['send-email', '--body', '/workspace/a', '--attachments', '/trusted/input-0,/trusted/input-1']
+
+
+def test_unused_upload_denied():
+    with pytest.raises(Denied):
+        prepare_argv('notify', ['list'], {'unused': 'unused'})
+
+
+@pytest.mark.asyncio
+async def test_denial_happens_before_files_or_subprocess(monkeypatch):
+    spawn = AsyncMock()
+    mkdir = Mock()
+    monkeypatch.setattr('asyncio.create_subprocess_exec', spawn)
+    monkeypatch.setattr('tempfile.mkdtemp', mkdir)
+    with pytest.raises(Denied):
+        await ToolInvoke().execute(None, EMAIL, 'loma_skills', {
+            'argv': ['import-dir', '--source', '/example'], 'files': {'x': 'x'}})
+    mkdir.assert_not_called()
+    spawn.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_skill_cli_auth_and_owner_filter(monkeypatch, capsys):
+    db = SimpleNamespace(users=SimpleNamespace(find_one=AsyncMock(return_value={'status': 'active'})))
+    client = Mock()
+    monkeypatch.setattr(loma_skills, '_connect_db', lambda: (client, db))
+    monkeypatch.setattr(loma_skills, 'verify_user_auth_token', lambda token, email: token == 'sample')
+    monkeypatch.setattr(loma_skills.skill_service, 'list_skills', AsyncMock(return_value=[
+        {'slug': 'shared', 'scope': 'workspace'},
+        {'slug': 'mine', 'scope': 'personal', 'created_by': EMAIL},
+        {'slug': 'other', 'scope': 'personal', 'created_by': 'other'},
+    ]))
+    args = SimpleNamespace(command='list', user_email=EMAIL, auth_token='sample')
+    assert await loma_skills._run(args) == 0
+    assert [s['slug'] for s in json.loads(capsys.readouterr().out)['skills']] == ['shared', 'mine']
+    args.auth_token = 'invalid'
+    assert await loma_skills._run(args) == 1
+    assert json.loads(capsys.readouterr().out)['status'] == 403
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('command', ['get', 'dump', 'file', 'asset', 'update-file', 'delete-file'])
+async def test_skill_owner_check_precedes_read_or_write(monkeypatch, capsys, command):
+    db = SimpleNamespace(users=SimpleNamespace(find_one=AsyncMock(return_value={'status': 'active'})),
+        skills=SimpleNamespace(find_one=AsyncMock(return_value={'scope': 'personal', 'created_by': 'other'})))
+    monkeypatch.setattr(loma_skills, '_connect_db', lambda: (Mock(), db))
+    monkeypatch.setattr(loma_skills, 'verify_user_auth_token', lambda token, email: True)
+    args = SimpleNamespace(command=command, user_email=EMAIL, auth_token='sample', slug='sample')
+    assert await loma_skills._run(args) == 1
+    assert json.loads(capsys.readouterr().out)['status'] == 403
+
+
+def test_requested_namespace_boundary_cannot_silently_downgrade(monkeypatch):
+    from broker import worker
+    monkeypatch.setenv('LOMA_WORKER_BWRAP', '1')
+    monkeypatch.setattr(worker.shutil, 'which', lambda name: None)
+    with pytest.raises(worker.WorkerIsolationError):
+        worker.bwrap_available()
+
+
+def test_sdk_launcher_obeys_namespace_policy(monkeypatch, tmp_path):
+    from broker import worker
+    monkeypatch.setattr(worker, '_worker_uid_gid', lambda: (None, None))
+    monkeypatch.setenv('LOMA_WORKER_BWRAP', '1')
+    monkeypatch.setattr(worker.shutil, 'which', lambda name: '/usr/bin/' + name)
+    (tmp_path / 'tmp').mkdir(mode=0o700)
+    tmp_path.chmod(0o700)
+    launcher = worker.write_cli_launcher(tmp_path, '/usr/bin/example-cli', {'HOME': str(tmp_path)})
+    text = launcher.read_text()
+    assert "'bwrap'" in text and "'--unshare-pid'" in text
+    assert "'--bind'" in text
+    assert "'/opt'" not in text
+
+
+def test_sdk_launcher_refuses_missing_privilege_drop(monkeypatch, tmp_path):
+    from broker import worker
+    monkeypatch.setattr(worker, '_worker_uid_gid', lambda: (12345, 12345))
+    monkeypatch.setattr(worker.shutil, 'which', lambda name: None)
+    with pytest.raises(worker.WorkerIsolationError):
+        worker.write_cli_launcher(tmp_path, '/usr/bin/example-cli', {})
+
+
+def test_configured_identity_does_not_fall_back_to_backend_user(monkeypatch):
+    from broker import worker
+    monkeypatch.setenv('LOMA_WORKER_UID', '12345')
+    monkeypatch.setenv('LOMA_WORKER_GID', '12345')
+    monkeypatch.setattr(worker.os, 'geteuid', lambda: 23456)
+    with pytest.raises(worker.WorkerIsolationError):
+        worker._worker_uid_gid()
+
+
+@pytest.mark.parametrize('argv', [
+    ['--auth-token', 'sample', 'list', '--user-email', EMAIL],
+    ['--user-email', EMAIL, '--auth-token', 'sample', 'get', '--slug', 'sample'],
+    ['get', '--slug', 'sample', '--user-email', EMAIL, '--auth-token', 'sample'],
+    ['--auth-token', 'sample', 'update-file', '--slug', 'sample', '--path', 'SKILL.md',
+     '--content-file', '/workspace/example', '--user-email', EMAIL],
+])
+def test_skill_real_parser_preserves_global_and_subcommand_identity(monkeypatch, argv):
+    seen = []
+    async def capture(args):
+        seen.append(args)
+        return 0
+    monkeypatch.setattr(sys, 'argv', ['loma_skills.py', *argv])
+    monkeypatch.setattr(loma_skills, '_run', capture)
+    assert loma_skills.main() == 0
+    assert seen[0].auth_token == 'sample' and seen[0].user_email == EMAIL
+
+
+def test_ashby_identity_retained_after_command(monkeypatch):
+    monkeypatch.setattr(access, 'require_cli_access', lambda *args: None)
+    monkeypatch.setattr(sys, 'argv', ['ashby.py', '--auth-token=sample', 'list-jobs', '--user-email', EMAIL])
+    access.authorize_cli('ashby', preserve_identity=True)
+    assert sys.argv == ['ashby.py', 'list-jobs', '--user-email', EMAIL, '--auth-token', 'sample']
+
+
+def test_generated_shim_uploads_only_declared_file_arguments(monkeypatch, tmp_path, capsys):
+    import runpy
+    from broker.worker import populate_tool_shims
+    populate_tool_shims(tmp_path, ['gmail'])
+    attachment = tmp_path / 'attachment.txt'
+    attachment.write_text('synthetic content')
+    sibling = tmp_path.parent / (tmp_path.name + '-sibling')
+    sibling.mkdir()
+    outside = sibling / 'outside.txt'
+    outside.write_text('not part of this workspace')
+    monkeypatch.setenv('HOME', str(tmp_path))
+    monkeypatch.setattr(sys, 'argv', ['gmail.py', '--auth-token=sample', 'send-email',
+        '--body', str(attachment), '--attachments=' + str(attachment) + ',' + str(outside)])
+    captured = []
+    class Response:
+        def __enter__(self): return self
+        def __exit__(self, *args): pass
+        def read(self): return b'{"stdout":"","exit_code":0}'
+    def urlopen(request, **kwargs):
+        captured.append(json.loads(request.data))
+        return Response()
+    monkeypatch.setattr('urllib.request.urlopen', urlopen)
+    shim = runpy.run_path(str(tmp_path / 'tools/gmail.py'))
+    assert shim['main']() == 0
+    assert captured[0]['params']['files'] == {str(attachment): {
+        'encoding': 'base64', 'data': 'c3ludGhldGljIGNvbnRlbnQ='}}
+
+
+@pytest.mark.asyncio
+async def test_tool_output_limit_is_enforced_while_reading(monkeypatch):
+    from broker import operations
+    import asyncio
+    monkeypatch.setattr(operations, '_MAX_OUTPUT_BYTES', 32)
+    stdout = asyncio.StreamReader()
+    stdout.feed_data(b'x' * 33)
+    stdout.feed_eof()
+    stderr = asyncio.StreamReader()
+    stderr.feed_eof()
+    process = SimpleNamespace(stdout=stdout, stderr=stderr, wait=AsyncMock(return_value=0))
+    with pytest.raises(operations.ToolOutputLimit):
+        await operations._collect_tool_output(process)
+
+
+@pytest.mark.asyncio
+async def test_tool_cancellation_terminates_process_and_removes_uploads(monkeypatch):
+    from broker import operations
+    import asyncio
+    process = SimpleNamespace(pid=12345, wait=AsyncMock(return_value=0))
+    spawn = AsyncMock(return_value=process)
+    kill = Mock()
+    monkeypatch.setattr(asyncio, 'create_subprocess_exec', spawn)
+    monkeypatch.setattr(operations, '_collect_tool_output', AsyncMock(side_effect=asyncio.CancelledError))
+    monkeypatch.setattr(operations.os, 'killpg', kill)
+    monkeypatch.setattr('tools._auth_token.create_user_auth_token', lambda email: 'sample')
+    with pytest.raises(asyncio.CancelledError):
+        await operations.ToolInvoke().execute(None, EMAIL, 'google_drive', {
+            'argv': ['upload-file', '--file-path', '/workspace/a.txt'],
+            'files': {'/workspace/a.txt': 'test'},
+        })
+    kill.assert_called_once()
+    process.wait.assert_awaited_once()
+    args = spawn.call_args.args
+    uploaded_path = args[args.index('--file-path') + 1]
+    assert uploaded_path.endswith('.txt') and not Path(uploaded_path).exists()
+    assert spawn.call_args.kwargs['start_new_session'] is True

--- a/tests/test_custom_connector.py
+++ b/tests/test_custom_connector.py
@@ -37,11 +37,7 @@ async def test_custom_connector_with_token():
          patch("api.oauth_helpers.decrypt_token", return_value="tok-123"):
         config = await merge_db_integrations({"mcp_servers": {}})
 
-    assert config["mcp_servers"]["acme"] == {
-        "type": "http",
-        "url": "https://mcp.acme.com/mcp",
-        "headers": {"Authorization": "tok-123"},
-    }
+    assert "acme" not in config["mcp_servers"]
 
 
 @pytest.mark.asyncio
@@ -59,7 +55,7 @@ async def test_custom_connector_custom_header():
          patch("api.oauth_helpers.decrypt_token", return_value="tok-123"):
         config = await merge_db_integrations({"mcp_servers": {}})
 
-    assert config["mcp_servers"]["acme"]["headers"] == {"X-Api-Key": "tok-123"}
+    assert "acme" not in config["mcp_servers"]
 
 
 @pytest.mark.asyncio
@@ -76,8 +72,4 @@ async def test_custom_connector_without_token_has_no_headers():
     with patch("observability.db.get_db", return_value=db):
         config = await merge_db_integrations({"mcp_servers": {}})
 
-    assert config["mcp_servers"]["acme"] == {
-        "type": "http",
-        "url": "https://mcp.acme.com/mcp",
-    }
-    assert "headers" not in config["mcp_servers"]["acme"]
+    assert "acme" not in config["mcp_servers"]

--- a/tests/test_execution_broker.py
+++ b/tests/test_execution_broker.py
@@ -1,0 +1,269 @@
+"""Synthetic broker tests. No real providers, databases or credentials."""
+import asyncio
+import copy
+import json
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from aiohttp.test_utils import TestClient, TestServer
+
+from broker.service import Broker, Denied
+from broker.grain import GrainTranscript
+from broker.http import create_app
+
+RESOURCE = '11111111-2222-3333-4444-555555555555'
+OTHER = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'
+EMAIL = 'owner@example.test'
+
+
+class Capabilities:
+    def __init__(self):
+        self.docs = {}
+        self.create_index = AsyncMock()
+
+    async def insert_one(self, doc):
+        self.docs[doc['_id']] = copy.deepcopy(doc)
+
+    async def find_one_and_update(self, query, update):
+        doc = self.docs.get(query['_id'])
+        if not doc or any(doc[k] != query[k] for k in ('deployment_id', 'revoked')):
+            return None
+        if doc['expires_at'] <= query['expires_at']['$gt'] or doc['remaining_calls'] <= 0:
+            return None
+        if query['scopes']['$elemMatch'] not in doc['scopes']:
+            return None
+        old = copy.deepcopy(doc)
+        doc['remaining_calls'] += update['$inc']['remaining_calls']
+        return old
+
+    async def update_many(self, query, update):
+        for doc in self.docs.values():
+            if all(doc[k] == v for k, v in query.items()):
+                doc.update(update['$set'])
+
+
+@pytest.fixture
+def setup():
+    db = SimpleNamespace(
+        users=SimpleNamespace(find_one=AsyncMock(return_value={'status': 'active'})),
+        execution_capabilities=Capabilities(),
+        execution_audit=SimpleNamespace(insert_one=AsyncMock()),
+        oauth_tokens=SimpleNamespace(find_one=AsyncMock(return_value={
+            'access_token': 'encrypted-synthetic',
+            'token_expiry': datetime.now(timezone.utc) + timedelta(minutes=5),
+        })),
+    )
+    operation = SimpleNamespace(valid_resource=GrainTranscript.valid_resource,
+                                execute=AsyncMock(return_value={'transcript': 'hello'}))
+    broker = Broker(db, 'deployment-a', {'grain.transcript': operation})
+    return db, broker, operation
+
+
+async def issue(broker, **kwargs):
+    return await broker.issue(user_email=EMAIL, grants={'grain.transcript': [RESOURCE]}, **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_opaque_capability_and_server_derived_identity(setup):
+    db, broker, operation = setup
+    run, token = await issue(broker)
+    assert EMAIL not in token and run not in token
+    assert token not in repr(db.execution_capabilities.docs)
+    assert await broker.execute(token, 'grain.transcript', RESOURCE) == {'transcript': 'hello'}
+    operation.execute.assert_awaited_once_with(db, EMAIL, RESOURCE)
+    assert token not in repr(db.execution_audit.insert_one.call_args)
+    await broker.initialize()
+    db.execution_capabilities.create_index.assert_awaited_once_with('expires_at', expireAfterSeconds=0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('case', ['token', 'operation', 'resource', 'expiry', 'revocation', 'tenant'])
+async def test_invalid_or_out_of_scope_capabilities_never_call_provider(setup, case):
+    db, broker, operation = setup
+    run, token = await issue(broker)
+    name, resource = 'grain.transcript', RESOURCE
+    if case == 'token': token += 'x'
+    if case == 'operation': name = 'grain.delete'
+    if case == 'resource': resource = OTHER
+    if case == 'expiry': next(iter(db.execution_capabilities.docs.values()))['expires_at'] = datetime.now(timezone.utc)
+    if case == 'revocation': await broker.revoke(run)
+    if case == 'tenant': broker = Broker(db, 'deployment-b', broker.operations)
+    with pytest.raises(Denied):
+        await broker.execute(token, name, resource)
+    operation.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('status', ['pending', 'rejected', None, 'deleted'])
+async def test_account_rechecked_after_issuance(setup, status):
+    db, broker, operation = setup
+    _, token = await issue(broker)
+    db.users.find_one.return_value = {'status': status} if status != 'deleted' else None
+    with pytest.raises(Denied): await broker.execute(token, 'grain.transcript', RESOURCE)
+    with pytest.raises(Denied): await issue(broker)
+    operation.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_budget_admission_concurrency_and_failures(setup):
+    _, broker, operation = setup
+    _, token = await issue(broker, max_calls=2)
+    operation.execute.side_effect = RuntimeError('synthetic failure')
+    results = await asyncio.gather(*(
+        broker.execute(token, 'grain.transcript', RESOURCE) for _ in range(10)
+    ), return_exceptions=True)
+    assert sum(isinstance(r, Denied) for r in results) == 8
+    assert operation.execute.await_count == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('target', ['users', 'execution_audit'])
+async def test_dependency_failure_prevents_provider_call(setup, target):
+    db, broker, operation = setup
+    _, token = await issue(broker)
+    getattr(getattr(db, target), 'find_one' if target == 'users' else 'insert_one').side_effect = RuntimeError('offline')
+    with pytest.raises(RuntimeError): await broker.execute(token, 'grain.transcript', RESOURCE)
+    operation.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('kwargs', [{'ttl_seconds': 0}, {'ttl_seconds': 7201}, {'ttl_seconds': True},
+                                   {'max_calls': 0}, {'max_calls': 1001}, {'max_calls': False}])
+async def test_invalid_issuance_bounds(setup, kwargs):
+    with pytest.raises(ValueError): await issue(setup[1], **kwargs)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('grants', [{}, {'unknown': [RESOURCE]}, {'grain.transcript': ['*']},
+                                   {'grain.transcript': []}, {'grain.transcript': RESOURCE}])
+async def test_grants_deny_unknown_operations_and_wildcards(setup, grants):
+    with pytest.raises(ValueError): await setup[1].issue(user_email=EMAIL, grants=grants)
+
+
+@pytest.mark.parametrize('resource', ['../../etc/passwd', 'https://evil.test', RESOURCE + '?url=x',
+                                     RESOURCE + '/..', '', None, {}, '*'])
+def test_resource_validation(resource):
+    assert not GrainTranscript.valid_resource(resource)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('body', [[], {}, {'operation': 'grain.transcript', 'resource': RESOURCE, 'user_email': EMAIL},
+                                 {'operation': 'grain.transcript', 'resource': RESOURCE, 'url': 'https://evil.test'}])
+async def test_http_rejects_identity_or_destination_override(setup, body):
+    _, broker, operation = setup
+    _, token = await issue(broker)
+    async with TestClient(TestServer(create_app(broker))) as client:
+        response = await client.post('/v1/invoke', headers={'Authorization': 'Bearer ' + token}, json=body)
+        assert response.status == 400
+        assert (await client.post('/v1/issue', json={})).status == 404
+    operation.execute.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_http_errors_hide_secrets_and_headers_do_not_authenticate(setup):
+    db, broker, operation = setup
+    _, token = await issue(broker)
+    operation.execute.side_effect = RuntimeError('SECRET provider key')
+    async with TestClient(TestServer(create_app(broker))) as client:
+        response = await client.post('/v1/invoke', headers={'X-User-Email': EMAIL},
+                                     json={'operation': 'grain.transcript', 'resource': RESOURCE})
+        assert response.status == 403
+        response = await client.post('/v1/invoke', headers={'Authorization': 'Bearer ' + token},
+                                     json={'operation': 'grain.transcript', 'resource': RESOURCE})
+        assert response.status == 503 and 'SECRET' not in await response.text()
+
+
+@pytest.mark.asyncio
+async def test_http_success_redacts_and_is_not_cached(setup):
+    _, broker, operation = setup
+    _, token = await issue(broker)
+    operation.execute.return_value = {'text': token, 'access_token': 'synthetic'}
+    async with TestClient(TestServer(create_app(broker))) as client:
+        response = await client.post('/v1/invoke', headers={'Authorization': 'Bearer ' + token},
+                                     json={'operation': 'grain.transcript', 'resource': RESOURCE})
+        assert response.status == 200 and response.headers['Cache-Control'] == 'no-store'
+        text = await response.text()
+        assert token not in text and 'synthetic' not in text
+
+
+class Response:
+    def __init__(self, status=200, chunks=None, encoding='identity'):
+        self.status = status
+        self.headers = {'Content-Encoding': encoding}
+        self.chunks = chunks or [b'hello synthetic-provider-token']
+        self.content = self
+
+    async def iter_chunked(self, size):
+        for chunk in self.chunks: yield chunk
+
+    async def __aenter__(self): return self
+    async def __aexit__(self, *args): pass
+
+
+def network(response):
+    session = SimpleNamespace(get=Mock(return_value=response))
+    context = AsyncMock()
+    context.__aenter__.return_value = session
+    return context
+
+
+@pytest.mark.asyncio
+async def test_grain_pins_destination_and_only_reads_owners_oauth(setup):
+    db = setup[0]
+    with patch('broker.grain.decrypt_token', return_value='synthetic-provider-token'), \
+            patch('broker.grain.aiohttp.ClientSession', return_value=network(Response())) as factory:
+        result = await GrainTranscript().execute(db, EMAIL, RESOURCE)
+    db.oauth_tokens.find_one.assert_awaited_once_with({'user_email': EMAIL, 'provider': 'grain'})
+    assert 'synthetic-provider-token' not in json.dumps(result)
+    assert factory.call_args.kwargs['trust_env'] is False
+    assert factory.call_args.kwargs['auto_decompress'] is False
+    request = factory.return_value.__aenter__.return_value.get
+    assert request.call_args.args == (f'https://api.grain.com/_/public-api/v2/recordings/{RESOURCE}/transcript.txt',)
+    assert request.call_args.kwargs['allow_redirects'] is False
+    assert request.call_args.kwargs['headers']['Authorization'] == 'Bearer synthetic-provider-token'
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('state', ['absent', 'expired'])
+async def test_grain_no_organization_or_environment_fallback(setup, state, monkeypatch):
+    db = setup[0]
+    monkeypatch.setenv('GRAIN_API_TOKEN', 'organization-secret')
+    db.oauth_tokens.find_one.return_value = None if state == 'absent' else {
+        'access_token': 'encrypted', 'token_expiry': datetime.now(timezone.utc) - timedelta(seconds=1)}
+    with patch('broker.grain.aiohttp.ClientSession') as factory:
+        with pytest.raises(Denied): await GrainTranscript().execute(db, EMAIL, RESOURCE)
+    factory.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('response', [Response(status=302), Response(status=401),
+                                     Response(encoding='gzip'), Response(chunks=[b'x' * (1024 * 1024 + 1)])])
+async def test_grain_rejects_redirects_compression_errors_and_oversize(setup, response):
+    with patch('broker.grain.decrypt_token', return_value='synthetic-provider-token'), \
+            patch('broker.grain.aiohttp.ClientSession', return_value=network(response)):
+        with pytest.raises(Denied): await GrainTranscript().execute(setup[0], EMAIL, RESOURCE)
+
+
+@pytest.mark.asyncio
+async def test_restart_and_targeted_revocation(setup):
+    db, broker, operation = setup
+    first_run, first = await issue(broker)
+    _, second = await issue(broker)
+    restarted = Broker(db, 'deployment-a', broker.operations)
+    await restarted.revoke(first_run)
+    with pytest.raises(Denied): await restarted.execute(first, 'grain.transcript', RESOURCE)
+    await restarted.execute(second, 'grain.transcript', RESOURCE)
+    assert operation.execute.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_http_oversize_and_invalid_json(setup):
+    _, broker, operation = setup
+    _, token = await issue(broker)
+    async with TestClient(TestServer(create_app(broker))) as client:
+        for body, status in [('x' * (3 * 1024 * 1024), 413), ('{bad', 400)]:
+            response = await client.post('/v1/invoke', headers={'Authorization': 'Bearer ' + token}, data=body)
+            assert response.status == status
+    operation.execute.assert_not_awaited()

--- a/tests/test_gvisor_execution.py
+++ b/tests/test_gvisor_execution.py
@@ -1,0 +1,103 @@
+"""Real runtime smoke checks on a dedicated, secrets-free CI host.
+
+No vendor credentials or deployment are involved. Normal unit runs skip this
+file; the Worker Isolation workflow supplies the built image and runsc.
+"""
+import json
+import os
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+import asyncio
+from aiohttp import web
+
+from broker import sandbox, worker
+
+pytestmark = pytest.mark.skipif(os.environ.get('LOMA_TEST_GVISOR') != '1', reason='requires a gVisor-capable host and worker image')
+
+
+@pytest_asyncio.fixture
+async def running_sandbox(tmp_path, monkeypatch):
+    monkeypatch.setenv('LOMA_WORKER_SANDBOX', 'runsc')
+    monkeypatch.setenv('LOMA_WORKER_UID_RANGE', '240000-240999')
+    monkeypatch.setenv('LOMA_WORKER_ROOT', str(tmp_path / 'workers'))
+    monkeypatch.setenv('LOMA_SANDBOX_STATE', str(tmp_path / 'control'))
+    monkeypatch.setenv('LOMA_SANDBOX_SOCKETS', str(tmp_path / 'transports'))
+    private = tmp_path / 'synthetic-host-only.txt'
+    private.write_text('synthetic-host-only')
+    private.chmod(0o644)  # must be hidden by isolation, not just Unix permissions
+    app = web.Application()
+    async def ok(request):
+        return web.json_response({'synthetic': True})
+    app.router.add_get('/test', ok)
+    broker = web.AppRunner(app)
+    gateway = web.AppRunner(web.Application())
+    await broker.setup()
+    await gateway.setup()
+    await sandbox.serve_transports(broker, gateway)
+    workspace = worker.create_workspace(prefix='ci')
+    sibling = worker.create_workspace(prefix='sibling')
+    (sibling / 'synthetic.txt').write_text('synthetic-sibling')
+    try:
+        yield workspace, sibling, private
+    finally:
+        worker.cleanup_workspace(workspace)
+        worker.cleanup_workspace(sibling)
+        await broker.cleanup()
+        await gateway.cleanup()
+    assert not workspace.exists()
+    assert not list(sandbox.state_root().glob('run-*'))
+
+
+@pytest.mark.asyncio
+async def test_actual_independent_sandbox(running_sandbox):
+    workspace, sibling, private = running_sandbox
+    code = '''import json,os,socket,urllib.request
+from pathlib import Path
+assert Path('/proc/gvisor/kernel_is_gvisor').exists()
+assert not Path(%r).exists()
+assert not Path(%r).exists()
+assert 'OAUTH_ENCRYPTION_KEY' not in os.environ
+assert os.getuid() != 0
+for address in [('198.51.100.1',443),('127.0.0.1',3000)]:
+    try:
+        socket.create_connection(address,timeout=1)
+    except OSError:
+        pass
+    else:
+        raise AssertionError('unexpected network access')
+print(json.dumps({'broker': json.load(urllib.request.urlopen('http://127.0.0.1:3100/test'))}))
+''' % (str(private), str(sibling))
+    process = await worker.spawn_worker(['python3', '-c', code], workspace=workspace,
+                                        env=worker.build_worker_env(workspace), wall_time_seconds=60)
+    stdout, stderr = await asyncio.wait_for(process.communicate(), 90)
+    assert process.returncode == 0, stderr.decode()
+    assert json.loads(stdout)['broker'] == {'synthetic': True}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('cli', ['claude', 'codex', 'opencode'])
+async def test_installed_cli_boots_in_real_sandbox(running_sandbox, cli):
+    workspace, _, _ = running_sandbox
+    process = await worker.spawn_worker([cli, '--version'], workspace=workspace,
+                                        env=worker.build_worker_env(workspace), wall_time_seconds=60)
+    stdout, stderr = await asyncio.wait_for(process.communicate(), 90)
+    assert process.returncode == 0, stderr.decode()
+    assert stdout.strip() or stderr.strip()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_worker_cannot_leave_detached_processes(running_sandbox):
+    workspace, _, _ = running_sandbox
+    process = await worker.spawn_worker(['python3', '-u', '-c',
+        "import subprocess,time; subprocess.Popen(['sleep','300'], start_new_session=True); print('ready',flush=True); time.sleep(300)"],
+        workspace=workspace, env=worker.build_worker_env(workspace), wall_time_seconds=60)
+    assert await asyncio.wait_for(process.stdout.readline(), 45) == b'ready\n'
+    worker.terminate_worker(process)
+    # Teardown must force-delete the sandbox, including children that detached
+    # from the runtime's original process group, before releasing its workspace.
+    await asyncio.to_thread(worker.cleanup_workspace, workspace)
+    await asyncio.wait_for(process.communicate(), 15)
+    assert not workspace.exists()
+    assert not list(sandbox.state_root().glob('run-*'))

--- a/tests/test_image_cli_install.py
+++ b/tests/test_image_cli_install.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+from unittest.mock import patch
+import subprocess
+
+import pytest
+from scripts.check_worker_clis import check_clis
+
+
+def test_opencode_is_copied_out_of_root_before_worker_image_snapshot():
+    dockerfile = Path("Dockerfile").read_text()
+    install = "install -m 0755 /root/.opencode/bin/opencode /usr/local/bin/opencode"
+    assert "OPENCODE_INSTALL_DIR=" not in dockerfile
+    assert "bash /tmp/install-opencode.sh --no-modify-path" in dockerfile
+    assert dockerfile.index(install) < dockerfile.index("&& opencode --version")
+    assert dockerfile.index("RUN python /tmp/check_worker_clis.py") < dockerfile.index("FROM worker-base AS backend")
+
+
+def test_smoke_check_drops_identity_and_does_not_inherit_secrets():
+    with patch("os.geteuid", return_value=0), patch("os.chown"), \
+         patch("shutil.which", side_effect=lambda name, **kw: "/usr/local/bin/" + name), \
+         patch("subprocess.run") as run:
+        check_clis()
+    assert run.call_count == 3
+    for call in run.call_args_list:
+        assert call.kwargs["user"] == call.kwargs["group"] == 65534
+        assert call.kwargs["extra_groups"] == ()
+        assert set(call.kwargs["env"]) == {"PATH", "HOME", "XDG_CONFIG_HOME", "XDG_DATA_HOME"}
+        assert call.kwargs["check"] is True
+
+
+def test_smoke_check_propagates_cli_failure():
+    with patch("os.geteuid", return_value=0), patch("os.chown"), \
+         patch("shutil.which", return_value="/usr/local/bin/opencode"), \
+         patch("subprocess.run", side_effect=subprocess.CalledProcessError(127, "opencode")):
+        with pytest.raises(subprocess.CalledProcessError):
+            check_clis()

--- a/tests/test_integration_access.py
+++ b/tests/test_integration_access.py
@@ -1,0 +1,185 @@
+"""Owner and sharing checks, with synthetic records and no provider calls."""
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import web
+
+from integrations.access import allows_user, require_provider
+from broker.operations import ToolInvoke, McpRequest, _strip_identity_flags
+from broker.service import Denied
+from api import integration_routes, routes, skill_service
+from tests.test_security_boundaries import Request, proxy_secret
+
+EMAIL = 'owner@example.test'
+
+
+@pytest.mark.parametrize('doc,allowed', [
+    ({'status': 'active'}, True),
+    ({'status': 'inactive'}, False),
+    ({'status': 'active', 'shared_with': {'mode': 'unknown'}}, False),
+    ({'status': 'active', 'shared_with': {'mode': 'specific', 'users': [EMAIL]}}, True),
+    ({'status': 'active', 'shared_with': {'mode': 'specific', 'users': ['other']}}, False),
+    ({'status': 'active', 'is_custom': True, 'connected_by': EMAIL}, True),
+    ({'status': 'active', 'is_custom': True, 'connected_by': 'other'}, False),
+    ({'status': 'active', 'is_custom': True}, False),
+    ({'status': 'active', 'scope': 'personal', 'connected_by': 'other', 'shared_with': {'mode': 'everyone'}}, False),
+])
+def test_connection_ownership(doc, allowed):
+    assert allows_user(doc, EMAIL) is allowed
+    assert not allows_user(doc, '')
+
+
+def test_team_scope():
+    doc = {'status': 'active', 'shared_with': {'mode': 'specific', 'teams': ['finance']}}
+    assert allows_user(doc, EMAIL, ['finance'])
+    assert not allows_user(doc, EMAIL, ['engineering'])
+
+
+@pytest.mark.asyncio
+async def test_permissions_rechecked_on_every_tool_call():
+    lookup = AsyncMock(side_effect=[{'status': 'active'}, {'status': 'inactive'}])
+    db = SimpleNamespace(integrations=SimpleNamespace(find_one=lookup))
+    await require_provider(db, 'posthog', EMAIL)
+    with pytest.raises(Denied):
+        await ToolInvoke().execute(db, EMAIL, 'posthog', {'argv': []})
+    assert lookup.await_count == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('record', [None, RuntimeError('unavailable')])
+async def test_lookup_failures_deny(record):
+    lookup = AsyncMock(return_value=record) if record is None else AsyncMock(side_effect=record)
+    db = SimpleNamespace(integrations=SimpleNamespace(find_one=lookup))
+    with pytest.raises(Denied):
+        await require_provider(db, 'posthog', EMAIL)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('role', ['chatter', 'analyst', 'operator', 'maintainer'])
+@pytest.mark.parametrize('handler', [integration_routes._connect_integration, integration_routes._disconnect_integration])
+async def test_org_credentials_admin_only(role, handler):
+    with pytest.raises(web.HTTPForbidden):
+        await handler(Request(role=role))
+
+
+@pytest.mark.asyncio
+async def test_personal_skill_move_checks_owner_before_update():
+    db = SimpleNamespace(skills=SimpleNamespace(
+        find_one=AsyncMock(return_value={'scope': 'personal', 'created_by': 'other'}),
+        update_one=AsyncMock()))
+    with pytest.raises(skill_service.SkillError) as caught:
+        await skill_service.update_skill_folder(db, slug='sample', actor=EMAIL, folder='Folder')
+    assert caught.value.status == 403
+    db.skills.update_one.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('role', ['chatter', 'analyst', 'admin'])
+async def test_picker_only_returns_owned_or_shared_skills(role):
+    skills = [{'slug': 'mine', 'scope': 'personal', 'created_by': EMAIL},
+              {'slug': 'other', 'scope': 'personal', 'created_by': 'other'},
+              {'slug': 'global', 'scope': 'workspace'}, {'slug': 'builtin', 'scope': 'system'}]
+    with patch.object(routes, 'get_db', return_value=object()), patch.object(
+        skill_service, 'list_skills', AsyncMock(return_value=skills)):
+        result = await routes.handle_list_skills(Request(user=EMAIL, role=role))
+    assert [s['slug'] for s in json.loads(result.body)['skills']] == ['mine', 'global', 'builtin']
+
+
+def test_equals_identity_flags_removed():
+    assert _strip_identity_flags(['--user-email=other', '--auth-token=invalid', 'list']) == ['list']
+
+
+@pytest.mark.asyncio
+async def test_mcp_personal_provider_never_uses_org_fallback():
+    with patch('api.oauth_helpers.get_valid_provider_token', AsyncMock(return_value=None)):
+        with pytest.raises(Denied):
+            await McpRequest().execute(object(), EMAIL, 'grain')
+
+
+@pytest.mark.asyncio
+async def test_grain_auth_checked_before_db():
+    from tools.grain import run_personal
+    with patch('tools._auth_token.verify_user_auth_token', return_value=False):
+        with pytest.raises(ValueError, match='authentication'):
+            await run_personal('search', ['test'], EMAIL, 'invalid')
+
+
+def test_grain_ignores_organization_environment(monkeypatch):
+    from tools.grain import _get_api_token
+    monkeypatch.setenv('GRAIN_API_TOKEN', 'synthetic-test-value')
+    with pytest.raises(ValueError, match='personal Grain'):
+        _get_api_token()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('identifier', ['../other', 'id?query=1', 'https://example.test'])
+async def test_grain_pins_transcript_resource(identifier):
+    from tools.grain import get_transcript
+    with pytest.raises(ValueError, match='recording ID'):
+        await get_transcript(identifier)
+
+
+@pytest.mark.asyncio
+async def test_owner_custom_config_is_not_shared():
+    from agent.client import build_user_mcp_overrides
+    from tests.test_runtime_isolation import FakeCursor
+    lookup = MagicMock(return_value=FakeCursor([{
+        'provider': 'private-example', 'is_custom': True, 'status': 'active',
+        'connected_by': EMAIL, 'auth_mode': 'static', 'mcp_url': 'https://example.test/mcp',
+        'api_key_encrypted': 'encrypted-placeholder',
+    }]))
+    db = SimpleNamespace(integrations=SimpleNamespace(find=lookup))
+    with patch('observability.db.get_db', return_value=db), patch(
+        'api.oauth_helpers.get_valid_provider_token', AsyncMock(return_value=None)), patch(
+        'api.oauth_helpers.decrypt_token', return_value='synthetic-test-value'):
+        result = await build_user_mcp_overrides(EMAIL)
+    assert lookup.call_args.args[0]['connected_by'] == EMAIL
+    assert result['private-example']['url'] == 'https://example.test/mcp'
+
+
+@pytest.mark.asyncio
+async def test_provider_refresh_does_not_resurrect_revoked_connection():
+    from datetime import datetime, timezone, timedelta
+    from api.oauth_helpers import get_valid_provider_token
+    doc = {'access_token': 'old-encrypted', 'refresh_token': 'old-refresh',
+           'token_expiry': datetime.now(timezone.utc) - timedelta(hours=1)}
+    update = AsyncMock(return_value=SimpleNamespace(matched_count=0))
+    db = SimpleNamespace(oauth_tokens=SimpleNamespace(find_one=AsyncMock(return_value=doc), update_one=update))
+    with patch('api.oauth_helpers.decrypt_token', return_value='synthetic-refresh'), patch(
+        'api.oauth_helpers.encrypt_token', return_value='new-encrypted'), patch(
+        'api.oauth_helpers._refresh_oauth_token', AsyncMock(return_value={'access_token': 'synthetic-new'})):
+        assert await get_valid_provider_token(EMAIL, 'grain', db=db) is None
+    assert update.call_args.args[0]['access_token'] == 'old-encrypted'
+
+
+@pytest.mark.asyncio
+async def test_anonymous_mcp_configs_disabled(monkeypatch):
+    from broker import controller
+    from broker.gateway import McpProxyRegistry
+    monkeypatch.setattr(controller, '_registry', McpProxyRegistry())
+    marker = controller.current_run.set(None)
+    try:
+        configs, tokens, disabled = controller.proxy_mcp_servers_for_worker({'example': {'type': 'http', 'url': 'https://example.test'}})
+        assert configs == {} and tokens == [] and disabled == ['example']
+    finally:
+        controller.current_run.reset(marker)
+
+
+@pytest.mark.asyncio
+async def test_claude_run_does_not_reuse_unbound_warm_client(monkeypatch):
+    from agent.pool import ClientPool
+    from broker import controller
+    pool = ClientPool.__new__(ClientPool)
+    pool._closed = False
+    pool._accounts = [{'email': EMAIL}]
+    pool._in_use = 0
+    pool._next_account = lambda: pool._accounts[0]
+    pool._create_client = AsyncMock(return_value='fresh-bound-client')
+    marker = controller.current_run.set(SimpleNamespace(capability='synthetic'))
+    try:
+        assert await pool.acquire() == 'fresh-bound-client'
+        pool._create_client.assert_awaited_once()
+    finally:
+        controller.current_run.reset(marker)

--- a/tests/test_login_terminal.py
+++ b/tests/test_login_terminal.py
@@ -1,0 +1,62 @@
+"""Credential setup uses only fixed vendor login commands, not a shell."""
+import json
+import time
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
+
+from api import terminal_routes as terminal
+
+
+@pytest.fixture(autouse=True)
+def registry(monkeypatch):
+    monkeypatch.setattr(terminal, '_login_tokens', {})
+    monkeypatch.setattr(terminal.shutil, 'which', lambda name: '/synthetic/' + name)
+
+
+@pytest.mark.parametrize('provider,command', [
+    ('claude', ['/synthetic/claude', 'auth', 'login']),
+    ('codex', ['/synthetic/codex', 'login', '--device-auth']),
+])
+def test_login_grant_is_fixed_argv_and_contains_no_backend_env(tmp_path, monkeypatch, provider, command):
+    monkeypatch.setenv('SYNTHETIC_BACKEND_SECRET', 'must-stay-backend')
+    email = 'owner@example.test'
+    config = tmp_path / email
+    token = terminal.register_login_terminal(email, provider, config)
+    grant = terminal._login_tokens[token]
+    assert grant['argv'] == command
+    assert grant['email'] == email
+    assert grant['expiry'] > time.time()
+    assert 'must-stay-backend' not in json.dumps(grant)
+    assert 'SYNTHETIC_BACKEND_SECRET' not in grant['env']
+    assert config.stat().st_mode & 0o777 == 0o700
+    assert not any(arg in ('bash', 'sh', '-c', '-p') for arg in command)
+
+
+@pytest.mark.parametrize('email', ['../other', 'a/b@example.test', '.', '..', ''])
+def test_login_directory_identity_is_validated(tmp_path, email):
+    with pytest.raises(web.HTTPBadRequest):
+        terminal.register_login_terminal(email, 'claude', tmp_path / 'unused')
+    assert terminal._login_tokens == {}
+
+
+def test_unknown_provider_is_not_an_arbitrary_backend_command(tmp_path):
+    with pytest.raises(web.HTTPBadRequest):
+        terminal.register_login_terminal('owner@example.test', 'bash', tmp_path / 'unused')
+
+
+@pytest.mark.asyncio
+async def test_login_grant_is_owner_bound_and_consumed_before_fork(tmp_path, monkeypatch):
+    token = terminal.register_login_terminal('owner@example.test', 'claude', tmp_path / 'owner')
+    fork = Mock(side_effect=AssertionError('must not fork'))
+    monkeypatch.setattr(terminal.pty, 'fork', fork)
+    req = make_mocked_request('GET', '/api/terminal/ws?token=' + token)
+    req['user_email'] = 'another@example.test'
+    req['system_role'] = 'chatter'
+    response = await terminal.handle_terminal_ws(req)
+    assert response.status == 403
+    assert token not in terminal._login_tokens
+    fork.assert_not_called()

--- a/tests/test_loma_skills_cli.py
+++ b/tests/test_loma_skills_cli.py
@@ -1,5 +1,6 @@
 import asyncio
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 
 from tools import loma_skills
@@ -14,10 +15,11 @@ def test_get_notes_that_it_returns_skill_md_only(monkeypatch, capsys):
             "content": "Main instructions",
         }
 
-    monkeypatch.setattr(loma_skills, "_connect_db", lambda: (SimpleNamespace(close=lambda: None), object()))
+    monkeypatch.setattr(loma_skills, "_connect_db", lambda: (SimpleNamespace(close=lambda: None), SimpleNamespace(skills=SimpleNamespace(find_one=AsyncMock(return_value=None)))))
+    monkeypatch.setattr(loma_skills, "_require_reader", AsyncMock(return_value="owner@example.test"))
     monkeypatch.setattr(loma_skills.skill_service, "get_skill", fake_get_skill)
 
-    status = asyncio.run(loma_skills._run(SimpleNamespace(command="get", slug="demo")))
+    status = asyncio.run(loma_skills._run(SimpleNamespace(command="get", slug="demo", user_email="owner@example.test", auth_token="sample")))
 
     assert status == 0
     output = capsys.readouterr().out
@@ -29,11 +31,12 @@ def test_dump_prints_markdown(monkeypatch, capsys):
     async def fake_get_skill(db, slug):
         return {"slug": slug, "name": "Demo", "files": []}
 
-    monkeypatch.setattr(loma_skills, "_connect_db", lambda: (SimpleNamespace(close=lambda: None), object()))
+    monkeypatch.setattr(loma_skills, "_connect_db", lambda: (SimpleNamespace(close=lambda: None), SimpleNamespace(skills=SimpleNamespace(find_one=AsyncMock(return_value=None)))))
+    monkeypatch.setattr(loma_skills, "_require_reader", AsyncMock(return_value="owner@example.test"))
     monkeypatch.setattr(loma_skills.skill_service, "get_skill", fake_get_skill)
     monkeypatch.setattr(loma_skills.skill_service, "format_skill_dump_markdown", lambda skill: "# Demo\n")
 
-    status = asyncio.run(loma_skills._run(SimpleNamespace(command="dump", slug="demo")))
+    status = asyncio.run(loma_skills._run(SimpleNamespace(command="dump", slug="demo", user_email="owner@example.test", auth_token="sample")))
 
     assert status == 0
     assert capsys.readouterr().out == "# Demo\n"

--- a/tests/test_oauth_routes.py
+++ b/tests/test_oauth_routes.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+from unittest.mock import AsyncMock, MagicMock
 from urllib.parse import parse_qs, urlparse
 
 from aiohttp.test_utils import make_mocked_request
@@ -9,7 +10,10 @@ from api.oauth_helpers import SLACK_USER_SCOPES
 
 
 def test_slack_authorize_uses_configured_redirect_uri(monkeypatch):
-    monkeypatch.setattr("api.oauth_routes.get_db", lambda: object())
+    db = MagicMock()
+    db.oauth_states.create_index = AsyncMock()
+    db.oauth_states.insert_one = AsyncMock()
+    monkeypatch.setattr("api.oauth_routes.get_db", lambda: db)
     monkeypatch.setenv("OAUTH_ENCRYPTION_KEY", "test-key")
     monkeypatch.setenv("SLACK_OAUTH_CLIENT_ID", "slack-client")
     monkeypatch.setenv(
@@ -37,7 +41,10 @@ def test_slack_authorize_uses_configured_redirect_uri(monkeypatch):
 
 
 def test_slack_authorize_derives_redirect_uri_from_public_base_url(monkeypatch):
-    monkeypatch.setattr("api.oauth_routes.get_db", lambda: object())
+    db = MagicMock()
+    db.oauth_states.create_index = AsyncMock()
+    db.oauth_states.insert_one = AsyncMock()
+    monkeypatch.setattr("api.oauth_routes.get_db", lambda: db)
     monkeypatch.setenv("OAUTH_ENCRYPTION_KEY", "test-key")
     monkeypatch.setenv("SLACK_OAUTH_CLIENT_ID", "slack-client")
     monkeypatch.setenv("PUBLIC_BASE_URL", "https://app.lomahq.com/")

--- a/tests/test_oauth_security.py
+++ b/tests/test_oauth_security.py
@@ -1,0 +1,207 @@
+"""Local, synthetic regression tests for connection and credential boundaries."""
+import asyncio
+import base64
+import hashlib
+import hmac
+import json
+import time
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from aiohttp.test_utils import make_mocked_request
+
+from api import oauth_helpers as helpers, oauth_routes as routes, governance_routes
+from tools._auth_token import create_user_auth_token, verify_user_auth_token
+from utils.secret_redaction import redact_secrets
+from observability.observer import ConversationObserver
+
+
+class StateStore:
+    def __init__(self):
+        self.records = {}
+        self.create_index = AsyncMock()
+
+    async def insert_one(self, doc):
+        self.records[doc['_id']] = doc.copy()
+
+    async def find_one_and_delete(self, query):
+        doc = self.records.get(query['_id'])
+        if not doc or any(doc[k] != query[k] for k in ('provider', 'browser_hash')):
+            return None
+        if doc['expires_at'] <= query['expires_at']['$gt']:
+            return None
+        return self.records.pop(query['_id'])
+
+
+@pytest.fixture
+def db():
+    return SimpleNamespace(oauth_states=StateStore(), users=SimpleNamespace(
+        find_one=AsyncMock(return_value={'email': 'owner@example.com', 'status': 'active'}),
+    ))
+
+
+@pytest.fixture(autouse=True)
+def synthetic_key(monkeypatch):
+    monkeypatch.setenv('OAUTH_ENCRYPTION_KEY', 'synthetic-test-key')
+
+
+@pytest.mark.asyncio
+async def test_state_opaque_and_single_use_across_workers(db):
+    state, cookie = await helpers.create_oauth_state(db, 'owner@example.com', 'google', 'verifier')
+    assert 'owner' not in state and 'verifier' not in state
+    assert not verify_user_auth_token(state, 'owner@example.com')
+    results = await asyncio.gather(*(helpers.consume_oauth_state(db, state, 'google', cookie) for _ in range(2)))
+    assert sum(result is not None for result in results) == 1
+    assert next(result for result in results if result)['code_verifier'] == 'verifier'
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('wrong', ['cookie', 'provider', 'state'])
+async def test_state_requires_exact_browser_and_provider_without_consuming(db, wrong):
+    state, cookie = await helpers.create_oauth_state(db, 'owner@example.com', 'grain')
+    assert await helpers.consume_oauth_state(db, state + 'x' if wrong == 'state' else state,
+        'google' if wrong == 'provider' else 'grain', '' if wrong == 'cookie' else cookie) is None
+    assert await helpers.consume_oauth_state(db, state, 'grain', cookie)
+
+
+@pytest.mark.asyncio
+async def test_expired_state_denied_before_ttl_cleanup(db):
+    state, cookie = await helpers.create_oauth_state(db, 'owner@example.com', 'google')
+    next(iter(db.oauth_states.records.values()))['expires_at'] = datetime.now(timezone.utc) - timedelta(seconds=1)
+    assert await helpers.consume_oauth_state(db, state, 'google', cookie) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('user', [None, {'status': 'pending'}, {'status': 'rejected'}])
+async def test_disabled_user_cannot_finish_linking(db, user):
+    state, cookie = await helpers.create_oauth_state(db, 'owner@example.com', 'google')
+    db.users.find_one.return_value = user
+    assert await helpers.consume_oauth_state(db, state, 'google', cookie) is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('provider', ['google', 'slack', 'grain', 'notion', 'hubspot', 'custom-mcp/demo'])
+async def test_every_callback_rejects_missing_browser_before_token_exchange(db, provider):
+    state, _ = await helpers.create_oauth_state(db, 'owner@example.com', provider)
+    custom = provider.startswith('custom-mcp/')
+    handler = routes.handle_custom_mcp_callback if custom else (
+        {'google': routes.handle_google_callback, 'slack': routes.handle_slack_callback}.get(provider, routes.handle_provider_callback))
+    req = make_mocked_request('GET', f'/api/oauth/{provider}/callback?code=synthetic&state={state}',
+                              match_info={'provider': provider.split('/')[-1]})
+    with patch.object(routes, 'get_db', return_value=db), patch.object(routes.aiohttp, 'ClientSession') as network:
+        response = await handler(req)
+    assert response.status == 400
+    network.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_authorize_cookie_properties_and_parallel_tabs(db, monkeypatch):
+    monkeypatch.setenv('GOOGLE_OAUTH_CLIENT_ID', 'synthetic-client')
+    monkeypatch.setenv('APP_BASE_URL', 'https://example.invalid')
+    request = make_mocked_request('GET', '/api/oauth/google/authorize')
+    request['user_email'] = 'owner@example.com'
+    with patch.object(routes, 'get_db', return_value=db):
+        first = await routes.handle_google_authorize(request)
+        second = await routes.handle_google_authorize(request)
+    assert set(first.cookies).isdisjoint(second.cookies)
+    state = parse_qs(urlparse(json.loads(first.text)['authorize_url']).query)['state'][0]
+    cookie = first.cookies[helpers.oauth_state_cookie(state)]
+    assert cookie['httponly'] and cookie['secure'] and cookie['samesite'] == 'Lax'
+    assert first.headers['Cache-Control'] == 'no-store'
+    assert await helpers.consume_oauth_state(db, state, 'google', cookie.value)
+
+
+@pytest.mark.asyncio
+async def test_google_callback_with_browser_stores_for_initiator(db, monkeypatch):
+    for key in ('GOOGLE_OAUTH_CLIENT_ID', 'GOOGLE_OAUTH_CLIENT_SECRET'):
+        monkeypatch.setenv(key, 'synthetic')
+    state, cookie = await helpers.create_oauth_state(db, 'owner@example.com', 'google')
+    req = make_mocked_request('GET', f'/api/oauth/google/callback?code=synthetic&state={state}',
+        headers={'Cookie': f'{helpers.oauth_state_cookie(state)}={cookie}'})
+    post = MagicMock()
+    post.__aenter__ = AsyncMock(return_value=SimpleNamespace(status=200, json=AsyncMock(return_value={
+        'access_token': 'synthetic-access', 'refresh_token': 'synthetic-refresh'})))
+    get = MagicMock()
+    get.__aenter__ = AsyncMock(return_value=SimpleNamespace(status=200, json=AsyncMock(return_value={
+        'email': 'chosen-account@example.com'})))
+    session = MagicMock()
+    session.__aenter__ = AsyncMock(return_value=SimpleNamespace(post=MagicMock(return_value=post), get=MagicMock(return_value=get)))
+    save = AsyncMock()
+    with patch.object(routes, 'get_db', return_value=db), patch.object(routes.aiohttp, 'ClientSession', return_value=session), patch.object(routes, 'store_google_tokens', save):
+        response = await routes.handle_google_callback(req)
+        replay = await routes.handle_google_callback(req)
+    assert response.status == 200 and replay.status == 400
+    assert save.await_count == 1
+    assert save.await_args.kwargs['user_email'] == 'owner@example.com'
+
+
+def test_personal_token_purpose_identity_and_expiry(monkeypatch):
+    token = create_user_auth_token('owner@example.com')
+    assert verify_user_auth_token(token, 'owner@example.com')
+    assert not verify_user_auth_token(token, 'other@example.com')
+    now = time.time()
+    monkeypatch.setattr(time, 'time', lambda: now + 3601)
+    assert not verify_user_auth_token(token, 'owner@example.com')
+    monkeypatch.setattr(time, 'time', lambda: now - 100)
+    assert not verify_user_auth_token(token, 'owner@example.com')
+
+
+def legacy_token():
+    ts = str(int(time.time()))
+    sig = hmac.new(b'synthetic-test-key', f'owner@example.com:{ts}'.encode(), hashlib.sha256).hexdigest()
+    return base64.urlsafe_b64encode(json.dumps({'email': 'owner@example.com', 'ts': ts, 'sig': sig}).encode()).decode()
+
+
+def test_legacy_tokens_and_oauth_state_no_longer_accepted():
+    assert not verify_user_auth_token(legacy_token(), 'owner@example.com')
+
+
+@pytest.mark.parametrize('payload', [[], None, 'text', 1, {'purpose': 'personal-tool', 'version': 1, 'email': [], 'ts': 1, 'sig': {}}])
+def test_malformed_tokens_fail_closed(payload):
+    token = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode()
+    assert not verify_user_auth_token(token, 'owner@example.com')
+
+
+@pytest.mark.parametrize('template', ['--auth-token {token}', '--auth-token="{token}"', 'Personal Tools Auth Token: {token}', '{{"nested": "{token}"}}', 'raw: {token}'])
+def test_redacts_old_and_new_personal_tokens(template):
+    for token in (legacy_token(), create_user_auth_token('owner@example.com')):
+        assert token not in redact_secrets(template.format(token=token))
+
+
+@pytest.mark.asyncio
+async def test_observer_redacts_before_truncation_and_history_response():
+    from api import routes as chat, task_routes
+    token = create_user_auth_token('owner@example.com')
+    database = MagicMock()
+    database.turns.update_one = AsyncMock()
+    observer = ConversationObserver(database, {'prompt': token})
+    await observer.record_tool_call(1, 'Bash', 'call', {'command': 'x' * 9900 + ' --auth-token ' + token})
+    assert token[:40] not in repr(database.turns.update_one.await_args)
+    await observer.record_tool_result('call', False, token)
+    assert token not in repr(database.turns.update_one.await_args)
+    for serialize in (chat._serialize, task_routes._serialize):
+        assert token not in json.dumps(serialize({'messages': [{'content': token}], 'tool_calls': [{'input': token}]}))
+
+
+@pytest.mark.asyncio
+async def test_profile_and_admin_serialization_exclude_local_auth():
+    database = MagicMock()
+    user = {'email': 'owner@example.com', 'local_auth': {'password_hash': 'synthetic-hash', 'salt': 'synthetic-salt'}}
+    database.users.find_one = AsyncMock(return_value=user)
+    req = make_mocked_request('GET', '/api/governance/me')
+    req['user_email'] = user['email']
+    with patch.object(governance_routes, 'get_db', return_value=database):
+        response = await governance_routes.handle_get_me(req)
+    assert 'local_auth' not in response.text
+    assert 'local_auth' not in governance_routes._serialize([user])[0]
+    assert 'local_auth' in user  # Sanitization never mutates credential storage.
+
+
+def test_callback_html_escapes_untrusted_provider_text():
+    response = routes._callback_error("</script><script>alert('test')</script>")
+    assert response.status == 400
+    assert response.text.count('<script>') == 1
+    assert "}, '*')" not in response.text

--- a/tests/test_oci_sandbox.py
+++ b/tests/test_oci_sandbox.py
@@ -1,0 +1,267 @@
+"""OCI configuration and transport tests. No claim of deployed isolation."""
+import asyncio
+import json
+import os
+from pathlib import Path
+import socket
+from types import SimpleNamespace
+
+import pytest
+from aiohttp import web, ClientSession, UnixConnector
+
+from broker import sandbox, worker
+
+
+@pytest.fixture
+def oci(tmp_path, monkeypatch):
+    monkeypatch.setenv('LOMA_WORKER_SANDBOX', 'runsc')
+    image = tmp_path / 'rootfs'
+    (image / 'usr/local/bin').mkdir(parents=True)
+    (image / 'usr/local/bin/python3').write_text('synthetic executable')
+    (image / '.loma-worker-image').write_text('1')
+    monkeypatch.setenv('LOMA_WORKER_ROOTFS', str(image))
+    monkeypatch.setenv('LOMA_SANDBOX_STATE', str(tmp_path / 'state'))
+    monkeypatch.setenv('LOMA_SANDBOX_SOCKETS', str(tmp_path / 'sockets'))
+    workspace = tmp_path / 'workspace'
+    workspace.mkdir(mode=0o700)
+    monkeypatch.setattr(worker, 'workspace_identity', lambda _: SimpleNamespace(uid=200000, gid=200000, per_run=True))
+    monkeypatch.setattr(worker, 'verify_workspace_ownership', lambda _: None)
+    monkeypatch.setattr(sandbox, '_runtime', lambda: '/usr/local/bin/runsc')
+    sockets = []
+    for name in ('broker', 'gateway'):
+        sock = socket.socket(socket.AF_UNIX)
+        sock.bind(str(sandbox.socket_root() / f'{name}.sock'))
+        sockets.append(sock)
+    yield workspace, image
+    for sock in sockets:
+        sock.close()
+
+
+def test_shipping_default_never_falls_back(monkeypatch):
+    monkeypatch.delenv('LOMA_WORKER_SANDBOX')
+    assert sandbox.enabled()
+    monkeypatch.setenv('LOMA_WORKER_SANDBOX', 'development')
+    monkeypatch.delenv('LOMA_ENV')
+    with pytest.raises(worker.WorkerIsolationError):
+        sandbox.enabled()
+
+
+def test_oci_has_separate_root_no_network_or_backend_mounts(oci):
+    workspace, image = oci
+    argv = sandbox.prepare(['python3', '-c', 'print(1)'], workspace, worker.build_worker_env(workspace))
+    bundle = Path(argv[-1])
+    config = json.loads((bundle / 'config.json').read_text())
+    assert config['root'] == {'path': str(image), 'readonly': True}
+    assert config['process']['noNewPrivileges']
+    assert config['process']['user']['uid'] == 200000
+    assert all(not value for value in config['process']['capabilities'].values())
+    assert {'type': 'network'} in config['linux']['namespaces']
+    sources = [m['source'] for m in config['mounts'] if m['type'] == 'bind']
+    assert sources == [str(workspace), str(sandbox.socket_root() / 'broker.sock'), str(sandbox.socket_root() / 'gateway.sock')]
+    assert bundle.stat().st_mode & 0o777 == 0o700
+    assert not bundle.is_relative_to(workspace)
+
+
+def test_launch_script_is_not_worker_writable(oci):
+    workspace, _ = oci
+    path = sandbox.launcher(workspace, 'python3', worker.build_worker_env(workspace), ())
+    assert not path.is_relative_to(workspace)
+    assert path.stat().st_mode & 0o777 == 0o700
+    assert '-I' in path.read_text()
+
+
+def test_missing_runtime_is_fatal(monkeypatch):
+    monkeypatch.setattr(sandbox.shutil, 'which', lambda _: None)
+    with pytest.raises(worker.WorkerIsolationError, match='fallback is disabled'):
+        sandbox._runtime()
+
+
+@pytest.mark.parametrize('kind', ['root', 'workspace', 'symlink', 'shared'])
+def test_invalid_image_rejected(oci, monkeypatch, kind):
+    workspace, image = oci
+    if kind == 'root':
+        monkeypatch.setenv('LOMA_WORKER_ROOTFS', '/')
+    elif kind == 'workspace':
+        monkeypatch.setenv('LOMA_WORKER_ROOTFS', str(workspace))
+    elif kind == 'symlink':
+        alias = image.parent / 'alias'
+        alias.symlink_to(image)
+        monkeypatch.setenv('LOMA_WORKER_ROOTFS', str(alias))
+    else:
+        image.chmod(0o777)
+    with pytest.raises(worker.WorkerIsolationError):
+        sandbox.prepare(['python3'], workspace, worker.build_worker_env(workspace))
+
+
+def test_shared_worker_uid_not_accepted(oci, monkeypatch):
+    workspace, _ = oci
+    monkeypatch.setattr(worker, 'workspace_identity', lambda _: SimpleNamespace(uid=990, gid=990, per_run=False))
+    with pytest.raises(worker.WorkerIsolationError):
+        sandbox.prepare(['python3'], workspace, worker.build_worker_env(workspace))
+
+
+@pytest.mark.asyncio
+async def test_unix_transport_serves_only_registered_app(tmp_path, monkeypatch):
+    monkeypatch.setenv('LOMA_SANDBOX_SOCKETS', str(tmp_path / 'sockets'))
+    app = web.Application()
+    app.router.add_get('/test', lambda request: web.json_response({'ok': True}))
+    broker = web.AppRunner(app)
+    gateway = web.AppRunner(web.Application())
+    await broker.setup()
+    await gateway.setup()
+    try:
+        await sandbox.serve_transports(broker, gateway)
+        async with ClientSession(connector=UnixConnector(path=str(sandbox.socket_root() / 'broker.sock'))) as client:
+            async with client.get('http://local/test') as response:
+                assert await response.json() == {'ok': True}
+        with pytest.raises(worker.WorkerIsolationError, match='already active'):
+            await sandbox.serve_transports(broker, gateway)
+    finally:
+        await broker.cleanup()
+        await gateway.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_bidirectional_transport_bridge(tmp_path):
+    from broker.sandbox_entry import bridge
+    path = tmp_path / 'echo.sock'
+    async def echo(reader, writer):
+        data = await reader.read(1024)
+        writer.write(data)
+        await writer.drain()
+        writer.close()
+    unix = await asyncio.start_unix_server(echo, path=str(path))
+    async def forward(reader, writer):
+        await bridge(reader, writer, unix=str(path))
+    tcp = await asyncio.start_server(forward, '127.0.0.1', 0)
+    try:
+        reader, writer = await asyncio.open_connection('127.0.0.1', tcp.sockets[0].getsockname()[1])
+        writer.write(b'synthetic')
+        await writer.drain()
+        assert await asyncio.wait_for(reader.read(1024), timeout=2) == b'synthetic'
+        writer.close()
+        await writer.wait_closed()
+    finally:
+        tcp.close()
+        unix.close()
+        await tcp.wait_closed()
+        await unix.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_ingress_rejects_symlink_to_host_socket(tmp_path):
+    workspace = tmp_path / 'workspace'
+    workspace.mkdir()
+    target = tmp_path / 'backend.sock'
+    called = []
+    async def backend(reader, writer):
+        called.append(True)
+        writer.close()
+    server = await asyncio.start_unix_server(backend, path=str(target))
+    (workspace / '.loma-ingress.sock').symlink_to(target)
+    proxy = await sandbox.ingress(0, workspace)
+    try:
+        reader, writer = await asyncio.open_connection('127.0.0.1', proxy.sockets[0].getsockname()[1])
+        assert await asyncio.wait_for(reader.read(100), timeout=2) == b''
+        assert not called
+        writer.close()
+        await writer.wait_closed()
+    finally:
+        server.close()
+        proxy.close()
+        await server.wait_closed()
+        await proxy.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_ingress_connects_pinned_socket_inode(tmp_path):
+    workspace = tmp_path / 'workspace'
+    workspace.mkdir()
+    async def echo(reader, writer):
+        writer.write(await reader.read(100))
+        await writer.drain()
+        writer.close()
+    server = await asyncio.start_unix_server(echo, path=str(workspace / '.loma-ingress.sock'))
+    proxy = await sandbox.ingress(0, workspace)
+    try:
+        reader, writer = await asyncio.open_connection('127.0.0.1', proxy.sockets[0].getsockname()[1])
+        writer.write(b'synthetic')
+        await writer.drain()
+        assert await asyncio.wait_for(reader.read(100), timeout=2) == b'synthetic'
+        writer.close()
+        await writer.wait_closed()
+    finally:
+        server.close()
+        proxy.close()
+        await server.wait_closed()
+        await proxy.wait_closed()
+
+
+def test_worker_renderer_is_local_not_privileged_broker(oci):
+    workspace, _ = oci
+    # This fixture uses a synthetic owner; don't chown test files.
+    import unittest.mock
+    with unittest.mock.patch.object(worker, 'workspace_identity', return_value=SimpleNamespace(uid=None)):
+        worker.populate_tool_shims(workspace, ['pptx_creator'])
+    source = (workspace / 'tools/pptx_creator.py').read_text()
+    assert 'runpy.run_path' in source
+    assert 'urlopen' not in source
+
+
+def test_runner_uses_fixed_isolation_flags_and_keeps_args_in_container(oci, monkeypatch):
+    from broker import sandbox_runner
+    workspace, _ = oci
+    command = sandbox.prepare(['python3'], workspace, worker.build_worker_env(workspace))
+    bundle = Path(command[-1])
+    seen = []
+    class Child:
+        def wait(self):
+            return 0
+        def poll(self):
+            return 0
+    monkeypatch.setattr(sandbox_runner.sys, 'argv', ['runner', str(bundle), '--network=host'])
+    monkeypatch.setattr(sandbox_runner.subprocess, 'Popen', lambda argv, **kwargs: seen.append((argv, kwargs)) or Child())
+    monkeypatch.setattr(sandbox_runner.subprocess, 'run', lambda *a, **k: SimpleNamespace(returncode=0))
+    monkeypatch.setattr(sandbox_runner.signal, 'signal', lambda *a: None)
+    assert sandbox_runner.main() == 0
+    argv, kwargs = seen[0]
+    assert '--network=none' in argv
+    assert '--network=host' not in argv
+    assert '--directfs=false' in argv
+    assert kwargs['env'] == {'PATH': '/usr/local/bin:/usr/bin:/bin'}
+    config = json.loads((bundle / 'config.json').read_text())
+    assert config['process']['args'][-1] == '--network=host'
+
+
+def test_blank_pptx_composition_has_no_backend_asset_dependency(tmp_path, monkeypatch):
+    from tools import pptx_creator
+    from pptx import Presentation
+    monkeypatch.setattr(pptx_creator, 'SLIDE_INDEX_PATH', tmp_path / 'absent.json')
+    monkeypatch.setattr(pptx_creator, 'OUTPUT_DIR', tmp_path / 'artifacts')
+    spec = tmp_path / 'deck.json'
+    spec.write_text(json.dumps({'output': 'synthetic.pptx', 'slides': [
+        {'action': 'create', 'layout': 'section-divider', 'content': {'title': 'Synthetic test'}}]}))
+    pptx_creator.cmd_compose(SimpleNamespace(spec=str(spec)))
+    output = tmp_path / 'artifacts/synthetic.pptx'
+    assert output.exists()
+    assert len(Presentation(output).slides) == 1
+
+
+def test_runner_does_not_report_success_when_teardown_fails(oci, monkeypatch):
+    from broker import sandbox_runner
+    workspace, _ = oci
+    command = sandbox.prepare(['python3'], workspace, worker.build_worker_env(workspace))
+    bundle = Path(command[-1])
+    class Child:
+        def wait(self):
+            return 0
+        def poll(self):
+            return 0
+    monkeypatch.setattr(sandbox_runner.sys, 'argv', ['runner', str(bundle)])
+    monkeypatch.setattr(sandbox_runner.subprocess, 'Popen', lambda *a, **kw: Child())
+    monkeypatch.setattr(sandbox_runner.subprocess, 'run', lambda *a, **kw: SimpleNamespace(returncode=1))
+    monkeypatch.setattr(sandbox_runner.signal, 'signal', lambda *a: None)
+    with pytest.raises(RuntimeError, match='teardown failed'):
+        sandbox_runner.main()
+    assert not (bundle / 'stopped').exists()
+    assert bundle.exists()

--- a/tests/test_opencode_runtime.py
+++ b/tests/test_opencode_runtime.py
@@ -317,10 +317,14 @@ async def test_run_opencode_agent_retries_idle_timeout_on_fresh_session(monkeypa
         process=None,
     )
 
-    async def fake_ensure(user_mcp_overrides=None):
+    async def fake_start(user_mcp_overrides=None, run_ctx=None):
         return server
 
-    monkeypatch.setattr(ocr, "_ensure_server_instance", fake_ensure)
+    async def fake_teardown(target):
+        return None
+
+    monkeypatch.setattr(ocr, "_start_dedicated_server", fake_start)
+    monkeypatch.setattr(ocr, "_teardown_dedicated_server", fake_teardown)
 
     async def fake_is_known_model(model_id):
         return True
@@ -329,7 +333,7 @@ async def test_run_opencode_agent_retries_idle_timeout_on_fresh_session(monkeypa
 
     created_sessions = []
 
-    async def fake_create_session(title, *, base_url=None):
+    async def fake_create_session(title, *, base_url=None, directory=None):
         created_sessions.append(title)
         return f"ses_{len(created_sessions)}"
 
@@ -343,7 +347,7 @@ async def test_run_opencode_agent_retries_idle_timeout_on_fresh_session(monkeypa
 
     attempts = {"count": 0}
 
-    async def fake_iter(base_url, *, session_id, body, idle_timeout_seconds, request_timeout_seconds):
+    async def fake_iter(base_url, *, session_id, body, idle_timeout_seconds, request_timeout_seconds, directory=None):
         attempts["count"] += 1
         if attempts["count"] == 1:
             raise ocr.OpenCodeError(
@@ -418,17 +422,21 @@ async def test_run_opencode_agent_does_not_retry_model_errors(monkeypatch):
         process=None,
     )
 
-    async def fake_ensure(user_mcp_overrides=None):
+    async def fake_start(user_mcp_overrides=None, run_ctx=None):
         return server
 
-    monkeypatch.setattr(ocr, "_ensure_server_instance", fake_ensure)
+    async def fake_teardown(target):
+        return None
+
+    monkeypatch.setattr(ocr, "_start_dedicated_server", fake_start)
+    monkeypatch.setattr(ocr, "_teardown_dedicated_server", fake_teardown)
 
     async def fake_is_known_model(model_id):
         return True
 
     monkeypatch.setattr(ocr, "is_known_model", fake_is_known_model)
 
-    async def fake_create_session(title, *, base_url=None):
+    async def fake_create_session(title, *, base_url=None, directory=None):
         return "ses_1"
 
     monkeypatch.setattr(ocr, "_create_session", fake_create_session)
@@ -441,7 +449,7 @@ async def test_run_opencode_agent_does_not_retry_model_errors(monkeypatch):
 
     attempts = {"count": 0}
 
-    async def fake_iter(base_url, *, session_id, body, idle_timeout_seconds, request_timeout_seconds):
+    async def fake_iter(base_url, *, session_id, body, idle_timeout_seconds, request_timeout_seconds, directory=None):
         attempts["count"] += 1
         raise ocr.OpenCodeModelError("provider rejected the request")
         yield  # pragma: no cover

--- a/tests/test_per_run_identity.py
+++ b/tests/test_per_run_identity.py
@@ -1,0 +1,217 @@
+"""Per-run worker identity separation.
+
+Two concurrent runs of DIFFERENT users must not be able to read each other's
+workspaces, temp files, or launcher/shim state. With LOMA_WORKER_UID_RANGE
+configured (backend as root) every workspace gets its own uid; the shared-uid
+fallback keeps strict 0700 ownership checks. Privilege-drop tests run only as
+root (they auto-skip in non-root CI). All values are plainly synthetic.
+"""
+
+import asyncio
+import os
+from pathlib import Path
+
+import pytest
+
+import broker.worker as worker_mod
+from broker.worker import (
+    WorkerIsolationError,
+    build_worker_env,
+    cleanup_workspace,
+    create_workspace,
+    spawn_worker,
+    verify_workspace_ownership,
+    workspace_identity,
+)
+
+IS_ROOT = os.geteuid() == 0
+RANGE = "210000-210015"
+
+
+@pytest.fixture
+def per_run_backend(monkeypatch, tmp_path):
+    monkeypatch.setenv("LOMA_WORKER_ROOT", str(tmp_path / "workers"))
+    monkeypatch.setenv("LOMA_WORKER_UID_RANGE", RANGE)
+    monkeypatch.delenv("LOMA_WORKER_UID", raising=False)
+    monkeypatch.delenv("LOMA_WORKER_GID", raising=False)
+    monkeypatch.delenv("LOMA_KEEP_WORKSPACES", raising=False)
+    return tmp_path
+
+
+@pytest.fixture
+def shared_backend(monkeypatch, tmp_path):
+    monkeypatch.setenv("LOMA_WORKER_ROOT", str(tmp_path / "workers"))
+    monkeypatch.delenv("LOMA_WORKER_UID_RANGE", raising=False)
+    monkeypatch.delenv("LOMA_WORKER_UID", raising=False)
+    monkeypatch.delenv("LOMA_WORKER_GID", raising=False)
+    return tmp_path
+
+
+async def _run(workspace, code):
+    process = await spawn_worker(
+        ["python3", "-c", code], workspace=workspace, env=build_worker_env(workspace),
+    )
+    stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=30)
+    return process.returncode, stdout.decode(), stderr.decode()
+
+
+# ── Allocator behavior (no privileges needed beyond what applies) ────────
+
+
+@pytest.mark.skipif(not IS_ROOT, reason="uid allocation requires root")
+def test_each_workspace_gets_a_distinct_uid_from_the_range(per_run_backend):
+    first = create_workspace(prefix="usera")
+    second = create_workspace(prefix="userb")
+    ida, idb = workspace_identity(first), workspace_identity(second)
+    assert ida.per_run and idb.per_run
+    assert ida.uid != idb.uid
+    assert 210000 <= ida.uid <= 210015 and 210000 <= idb.uid <= 210015
+    assert first.stat().st_uid == ida.uid
+    assert (first / "tmp").stat().st_uid == ida.uid
+    assert second.stat().st_uid == idb.uid
+
+
+@pytest.mark.skipif(not IS_ROOT, reason="uid allocation requires root")
+def test_uid_released_only_after_cleanup_and_reused(per_run_backend, monkeypatch):
+    monkeypatch.setenv("LOMA_WORKER_UID_RANGE", "210020-210021")
+    a = create_workspace()
+    b = create_workspace()
+    with pytest.raises(WorkerIsolationError):
+        create_workspace()  # range exhausted while both runs are live
+    uid_a = workspace_identity(a).uid
+    cleanup_workspace(a)
+    c = create_workspace()
+    assert workspace_identity(c).uid == uid_a  # released uid is reusable
+    cleanup_workspace(b)
+    cleanup_workspace(c)
+
+
+@pytest.mark.skipif(not IS_ROOT, reason="uid allocation requires root")
+def test_on_disk_owners_count_as_in_use_after_restart(per_run_backend, monkeypatch):
+    monkeypatch.setenv("LOMA_WORKER_UID_RANGE", "210030-210031")
+    survivor = create_workspace()
+    survivor_uid = workspace_identity(survivor).uid
+    # Simulate a backend restart: registry gone, workspace still on disk.
+    worker_mod._workspace_identities.clear()
+    replacement = create_workspace()
+    assert workspace_identity(replacement).uid != survivor_uid
+    cleanup_workspace(replacement)
+
+
+def test_range_without_root_fails_closed(per_run_backend, monkeypatch):
+    if IS_ROOT:
+        monkeypatch.setattr(os, "geteuid", lambda: 1000)
+    with pytest.raises(WorkerIsolationError):
+        create_workspace()
+
+
+def test_malformed_range_fails_closed(shared_backend, monkeypatch):
+    for bad in ("banana", "100-90", "0-99", "1000-999999999999"):
+        monkeypatch.setenv("LOMA_WORKER_UID_RANGE", bad)
+        with pytest.raises(WorkerIsolationError):
+            create_workspace()
+
+
+# ── Shared-uid fallback: strict ownership verification ───────────────────
+
+
+def test_spawn_refuses_group_readable_workspace(shared_backend):
+    workspace = create_workspace()
+    os.chmod(workspace, 0o755)
+    with pytest.raises(WorkerIsolationError):
+        verify_workspace_ownership(workspace)
+
+
+@pytest.mark.skipif(not IS_ROOT, reason="chown requires root")
+def test_spawn_refuses_foreign_owned_workspace(shared_backend):
+    workspace = create_workspace()
+    os.chown(workspace, 65534, 65534)  # hijacked by another identity
+    with pytest.raises(WorkerIsolationError):
+        verify_workspace_ownership(workspace)
+
+
+@pytest.mark.asyncio
+async def test_fallback_workspace_still_spawns(shared_backend):
+    workspace = create_workspace()
+    rc, out, _ = await _run(workspace, "print('ok')")
+    assert rc == 0 and out.strip() == "ok"
+
+
+# ── Adversarial: concurrent runs of two different users ──────────────────
+
+
+@pytest.mark.skipif(not IS_ROOT, reason="privilege-drop checks require root")
+@pytest.mark.asyncio
+async def test_concurrent_runs_cannot_read_each_other(per_run_backend):
+    """Alice's live run cannot read Bob's live run: workspace, tmp files,
+    tool shims, or planted credential-shaped material."""
+    alice = create_workspace(prefix="alice")
+    bob = create_workspace(prefix="bob")
+    assert workspace_identity(alice).uid != workspace_identity(bob).uid
+
+    secret_path = bob / "tmp" / "session-material.json"
+    secret_path.write_text('{"token": "synthetic-bob-session-value"}')
+    os.chmod(secret_path, 0o600)
+    os.chown(secret_path, workspace_identity(bob).uid, workspace_identity(bob).gid)
+
+    probe = (
+        "import os, json\n"
+        f"targets = [{str(bob)!r}, {str(secret_path)!r}, {str(bob / 'tools')!r}]\n"
+        "results = []\n"
+        "for target in targets:\n"
+        "    try:\n"
+        "        if os.path.isdir(target):\n"
+        "            os.listdir(target)\n"
+        "        else:\n"
+        "            open(target).read()\n"
+        "        results.append('LEAKED:' + target)\n"
+        "    except (PermissionError, FileNotFoundError):\n"
+        "        results.append('DENIED')\n"
+        "print(json.dumps(results))\n"
+    )
+    # Both runs execute CONCURRENTLY, each probing the other.
+    (rc_a, out_a, err_a), (rc_b, out_b, err_b) = await asyncio.gather(
+        _run(alice, probe),
+        _run(bob, "import os; print(os.geteuid())"),
+    )
+    assert rc_a == 0, err_a
+    assert rc_b == 0, err_b
+    assert "LEAKED" not in out_a
+    assert out_a.count("DENIED") == 3
+    assert int(out_b.strip()) == workspace_identity(bob).uid
+    assert "synthetic-bob-session-value" not in out_a
+
+
+@pytest.mark.skipif(not IS_ROOT, reason="privilege-drop checks require root")
+@pytest.mark.asyncio
+async def test_worker_cannot_write_into_sibling_workspace(per_run_backend):
+    alice = create_workspace(prefix="alice")
+    bob = create_workspace(prefix="bob")
+    code = (
+        "import os\n"
+        f"try:\n"
+        f"    open(os.path.join({str(bob)!r}, 'implant.py'), 'w').write('x')\n"
+        f"    print('WROTE')\n"
+        f"except (PermissionError, FileNotFoundError):\n"
+        f"    print('DENIED')\n"
+    )
+    rc, out, err = await _run(alice, code)
+    assert rc == 0, err
+    assert out.strip() == "DENIED"
+    assert not (bob / "implant.py").exists()
+
+
+@pytest.mark.skipif(not IS_ROOT, reason="privilege-drop checks require root")
+@pytest.mark.asyncio
+async def test_worker_runs_as_its_allocated_uid_not_root(per_run_backend):
+    workspace = create_workspace()
+    identity = workspace_identity(workspace)
+    rc, out, err = await _run(
+        workspace,
+        "import os; print(os.geteuid(), os.getegid(), os.getgroups())",
+    )
+    assert rc == 0, err
+    euid, egid, groups = out.strip().split(" ", 2)
+    assert int(euid) == identity.uid
+    assert int(egid) == identity.gid
+    assert groups in ("[]", f"[{identity.gid}]")

--- a/tests/test_personal_grain_webhook.py
+++ b/tests/test_personal_grain_webhook.py
@@ -1,0 +1,206 @@
+"""Personal webhook ownership, revocation and isolation, without provider traffic."""
+import hashlib
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytest_asyncio
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from webhooks import grain_personal as personal
+from tools import grain
+
+OWNER = 'owner@example.test'
+SECRET = 'x' * 43
+
+
+@pytest_asyncio.fixture
+async def webhook(monkeypatch):
+    db = SimpleNamespace(
+        users=SimpleNamespace(find_one=AsyncMock(return_value={'status': 'active'})),
+        grain_webhook_subscriptions=SimpleNamespace(
+            find_one=AsyncMock(return_value={'_id': OWNER}),
+            replace_one=AsyncMock(), delete_one=AsyncMock()),
+        personal_grain_events=SimpleNamespace(find_one=AsyncMock(return_value=None), update_one=AsyncMock(), find=MagicMock()),
+        changestreams=SimpleNamespace(update_one=AsyncMock()),
+    )
+    monkeypatch.setattr(personal, 'get_db', lambda: db)
+    token = AsyncMock(return_value='synthetic-personal-access')
+    monkeypatch.setattr(personal, 'get_valid_provider_token', token)
+    async def transcript(*args, **kwargs):
+        assert grain._access_token.get() == 'synthetic-personal-access'
+        return {'transcript': 'Private test transcript'}
+    fetch = AsyncMock(side_effect=transcript)
+    monkeypatch.setattr(grain, 'get_transcript', fetch)
+    monkeypatch.setattr(grain, 'find_recording_by_id', AsyncMock(return_value={'id': 'recording-1'}))
+    @web.middleware
+    async def identity(request, handler):
+        request['user_email'] = OWNER
+        return await handler(request)
+    app = web.Application(middlewares=[identity])
+    personal.setup_routes(app)
+    async with TestClient(TestServer(app)) as client:
+        yield client, db, token, fetch
+
+
+@pytest.mark.asyncio
+async def test_owner_comes_from_subscription_not_payload_and_storage_is_private(webhook):
+    client, db, token, fetch = webhook
+    response = await client.post('/webhooks/grain/personal', headers={'Authorization': 'Bearer ' + SECRET},
+                                 json={'recording_id': 'recording-1', 'owner': 'other', 'token': 'do-not-persist'})
+    assert response.status == 200
+    token.assert_awaited_once_with(OWNER, 'grain', db=db)
+    query, update = db.personal_grain_events.update_one.call_args.args
+    assert query == {'_id': hashlib.sha256((OWNER + '\0recording-1').encode()).hexdigest()}
+    event = update['$setOnInsert']
+    assert event['owner'] == OWNER and event['visibility'] == 'private'
+    assert event['raw_event']['webhook_body'] == {'recording_id': 'recording-1'}
+    db.changestreams.update_one.assert_not_awaited()
+    assert grain._access_token.get() is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('header', ['', 'Bearer wrong', 'Basic ' + SECRET])
+async def test_invalid_header_cannot_lookup_credentials(webhook, header):
+    client, db, token, fetch = webhook
+    response = await client.post('/webhooks/grain/personal', headers={'Authorization': header}, json={'recording_id': 'recording-1'})
+    assert response.status == 401
+    db.grain_webhook_subscriptions.find_one.assert_not_awaited()
+    token.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unknown_or_expired_subscription_denied(webhook):
+    client, db, token, fetch = webhook
+    db.grain_webhook_subscriptions.find_one.return_value = None
+    response = await client.post('/webhooks/grain/personal', headers={'Authorization': 'Bearer ' + SECRET}, json={'recording_id': 'recording-1'})
+    assert response.status == 401
+    assert '$gt' in db.grain_webhook_subscriptions.find_one.call_args.args[0]['expires_at']
+    token.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_revocation_during_fetch_prevents_storage(webhook):
+    client, db, token, fetch = webhook
+    db.grain_webhook_subscriptions.find_one.side_effect = [{'_id': OWNER}, None]
+    response = await client.post('/webhooks/grain/personal', headers={'Authorization': 'Bearer ' + SECRET}, json={'recording_id': 'recording-1'})
+    assert response.status == 401
+    db.personal_grain_events.update_one.assert_not_awaited()
+    assert grain._access_token.get() is None
+
+
+@pytest.mark.asyncio
+async def test_duplicate_does_not_fetch_again(webhook):
+    client, db, token, fetch = webhook
+    db.personal_grain_events.find_one.return_value = {'_id': 'existing'}
+    response = await client.post('/webhooks/grain/personal', headers={'Authorization': 'Bearer ' + SECRET}, json={'recording_id': 'recording-1'})
+    assert response.status == 200 and (await response.json())['duplicate']
+    fetch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('body', [{'recording_id': '../../private'}, {'recording_id': 'a?x=y'}, {}, []])
+async def test_invalid_recording_not_sent_to_provider(webhook, body):
+    client, db, token, fetch = webhook
+    response = await client.post('/webhooks/grain/personal', headers={'Authorization': 'Bearer ' + SECRET}, json=body)
+    assert response.status == 400
+    token.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_disconnected_account_no_org_fallback(webhook):
+    client, db, token, fetch = webhook
+    token.return_value = None
+    response = await client.post('/webhooks/grain/personal', headers={'Authorization': 'Bearer ' + SECRET}, json={'recording_id': 'recording-1'})
+    assert response.status == 409
+    fetch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_configuration_rotates_only_current_owner_and_stores_digest(webhook):
+    client, db, token, fetch = webhook
+    response = await client.put('/api/integrations/grain/webhook', json={'owner': 'other'})
+    assert response.status == 200 and response.headers['Cache-Control'] == 'no-store'
+    issued = (await response.json())['authorization'][7:]
+    query, doc = db.grain_webhook_subscriptions.replace_one.call_args.args
+    assert query == {'_id': OWNER} and doc['_id'] == OWNER
+    assert doc['token_hash'] == hashlib.sha256(issued.encode()).hexdigest()
+    assert issued not in str(doc)
+    response = await client.delete('/api/integrations/grain/webhook')
+    assert response.status == 200
+    db.grain_webhook_subscriptions.delete_one.assert_awaited_once_with({'_id': OWNER})
+
+
+@pytest.mark.asyncio
+async def test_read_endpoint_always_filters_owner(webhook):
+    client, db, token, fetch = webhook
+    db.personal_grain_events.find.return_value.sort.return_value.limit.return_value.to_list = AsyncMock(return_value=[])
+    response = await client.get('/api/integrations/grain/recordings?owner=other')
+    assert response.status == 200
+    db.personal_grain_events.find.assert_called_once_with({'owner': OWNER}, {'_id': 0})
+
+
+@pytest.mark.asyncio
+async def test_oversize_body_rejected_before_provider(webhook):
+    client, db, token, fetch = webhook
+    response = await client.post('/webhooks/grain/personal', headers={'Authorization': 'Bearer ' + SECRET}, data=b'x' * 16_385)
+    assert response.status == 413
+    token.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_inactive_owner_denied_before_credentials(webhook):
+    client, db, token, fetch = webhook
+    db.users.find_one.return_value = None
+    response = await client.post('/webhooks/grain/personal', headers={'Authorization': 'Bearer ' + SECRET}, json={'recording_id': 'recording-1'})
+    assert response.status == 403
+    token.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_upstream_failure_resets_context_without_logging_provider_secret(webhook):
+    client, db, token, fetch = webhook
+    fetch.side_effect = RuntimeError('synthetic-private-upstream-error')
+    response = await client.post('/webhooks/grain/personal', headers={'Authorization': 'Bearer ' + SECRET}, json={'recording_id': 'recording-1'})
+    assert response.status == 502
+    assert 'synthetic-private' not in await response.text()
+    db.personal_grain_events.update_one.assert_not_awaited()
+    assert grain._access_token.get() is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('remaining', [None, -1, 3600])
+async def test_status_is_owner_scoped_and_never_returns_secret(webhook, remaining):
+    from datetime import datetime, timedelta, timezone
+    client, db, token, fetch = webhook
+    expiry = datetime.now(timezone.utc) + timedelta(seconds=remaining) if remaining is not None else None
+    db.grain_webhook_subscriptions.find_one.return_value = ({'_id': OWNER, 'expires_at': expiry,
+        'token_hash': 'must-not-be-returned'} if expiry else None)
+    response = await client.get('/api/integrations/grain/webhook?owner=other')
+    assert response.status == 200
+    assert response.headers['Cache-Control'] == 'no-store'
+    body = await response.json()
+    assert body['enabled'] is (remaining is not None and remaining > 0)
+    assert set(body) == {'enabled', 'expires_at', 'path'}
+    db.grain_webhook_subscriptions.find_one.assert_awaited_once_with({'_id': OWNER}, {'expires_at': 1})
+    token.assert_not_awaited()
+    db.grain_webhook_subscriptions.replace_one.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_status_accepts_mongo_naive_utc_date(webhook):
+    from datetime import datetime, timedelta
+    client, db, *_ = webhook
+    db.grain_webhook_subscriptions.find_one.return_value = {'expires_at': datetime.now() + timedelta(days=1)}
+    response = await client.get('/api/integrations/grain/webhook')
+    assert (await response.json())['enabled']
+
+
+@pytest.mark.asyncio
+async def test_inactive_user_cannot_read_webhook_status(webhook):
+    client, db, *_ = webhook
+    db.users.find_one.return_value = None
+    response = await client.get('/api/integrations/grain/webhook')
+    assert response.status == 403
+    db.grain_webhook_subscriptions.find_one.assert_not_awaited()

--- a/tests/test_personal_subscription_providers.py
+++ b/tests/test_personal_subscription_providers.py
@@ -1,0 +1,67 @@
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from agent import subscription_providers as providers
+from broker import controller
+from broker.gateway import SubscriptionProxyRegistry
+
+
+@pytest.fixture
+def accounts(tmp_path, monkeypatch):
+    for provider, info in providers.PROVIDERS.items():
+        root = tmp_path / provider
+        monkeypatch.setenv(info['directory_env'], str(root))
+        for email in ('owner@example.test', 'other@example.test'):
+            directory = root / email
+            directory.mkdir(parents=True)
+            (directory / info['filename']).write_text(json.dumps({'synthetic_private_value': email}))
+    return tmp_path
+
+
+def test_provider_configs_contain_only_own_run_proxies(accounts, monkeypatch):
+    registry = SubscriptionProxyRegistry()
+    monkeypatch.setattr(controller, '_sub_registry', registry)
+    ctx = SimpleNamespace(capability='test-run', user_email='owner@example.test', sub_proxy_tokens=[])
+    configs = providers.worker_providers(ctx)
+    assert set(configs) == {'loma-claude', 'loma-codex'}
+    assert len(ctx.sub_proxy_tokens) == 2
+    for token in ctx.sub_proxy_tokens:
+        entry = registry.lookup(token)
+        assert entry['capability'] == 'test-run'
+        assert Path(entry['credentials_path']).parent.name == 'owner@example.test'
+    assert 'synthetic_private_value' not in json.dumps(configs)
+    assert 'other@example.test' not in json.dumps(configs)
+    assert configs['loma-codex']['npm'] == '@ai-sdk/openai'
+
+
+def test_missing_personal_account_does_not_use_pool(accounts):
+    assert providers.model_catalog('missing@example.test') == []
+    assert providers.worker_providers(SimpleNamespace(capability='test-run', user_email='missing@example.test')) == {}
+
+
+@pytest.mark.parametrize('email', ['../other@example.test', '/other@example.test', None, ''])
+def test_invalid_identity_cannot_select_account(accounts, email):
+    assert providers.personal_accounts(email) == {}
+
+
+def test_symlink_cannot_alias_another_persons_account(accounts):
+    source = accounts / 'claude/owner@example.test'
+    target = accounts / 'claude/alias@example.test'
+    target.symlink_to(source)
+    assert providers.personal_accounts('alias@example.test') == {}
+
+
+def test_catalog_has_no_cross_user_cache(accounts):
+    first = providers.model_catalog('owner@example.test')
+    assert first
+    first.clear()
+    assert providers.model_catalog('owner@example.test')
+    assert not providers.model_catalog('missing@example.test')
+
+
+def test_unowned_runs_have_no_provider_configuration(accounts):
+    assert providers.worker_providers(None) == {}
+    assert providers.worker_providers(SimpleNamespace(capability=None)) == {}

--- a/tests/test_proxy_identity.py
+++ b/tests/test_proxy_identity.py
@@ -1,0 +1,68 @@
+"""Internal identity assertions cannot be substituted for browser authentication."""
+import hashlib
+import hmac
+import time
+from unittest.mock import AsyncMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
+
+from api import auth_middleware as middleware
+from api.proxy_identity import sign_identity, verify_identity
+
+EMAIL = 'owner@example.test'
+KEY = 'synthetic-proxy-test-key-32-characters'
+
+
+@pytest.fixture(autouse=True)
+def configured(monkeypatch):
+    monkeypatch.setenv('BACKEND_PROXY_SECRET', KEY)
+    monkeypatch.setattr(middleware, '_IS_PREVIEW', False)
+    monkeypatch.setattr(middleware, '_IS_DEV', False)
+
+
+def test_purpose_bound_signature_matches_cross_language_payload():
+    timestamp = str(int(time.time()))
+    expected = hmac.new(KEY.encode(), f'loma-proxy-identity-v1\n{timestamp}\n{EMAIL}'.encode(), hashlib.sha256).hexdigest()
+    assert sign_identity(EMAIL, timestamp) == expected
+    assert verify_identity(EMAIL, timestamp, expected)
+    assert not verify_identity('another@example.test', timestamp, expected)
+
+
+@pytest.mark.parametrize('offset', [-61, 60, 100000])
+def test_expired_and_future_assertions_rejected(offset):
+    stamp = str(int(time.time()) + offset)
+    assert not verify_identity(EMAIL, stamp, sign_identity(EMAIL, stamp))
+
+
+@pytest.mark.parametrize('timestamp,signature', [('', ''), ('1', 'x'*64), ('unicode-١٢٣', 'a'*64)])
+def test_malformed_assertions_rejected(timestamp, signature):
+    assert not verify_identity(EMAIL, timestamp, signature)
+
+
+@pytest.mark.asyncio
+async def test_unsigned_backend_identity_rejected_before_database(monkeypatch):
+    lookup = AsyncMock()
+    monkeypatch.setattr(middleware, 'get_db', lookup)
+    request = make_mocked_request('GET', '/api/env', headers={'X-User-Email': EMAIL})
+    handler = AsyncMock(return_value=web.Response())
+    result = await middleware.auth_middleware(request, handler)
+    assert result.status == 401
+    handler.assert_not_called()
+    lookup.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_missing_signing_configuration_fails_closed(monkeypatch):
+    monkeypatch.delenv('BACKEND_PROXY_SECRET')
+    monkeypatch.delenv('OAUTH_ENCRYPTION_KEY', raising=False)
+    request = make_mocked_request('GET', '/api/env', headers={'X-User-Email': EMAIL})
+    result = await middleware.auth_middleware(request, AsyncMock())
+    assert result.status == 503
+
+
+def test_signing_secret_cannot_be_forwarded_to_worker(tmp_path, monkeypatch):
+    from broker.worker import build_worker_env, WorkerIsolationError
+    with pytest.raises(WorkerIsolationError):
+        build_worker_env(tmp_path, {'BACKEND_PROXY_SECRET': KEY})

--- a/tests/test_remaining_tool_adapters.py
+++ b/tests/test_remaining_tool_adapters.py
@@ -1,0 +1,156 @@
+"""Static command coverage and public fetch checks; no live providers."""
+import ast
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from broker.tool_policy import POLICY, prepare_argv
+from broker.service import Denied
+from tools._public_download import PublicResolver, validate_url
+
+
+@pytest.mark.parametrize('tool', ['apollo', 'dataroom', 'stitch'])
+def test_every_dispatch_command_has_reviewed_schema(tool):
+    tree = ast.parse((Path(__file__).parents[1] / 'tools' / f'{tool}.py').read_text())
+    commands = {n.test.comparators[0].value for n in ast.walk(tree)
+                if isinstance(n, ast.If) and isinstance(n.test, ast.Compare)
+                and isinstance(n.test.left, ast.Name) and n.test.left.id == 'command'
+                and len(n.test.comparators) == 1 and isinstance(n.test.comparators[0], ast.Constant)}
+    assert commands == set(POLICY[tool])
+
+
+NEW_COMMANDS = [(tool, command) for tool in ['apollo', 'dataroom', 'stitch', 'cdn_upload'] for command in POLICY[tool]]
+
+
+@pytest.mark.parametrize('tool,command', NEW_COMMANDS)
+def test_new_schemas_reject_unknown_flags(tool, command):
+    with pytest.raises(Denied):
+        prepare_argv(tool, [command, '--unreviewed', 'value'], {})
+
+
+@pytest.mark.parametrize('tool,command', NEW_COMMANDS)
+def test_each_declared_argument_is_accepted(tool, command):
+    spec = POLICY[tool][command]
+    argv = [command] + ['resource'] * spec.positionals
+    files = {}
+    for name in spec.values.split():
+        argv += ['--' + name, 'value']
+    for name in spec.switches.split():
+        argv += ['--' + name]
+    for name in (spec.files + ' ' + spec.outputs).split():
+        path = '/workspace/' + name
+        argv += ['--' + name, path]
+        files[path] = '/request/' + name
+    assert prepare_argv(tool, argv, files)
+
+
+def test_repeats_allowed_only_for_reviewed_repeatable_fields():
+    argv = ['search', '--title', 'A', '--title', 'B']
+    assert prepare_argv('apollo', argv, {}) == argv
+    with pytest.raises(Denied):
+        prepare_argv('apollo', ['enrich', '--email', 'a', '--email', 'b'], {})
+
+
+def test_cdn_never_accepts_backend_file_paths():
+    with pytest.raises(Denied):
+        prepare_argv('cdn_upload', ['upload', '--file', '/backend/private'], {})
+    assert prepare_argv('cdn_upload', ['upload', '--file', '/workspace/image.png'],
+                        {'/workspace/image.png': '/request/input.png'})[-1] == '/request/input.png'
+
+
+@pytest.mark.parametrize('url', [
+    'http://example.com', 'https://localhost:3100', 'https://127.0.0.1/',
+    'https://169.254.169.254/', 'https://10.0.0.1/', 'https://[::1]/',
+    'https://[::ffff:127.0.0.1]/', 'https://user:pass@example.com/',
+    'https://example.com/#fragment', 'https://example.com\\@localhost/',
+    'https://2130706433/', 'https://127.1/', 'https://0177.0.0.1/', 'https://１２７.０.０.１/',
+    'file:///etc/passwd', 'https://example.com/\n', 'https://[fe80::1%25eth0]/',
+])
+def test_nonpublic_or_ambiguous_download_urls_rejected(url):
+    with pytest.raises(ValueError):
+        validate_url(url)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('addresses', [['127.0.0.1'], ['93.184.216.34', '10.0.0.1'], ['169.254.169.254'], ['::1'], []])
+async def test_connector_uses_only_checked_dns_answers(addresses):
+    resolver = PublicResolver()
+    resolver.resolver = AsyncMock()
+    resolver.resolver.resolve.return_value = [{'host': address} for address in addresses]
+    with pytest.raises(ValueError):
+        await resolver.resolve('example.test', 443)
+
+
+@pytest.mark.asyncio
+async def test_public_dns_answers_returned_without_reresolution():
+    resolver = PublicResolver()
+    resolver.resolver = AsyncMock()
+    answers = [{'host': '93.184.216.34'}]
+    resolver.resolver.resolve.return_value = answers
+    assert await resolver.resolve('example.test', 443) is answers
+    resolver.resolver.resolve.assert_awaited_once()
+
+
+@pytest.mark.parametrize('argv', [['download', '--url', 'https://example.test'], ['download', '--output', '/workspace/output']])
+def test_stitch_requires_explicit_url_and_request_owned_output(argv):
+    with pytest.raises(Denied):
+        prepare_argv('stitch', argv, {'/workspace/output': '/request/output'} if '--output' in argv else {})
+
+
+@pytest.mark.asyncio
+async def test_download_rejects_redirects_and_large_bodies(monkeypatch):
+    from tools import _public_download as downloads
+    class Content:
+        async def iter_chunked(self, size):
+            yield b'x' * 6
+            yield b'y' * 6
+    class Response:
+        status = 302
+        content_length = None
+        content = Content()
+        headers = {}
+        async def __aenter__(self): return self
+        async def __aexit__(self, *args): pass
+    response = Response()
+    class Session:
+        def __init__(self, **kwargs):
+            assert kwargs['trust_env'] is False
+            assert kwargs['auto_decompress'] is False
+        async def __aenter__(self): return self
+        async def __aexit__(self, *args): pass
+        def get(self, url, **kwargs):
+            assert kwargs['allow_redirects'] is False
+            return response
+    monkeypatch.setattr(downloads.aiohttp, 'ClientSession', Session)
+    monkeypatch.setattr(downloads.aiohttp, 'TCPConnector', lambda **kwargs: None)
+    monkeypatch.setattr(downloads, 'MAX_DOWNLOAD_BYTES', 10)
+    with pytest.raises(ValueError, match='200'):
+        await downloads.download_public('https://example.test')
+    response.status = 200
+    with pytest.raises(ValueError, match='size'):
+        await downloads.download_public('https://example.test')
+    response.content_length = 11
+    with pytest.raises(ValueError, match='size'):
+        await downloads.download_public('https://example.test')
+
+
+def test_agreement_has_personal_identity_and_confined_io():
+    from broker.operations import AUTH_TOOLS, UTILITY_TOOLS
+    assert 'agreement_review' in AUTH_TOOLS
+    assert 'agreement_review' not in UTILITY_TOOLS
+    for command in ['download', 'annotate']:
+        with pytest.raises(Denied):
+            prepare_argv('agreement_review', [command], {})
+    with pytest.raises(Denied):
+        prepare_argv('agreement_review', ['read', '--file-path', '/backend/private.docx'], {})
+
+
+def test_docx_archive_expansion_is_bounded(tmp_path):
+    from zipfile import ZipFile, ZIP_DEFLATED
+    from tools.agreement_review import _validate_docx
+    path = tmp_path / 'oversized.docx'
+    with ZipFile(path, 'w', ZIP_DEFLATED) as archive:
+        archive.writestr('word/document.xml', b'x' * 20_000_001)
+    with pytest.raises(ValueError, match='size limit'):
+        _validate_docx(path)

--- a/tests/test_runtime_isolation.py
+++ b/tests/test_runtime_isolation.py
@@ -1,0 +1,432 @@
+"""Wiring tests: every execution path goes through the worker boundary and
+the broker; the legacy in-process execution path no longer exists."""
+
+import copy
+import json
+import re
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import broker.controller as controller_mod
+from broker.controller import (
+    RunContext,
+    end_run,
+    proxy_mcp_servers_for_worker,
+    start_run,
+)
+from broker.gateway import McpProxyRegistry
+from broker.operations import ALL_TOOLS, INTEGRATION_TOOLS, PERSONAL_TOOLS
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+EMAIL = "owner@example.test"
+
+
+class FakeCursor:
+    def __init__(self, docs):
+        self.docs = list(docs)
+
+    def __aiter__(self):
+        self._iter = iter(self.docs)
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._iter)
+        except StopIteration:
+            raise StopAsyncIteration
+
+
+class Capabilities:
+    def __init__(self):
+        self.docs = {}
+        self.create_index = AsyncMock()
+
+    async def insert_one(self, doc):
+        self.docs[doc["_id"]] = copy.deepcopy(doc)
+
+    async def find_one_and_update(self, query, update):
+        doc = self.docs.get(query["_id"])
+        if not doc or doc["revoked"] or doc["remaining_calls"] <= 0:
+            return None
+        if doc["expires_at"] <= query["expires_at"]["$gt"]:
+            return None
+        if query["scopes"]["$elemMatch"] not in doc["scopes"]:
+            return None
+        old = copy.deepcopy(doc)
+        doc["remaining_calls"] -= 1
+        return old
+
+    async def update_many(self, query, update):
+        for doc in self.docs.values():
+            if all(doc.get(k) == v for k, v in query.items()):
+                doc.update(update["$set"])
+
+
+def make_db(integrations=(), user_status="active"):
+    return SimpleNamespace(
+        users=SimpleNamespace(find_one=AsyncMock(return_value={"status": user_status})),
+        execution_capabilities=Capabilities(),
+        execution_audit=SimpleNamespace(insert_one=AsyncMock()),
+        integrations=SimpleNamespace(find=lambda query: FakeCursor(integrations)),
+        teams=SimpleNamespace(count_documents=AsyncMock(return_value=0)),
+        oauth_tokens=SimpleNamespace(find_one=AsyncMock(return_value=None)),
+    )
+
+
+# ── Controller: run lifecycle & grants ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_start_run_issues_capability_and_workspace(monkeypatch, tmp_path):
+    monkeypatch.setenv("LOMA_WORKER_ROOT", str(tmp_path / "workers"))
+    db = make_db()
+    await controller_mod.init_execution_controller(db)
+    try:
+        ctx = await start_run(EMAIL, source="chat")
+        assert ctx.run_id and ctx.capability.startswith("loma_run_v1_")
+        assert ctx.workspace.is_dir()
+        # Broker-backed shims for every registered tool.
+        for tool in ALL_TOOLS:
+            assert (ctx.workspace / "tools" / f"{tool}.py").exists()
+        stored = list(db.execution_capabilities.docs.values())[0]
+        granted = {s["resource"] for s in stored["scopes"] if s["operation"] == "tool.invoke"}
+        assert PERSONAL_TOOLS <= granted
+        await end_run(ctx)
+        assert not ctx.workspace.exists()
+        assert stored["revoked"] is True
+    finally:
+        controller_mod._broker = None
+        controller_mod._registry = None
+
+
+@pytest.mark.asyncio
+async def test_start_run_excludes_unshared_integrations(monkeypatch, tmp_path):
+    monkeypatch.setenv("LOMA_WORKER_ROOT", str(tmp_path / "workers"))
+    db = make_db(integrations=[{
+        "provider": "posthog", "status": "active",
+        "shared_with": {"mode": "specific", "users": ["someone-else@example.test"]},
+    }])
+    await controller_mod.init_execution_controller(db)
+    try:
+        ctx = await start_run(EMAIL)
+        stored = list(db.execution_capabilities.docs.values())[0]
+        granted = {s["resource"] for s in stored["scopes"]}
+        assert "posthog" not in granted
+        assert "linear" not in granted  # unconfigured integrations are not granted
+        await end_run(ctx)
+    finally:
+        controller_mod._broker = None
+        controller_mod._registry = None
+
+
+@pytest.mark.asyncio
+async def test_start_run_fails_closed_for_inactive_users(monkeypatch, tmp_path):
+    monkeypatch.setenv("LOMA_WORKER_ROOT", str(tmp_path / "workers"))
+    db = make_db(user_status="rejected")
+    await controller_mod.init_execution_controller(db)
+    try:
+        ctx = await start_run(EMAIL)
+        # No capability is issued; the run cannot reach any credential.
+        assert ctx.capability is None and ctx.run_id is None
+        await end_run(ctx)
+    finally:
+        controller_mod._broker = None
+        controller_mod._registry = None
+
+
+@pytest.mark.asyncio
+async def test_start_run_without_controller_fails_closed(monkeypatch, tmp_path):
+    monkeypatch.setenv("LOMA_WORKER_ROOT", str(tmp_path / "workers"))
+    monkeypatch.setattr(controller_mod, "_broker", None)
+    monkeypatch.setattr(controller_mod, "_registry", None)
+    ctx = await start_run(EMAIL)
+    assert ctx.capability is None
+    await end_run(ctx)
+
+
+@pytest.mark.asyncio
+async def test_revoked_capability_is_rejected(monkeypatch, tmp_path):
+    monkeypatch.setenv("LOMA_WORKER_ROOT", str(tmp_path / "workers"))
+    db = make_db()
+    broker = await controller_mod.init_execution_controller(db)
+    try:
+        ctx = await start_run(EMAIL)
+        capability = ctx.capability
+        await end_run(ctx)
+        from broker.service import Denied
+        with pytest.raises(Denied):
+            await broker.execute(capability, "tool.invoke", "notify", {"argv": [], "files": {}})
+    finally:
+        controller_mod._broker = None
+        controller_mod._registry = None
+
+
+# ── MCP config rewriting ─────────────────────────────────────────────────
+
+
+def test_proxy_mcp_servers_fail_closed(monkeypatch):
+    monkeypatch.setattr(controller_mod, "current_run", SimpleNamespace(get=lambda: SimpleNamespace(
+        capability="loma_run_v1_" + "a" * 43, proxy_tokens=[])))
+    monkeypatch.setattr(controller_mod, "_registry", McpProxyRegistry())
+    proxied, tokens, disabled = proxy_mcp_servers_for_worker({
+        "linear": {"type": "http", "url": "https://mcp.linear.test/sse",
+                   "headers": {"Authorization": "Bearer org-secret"}},
+        "sentry": {"type": "stdio", "command": "npx",
+                   "env": {"SENTRY_ACCESS_TOKEN": "org-secret-2"}},
+    })
+    # HTTP server: proxied, no credentials in the worker-visible config.
+    assert set(proxied) == {"linear"}
+    assert "org-secret" not in str(proxied)
+    assert proxied["linear"]["url"].startswith("http://127.0.0.1")
+    assert "headers" not in proxied["linear"]
+    assert len(tokens) == 1
+    # Stdio server (env credentials): DISABLED, never silently passed through.
+    assert disabled == ["sentry"]
+
+
+# ── Claude pool wiring ───────────────────────────────────────────────────
+
+
+def test_pool_build_options_isolates_worker(monkeypatch, tmp_path):
+    monkeypatch.setattr(controller_mod, "current_run", SimpleNamespace(get=lambda: SimpleNamespace(
+        capability="loma_run_v1_" + "a" * 43, proxy_tokens=[])))
+    monkeypatch.setenv("LOMA_WORKER_ROOT", str(tmp_path / "workers"))
+    monkeypatch.setattr(controller_mod, "_registry", McpProxyRegistry())
+    from agent.pool import ClientPool
+
+    pool = ClientPool(pool_size=1)
+    pool.set_config({"mcp_servers": {
+        "linear": {"type": "http", "url": "https://mcp.linear.test/sse",
+                   "headers": {"Authorization": "Bearer org-secret"}},
+        "sentry": {"type": "stdio", "command": "npx", "args": ["-y", "@sentry/mcp-server"],
+                   "env": {"SENTRY_ACCESS_TOKEN": "org-secret-2"}},
+    }})
+    options = pool._build_options()
+
+    workspace = Path(options.cwd)
+    assert workspace != PROJECT_ROOT
+    assert (workspace / "tools").is_dir()
+
+    # Launcher scrubs the env before exec'ing the CLI.
+    launcher = Path(options.cli_path)
+    assert launcher.exists()
+    body = launcher.read_text()
+    assert "env -i" in body
+    assert "org-secret" not in body
+    assert "OAUTH_ENCRYPTION_KEY" not in body
+
+    # MCP: http proxied without credentials, stdio disabled.
+    assert set(options.mcp_servers) == {"linear"}
+    assert "org-secret" not in str(options.mcp_servers)
+    assert options._disabled_mcp_servers == ["sentry"]
+    assert "mcp__linear" in options.allowed_tools
+    assert "mcp__sentry" not in options.allowed_tools
+
+
+@pytest.mark.asyncio
+async def test_background_cli_env_is_scrubbed_and_workspace_cleaned(monkeypatch, tmp_path):
+    monkeypatch.setenv("LOMA_WORKER_ROOT", str(tmp_path / "workers"))
+    monkeypatch.delenv("LOMA_WORKER_UID", raising=False)
+    monkeypatch.delenv("LOMA_WORKER_UID_RANGE", raising=False)
+    monkeypatch.setenv("OAUTH_ENCRYPTION_KEY", "synthetic-key")
+    monkeypatch.setenv("OBSERVABILITY_MONGODB_URI", "mongodb://synthetic")
+    import agent.pool as pool_mod
+    from broker.gateway import SubscriptionProxyRegistry
+    account_dir = tmp_path / "account"
+    account_dir.mkdir()
+    monkeypatch.setattr(pool_mod, 'get_pool', lambda: SimpleNamespace(
+        _next_account=lambda: {'config_dir': str(account_dir)}))
+    monkeypatch.setattr(controller_mod, '_sub_registry', SubscriptionProxyRegistry())
+    ctx = SimpleNamespace(capability='synthetic', sub_proxy_tokens=[])
+    monkeypatch.setattr(controller_mod, 'current_run', SimpleNamespace(get=lambda: ctx))
+
+    returncode, stdout, _ = await pool_mod.run_background_cli(
+        ["python3", "-c", "import os, json; print(json.dumps(dict(os.environ)))"],
+        timeout=30,
+    )
+    assert returncode == 0
+    env = json.loads(stdout.decode())
+    assert "OAUTH_ENCRYPTION_KEY" not in env
+    assert "OBSERVABILITY_MONGODB_URI" not in env
+    assert "bgcli-" in env["HOME"]
+    assert env['CLAUDE_CONFIG_DIR'].startswith(env['HOME'])
+    assert str(account_dir) not in str(env)
+    assert not controller_mod._sub_registry._entries
+    # Each call gets a FRESH workspace that is removed afterwards.
+    workers_root = tmp_path / "workers"
+    assert not any(workers_root.glob("bgcli-*"))
+
+
+# ── stream_agent lifecycle ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_stream_agent_delivers_capability_and_revokes(monkeypatch, tmp_path):
+    monkeypatch.setattr("agent.client.build_user_mcp_overrides", AsyncMock(return_value={}))
+    monkeypatch.setattr("agent.client.get_excluded_integrations_for_user", AsyncMock(return_value=set()))
+    import agent.opencode_runtime as ocr
+    from agent.client import stream_agent
+
+    capability = "loma_run_v1_" + "c" * 43
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    lifecycle = {"started": 0, "ended": 0}
+
+    async def fake_start_run(user_email, *, source="run"):
+        lifecycle["started"] += 1
+        return RunContext(run_id="run-1", capability=capability,
+                          workspace=workspace, user_email=user_email)
+
+    async def fake_end_run(ctx):
+        lifecycle["ended"] += 1
+
+    monkeypatch.setattr(controller_mod, "start_run", fake_start_run)
+    monkeypatch.setattr(controller_mod, "end_run", fake_end_run)
+
+    seen = {}
+
+    async def fake_run_opencode_agent(**kwargs):
+        seen.update(kwargs)
+        yield "ok"
+
+    monkeypatch.setattr(ocr, "run_opencode_agent", fake_run_opencode_agent)
+
+    events = []
+    async for event in stream_agent(
+        "hello", user_email=EMAIL, selected_model="opencode-go/deepseek-v4-flash",
+    ):
+        events.append(event)
+
+    assert "ok" in events
+    assert lifecycle == {"started": 1, "ended": 1}
+    # The capability is delivered via the worker environment, NEVER via
+    # prompt text (it must not enter model context or transcripts)…
+    assert capability not in seen["full_prompt"]
+    assert f"[Authenticated User: {EMAIL}]" in seen["full_prompt"]
+    # …and the run context reaches the runtime for workspace/sandbox use.
+    assert seen["run_ctx"].workspace == workspace
+    assert seen["run_ctx"].worker_env_extra["LOMA_RUN_CAPABILITY"] == capability
+
+
+@pytest.mark.asyncio
+async def test_stream_agent_without_capability_disables_personal_tools(monkeypatch, tmp_path):
+    monkeypatch.setattr("agent.client.build_user_mcp_overrides", AsyncMock(return_value={}))
+    monkeypatch.setattr("agent.client.get_excluded_integrations_for_user", AsyncMock(return_value=set()))
+    import agent.opencode_runtime as ocr
+    from agent.client import stream_agent
+
+    workspace = tmp_path / "ws2"
+    workspace.mkdir()
+
+    async def fake_start_run(user_email, *, source="run"):
+        return RunContext(run_id=None, capability=None,
+                          workspace=workspace, user_email=user_email)
+
+    async def fake_end_run(ctx):
+        pass
+
+    monkeypatch.setattr(controller_mod, "start_run", fake_start_run)
+    monkeypatch.setattr(controller_mod, "end_run", fake_end_run)
+
+    seen = {}
+
+    async def fake_run_opencode_agent(**kwargs):
+        seen.update(kwargs)
+        yield "ok"
+
+    monkeypatch.setattr(ocr, "run_opencode_agent", fake_run_opencode_agent)
+
+    async for _ in stream_agent(
+        "hello", user_email=EMAIL, selected_model="opencode-go/deepseek-v4-flash",
+    ):
+        pass
+
+    prompt = seen["full_prompt"]
+    assert "Personal tools are DISABLED" in prompt
+    assert "Personal Tools Auth Token" not in prompt
+
+
+# ── OpenCode / Codex config wiring ───────────────────────────────────────
+
+
+def test_opencode_provider_overrides_use_gateway(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-synthetic")
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    from agent.opencode_runtime import _provider_gateway_overrides
+
+    capability = "loma_run_v1_" + "d" * 43
+    overrides = _provider_gateway_overrides(capability)
+    assert overrides["anthropic"]["options"]["apiKey"] == capability
+    assert "/model/anthropic" in overrides["anthropic"]["options"]["baseURL"]
+    # The real key never appears in worker-visible config.
+    assert "sk-ant-synthetic" not in str(overrides)
+    # No capability -> no provider access through the gateway.
+    assert _provider_gateway_overrides(None) == {}
+
+
+def test_codex_config_from_proxied_servers_has_no_secrets(monkeypatch):
+    monkeypatch.setattr(controller_mod, "current_run", SimpleNamespace(get=lambda: SimpleNamespace(
+        capability="loma_run_v1_" + "a" * 43, proxy_tokens=[])))
+    monkeypatch.setattr(controller_mod, "_registry", McpProxyRegistry())
+    from agent.codex_runtime import claude_mcp_to_codex_toml
+
+    proxied, _, disabled = proxy_mcp_servers_for_worker({
+        "linear": {"type": "http", "url": "https://mcp.linear.test/sse",
+                   "headers": {"Authorization": "Bearer org-secret"}},
+        "sentry": {"type": "stdio", "command": "npx",
+                   "env": {"SENTRY_ACCESS_TOKEN": "org-secret-2"}},
+    })
+    toml = claude_mcp_to_codex_toml(proxied)
+    assert "org-secret" not in toml
+    assert "sentry" not in toml
+    assert "linear" in toml
+
+
+# ── The legacy in-process execution path is gone ─────────────────────────
+
+
+EXECUTION_MODULES = [
+    "agent/pool.py",
+    "agent/client.py",
+    "agent/opencode_runtime.py",
+    "agent/codex_runtime.py",
+    "agent/codex_pool.py",
+    "api/terminal_routes.py",
+    "scheduler/executor.py",
+    "scheduler/webhook_executor.py",
+]
+
+
+@pytest.mark.parametrize("module", EXECUTION_MODULES)
+def test_no_backend_env_inheritance_in_execution_paths(module):
+    source = (PROJECT_ROOT / module).read_text()
+    assert "**os.environ" not in source, module
+    assert "dict(os.environ)" not in source, module
+
+
+def test_scheduler_paths_have_no_direct_spawns():
+    # Scheduled flows and webhook flows must execute only via stream_agent,
+    # which owns the isolated-run lifecycle.
+    for module in ("scheduler/executor.py", "scheduler/webhook_executor.py"):
+        source = (PROJECT_ROOT / module).read_text()
+        assert "create_subprocess" not in source, module
+        assert "stream_agent" in source, module
+
+
+def test_terminal_uses_worker_boundary():
+    source = (PROJECT_ROOT / "api/terminal_routes.py").read_text()
+    assert "build_worker_env" in source
+    assert "create_workspace" in source
+    assert re.search(r"\*\*os\.environ", source) is None
+
+
+def test_personal_tools_no_longer_reachable_without_broker():
+    # The prompt instructs `python3 tools/<name>.py` relative to the worker
+    # cwd; workers only ever contain broker shims, never the real tools.
+    from broker.worker import _SHIM_TEMPLATE
+    assert "tool.invoke" in _SHIM_TEMPLATE
+    assert "motor" not in _SHIM_TEMPLATE
+    assert "Fernet" not in _SHIM_TEMPLATE

--- a/tests/test_security_boundaries.py
+++ b/tests/test_security_boundaries.py
@@ -1,0 +1,277 @@
+"""Regression coverage for API authorization and durable artifact delivery."""
+import json
+import time
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
+
+from api import auth_middleware as auth, flow_routes, routes, task_routes, terminal_routes
+from scheduler import engine
+
+
+@pytest.fixture(autouse=True)
+def proxy_secret(monkeypatch):
+    monkeypatch.setenv('BACKEND_PROXY_SECRET', 'synthetic-proxy-test-key-32-characters')
+
+
+class Request(dict):
+    def __init__(self, body=None, *, user='caller@example.com', role='operator', file_id='invalid'):
+        super().__init__(user_email=user, system_role=role)
+        self.body = body or {}
+        self.path = '/api/chat'
+        self.method = 'POST'
+        from api.proxy_identity import sign_identity
+        timestamp = str(int(time.time()))
+        self.headers = {'X-User-Email': user, 'X-Auth-Timestamp': timestamp,
+                        'X-Auth-Signature': sign_identity(user, timestamp)}
+        self.match_info = {'file_id': file_id, 'conversation_id': 'conv'}
+        self.query = {}
+        self.app = {}
+
+    async def json(self):
+        return self.body
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('status', ['pending', 'rejected', 'unknown', None])
+async def test_nonactive_accounts_denied(status):
+    db = MagicMock()
+    db.users.find_one = AsyncMock(return_value={'status': status} if status else None)
+    handler = AsyncMock()
+    with patch.object(auth, 'get_db', return_value=db):
+        response = await auth.auth_middleware(Request(), handler)
+    assert response.status == 403
+    handler.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('user', [{'status': 'active'}, {'email': 'caller@example.com'}])
+async def test_active_and_legacy_accounts_allowed(user):
+    db = MagicMock()
+    db.users.find_one = AsyncMock(return_value=user)
+    handler = AsyncMock(return_value=web.Response())
+    with patch.object(auth, 'get_db', return_value=db):
+        assert (await auth.auth_middleware(Request(), handler)).status == 200
+
+
+@pytest.mark.asyncio
+async def test_unprovisioned_user_can_get_profile_only():
+    db = MagicMock()
+    db.users.find_one = AsyncMock(return_value=None)
+    req = Request()
+    req.path = '/api/governance/me'
+    req.method = 'GET'
+    handler = AsyncMock(return_value=web.Response())
+    with patch.object(auth, 'get_db', return_value=db):
+        assert (await auth.auth_middleware(req, handler)).status == 200
+        req.method = 'POST'
+        assert (await auth.auth_middleware(req, handler)).status == 403
+
+
+@pytest.mark.asyncio
+async def test_db_unavailable_fails_closed():
+    handler = AsyncMock()
+    with patch.object(auth, 'get_db', return_value=None):
+        assert (await auth.auth_middleware(Request(), handler)).status == 503
+    handler.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('role', ['chatter', 'analyst', 'operator'])
+async def test_terminal_requires_privileged_role(role):
+    req = Request(role=role)
+    with pytest.raises(web.HTTPForbidden):
+        await terminal_routes.handle_terminal_token(req)
+    with pytest.raises(web.HTTPForbidden):
+        await terminal_routes.handle_terminal_ws(req)
+
+
+@pytest.mark.asyncio
+async def test_terminal_tokens_are_bound_and_single_use():
+    owner = Request(role='maintainer')
+    response = await terminal_routes.handle_terminal_token(owner)
+    token = json.loads(response.body)['token']
+    other = Request(user='other@example.com', role='maintainer')
+    other.query = {'token': token}
+    assert (await terminal_routes.handle_terminal_ws(other)).status == 403
+    owner.query = {'token': token}
+    assert (await terminal_routes.handle_terminal_ws(owner)).status == 403
+
+
+@pytest.mark.asyncio
+async def test_terminal_owner_reaches_websocket_without_spawning_shell():
+    owner = Request(role='maintainer')
+    response = await terminal_routes.handle_terminal_token(owner)
+    owner.query = {'token': json.loads(response.body)['token']}
+    class StopBeforeShell(Exception):
+        pass
+    with patch.object(web.WebSocketResponse, 'prepare', AsyncMock(side_effect=StopBeforeShell)):
+        with pytest.raises(StopBeforeShell):
+            await terminal_routes.handle_terminal_ws(owner)
+    assert (await terminal_routes.handle_terminal_ws(owner)).status == 403
+
+
+@pytest.fixture
+def artifact_dir(tmp_path, monkeypatch):
+    served = tmp_path / 'served'
+    served.mkdir()
+    monkeypatch.setattr(routes, 'SERVED_FILES_DIR', served)
+    monkeypatch.setattr(routes, '_served_files', {})
+    return tmp_path
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('extension', ['txt', 'json', 'pdf', 'html'])
+async def test_file_survives_registry_restart_and_is_private(artifact_dir, extension):
+    source = artifact_dir / f'report.{extension}'
+    source.write_text('synthetic content')
+    info = routes.register_served_file(str(source), owner_email='caller@example.com')
+    routes._served_files.clear()
+    req = Request(file_id=info['file_id'])
+    response = await routes.handle_serve_file(req)
+    assert response.status == 200
+    assert response._path.read_text() == 'synthetic content'
+    assert response.headers['Cache-Control'] == 'private, no-store'
+    assert 'sandbox' in response.headers['Content-Security-Policy']
+    req['user_email'] = 'other@example.com'
+    assert (await routes.handle_serve_file(req)).status == 404
+
+
+@pytest.mark.asyncio
+async def test_unregistered_and_ownerless_files_not_served(artifact_dir):
+    source = artifact_dir / 'report.txt'
+    source.write_text('synthetic')
+    info = routes.register_served_file(str(source))
+    assert (await routes.handle_serve_file(Request(file_id=info['file_id']))).status == 404
+    assert (await routes.handle_serve_file(Request(file_id='../report.txt'))).status == 404
+
+
+@pytest.mark.asyncio
+async def test_file_sharing_tracks_conversation_permissions(artifact_dir):
+    source = artifact_dir / 'report.txt'
+    source.write_text('synthetic')
+    info = routes.register_served_file(str(source), conversation_id='conv')
+    db = MagicMock()
+    conversation = {'metadata': {'user_name': 'other@example.com', 'visibility': 'shared'}}
+    db.conversations.find_one = AsyncMock(return_value=conversation)
+    with patch.object(routes, 'get_db', return_value=db):
+        req = Request(file_id=info['file_id'])
+        assert (await routes.handle_serve_file(req)).status == 200
+        conversation['metadata']['visibility'] = 'private'
+        assert (await routes.handle_serve_file(req)).status == 404
+        db.conversations.find_one.return_value = None
+        assert (await routes.handle_serve_file(req)).status == 404
+
+
+@pytest.mark.asyncio
+async def test_symlink_replacement_denied(artifact_dir):
+    source = artifact_dir / 'report.txt'
+    source.write_text('synthetic')
+    info = routes.register_served_file(str(source), owner_email='caller@example.com')
+    dest = routes.SERVED_FILES_DIR / (info['file_id'] + '.txt')
+    dest.unlink()
+    dest.symlink_to(source)
+    assert (await routes.handle_serve_file(Request(file_id=info['file_id']))).status == 404
+
+
+@pytest.mark.asyncio
+async def test_registered_handler_is_selected():
+    app = web.Application()
+    routes.setup_api_routes(app)
+    resolved = await app.router.resolve(make_mocked_request('GET', '/api/files/example', app=app))
+    assert resolved.handler is routes.handle_serve_file
+
+
+@pytest.mark.asyncio
+async def test_flow_creator_is_authenticated_and_default_run_as_validated():
+    db = MagicMock()
+    db.flows.insert_one = AsyncMock()
+    db.users.find_one = AsyncMock(return_value={'status': 'active'})
+    body = {'name': 'test', 'prompt': 'test', 'schedule_type': 'once', 'status': 'paused',
+            'created_by': {'source': 'other@example.com'}}
+    with patch.object(flow_routes, 'get_db', return_value=db):
+        assert (await flow_routes.handle_create_flow(Request(body))).status == 201
+    doc = db.flows.insert_one.await_args.args[0]
+    assert doc['run_as'] == 'caller@example.com'
+    assert doc['created_by']['source'] == 'caller@example.com'
+    db.users.find_one.assert_awaited_once_with({'email': 'caller@example.com'})
+
+
+@pytest.mark.asyncio
+async def test_flow_cannot_run_as_other_user():
+    body = {'name': 'test', 'prompt': 'test', 'schedule_type': 'once', 'run_as': 'other@example.com'}
+    with patch.object(flow_routes, 'get_db', return_value=MagicMock()):
+        assert (await flow_routes.handle_create_flow(Request(body))).status == 403
+
+
+@pytest.mark.asyncio
+async def test_injection_uses_configured_db_and_does_not_retry_persistence_failure():
+    stream = SimpleNamespace(client=SimpleNamespace(query=AsyncMock()))
+    observer = SimpleNamespace(record_injected_message=AsyncMock(side_effect=RuntimeError('test')))
+    with patch('agent.active_streams.get_for_user', AsyncMock(return_value=stream)), \
+         patch.object(routes, 'get_db', return_value=MagicMock()), \
+         patch.object(routes, 'ConversationObserver', return_value=observer):
+        assert (await routes.handle_inject_message(Request({'message': 'test'}))).status == 200
+    stream.client.query.assert_awaited_once_with('test')
+
+
+@pytest.mark.asyncio
+async def test_injection_checks_db_before_delivery():
+    stream = SimpleNamespace(client=SimpleNamespace(query=AsyncMock()))
+    with patch('agent.active_streams.get_for_user', AsyncMock(return_value=stream)), \
+         patch.object(routes, 'get_db', return_value=None):
+        assert (await routes.handle_inject_message(Request({'message': 'test'}))).status == 503
+    stream.client.query.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_shared_reader_cannot_resume_original():
+    db = MagicMock()
+    db.conversations.find_one = AsyncMock(return_value={
+        'metadata': {'user_name': 'other@example.com', 'visibility': 'shared'}, 'source': 'dashboard',
+    })
+    with patch.object(routes, 'get_db', return_value=db), patch.object(routes, 'is_draining', return_value=False):
+        response = await routes.handle_chat(Request({'message': 'test', 'conversation_id': 'conv'}))
+    assert response.status == 404
+    db.conversations.update_one.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_shared_task_fork_is_private():
+    db = MagicMock()
+    db.conversations.find_one = AsyncMock(return_value={
+        'metadata': {'user_name': 'other@example.com', 'visibility': 'shared'}, 'messages': [],
+    })
+    db.conversations.insert_one = AsyncMock()
+    db.users.find_one = AsyncMock(return_value={})
+    with patch.object(task_routes, 'get_db', return_value=db):
+        assert (await task_routes.handle_fork_task(Request())).status == 201
+    doc = db.conversations.insert_one.await_args.args[0]
+    assert doc['metadata']['visibility'] == 'private'
+    assert not routes._check_conversation_access(doc, 'unrelated@example.com', 'chatter')
+
+
+def test_recurring_schedule_honors_start_and_end():
+    scheduler = MagicMock()
+    start = datetime(2030, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2030, 1, 5, tzinfo=timezone.utc)
+    with patch.object(engine, '_scheduler', scheduler):
+        engine._add_job_for_flow({'flow_id': 'test', 'schedule_type': 'recurring',
+                                 'cron': '0 9 * * *', 'timezone': 'UTC', 'start_time': start, 'end_time': end})
+    trigger = scheduler.add_job.call_args.kwargs['trigger']
+    assert trigger.get_next_fire_time(None, datetime(2026, 1, 1, tzinfo=timezone.utc)) >= start
+    assert trigger.get_next_fire_time(None, datetime(2031, 1, 1, tzinfo=timezone.utc)) is None
+
+
+def test_recurring_schedule_normalizes_naive_boundaries():
+    scheduler = MagicMock()
+    with patch.object(engine, '_scheduler', scheduler):
+        engine._add_job_for_flow({'flow_id': 'test', 'schedule_type': 'recurring',
+                                 'cron': '0 9 * * *', 'timezone': 'UTC',
+                                 'start_time': datetime(2030, 1, 1)})
+    trigger = scheduler.add_job.call_args.kwargs['trigger']
+    assert trigger.get_next_fire_time(None, datetime(2026, 1, 1, tzinfo=timezone.utc)).year == 2030

--- a/tests/test_subscription_boundary.py
+++ b/tests/test_subscription_boundary.py
@@ -1,0 +1,343 @@
+"""Synthetic protocol/credential boundary checks, without live provider calls."""
+import base64
+import json
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from broker import controller
+from broker.gateway import (SubscriptionProxyRegistry, McpProxyRegistry, create_gateway_app,
+                            _claude_subscription_auth, _codex_subscription_auth)
+from broker.operations import ToolInvoke
+from broker.service import Denied
+from broker.tool_policy import prepare_argv
+from utils.secret_redaction import redact_secrets
+
+
+@pytest.fixture
+def account(tmp_path):
+    path = tmp_path / 'account'
+    path.mkdir()
+    (path / '.credentials.json').write_text(json.dumps({'claudeAiOauth': {
+        'accessToken': 'synthetic-provider-value', 'expiresAt': (time.time() + 60) * 1000}}))
+    (path / 'private-history.json').write_text('private history')
+    (path / 'auth.json').write_text(json.dumps({'tokens': {
+        'access_token': 'synthetic-codex-value', 'account_id': 'synthetic-account'}}))
+    return {'config_dir': str(path)}
+
+
+def test_subscription_registration_requires_run(account):
+    registry = SubscriptionProxyRegistry()
+    with pytest.raises(Denied):
+        registry.register('claude', account['config_dir'], capability='')
+    assert not hasattr(registry, 'register_anonymous')
+
+
+def test_subscription_registry_revocation_and_expiry(account):
+    registry = SubscriptionProxyRegistry()
+    token = registry.register('claude', account['config_dir'], capability='sample')
+    assert registry.lookup(token)['capability'] == 'sample'
+    registry.revoke(token)
+    with pytest.raises(Denied):
+        registry.lookup(token)
+    token = registry.register('claude', account['config_dir'], capability='sample', ttl_seconds=0)
+    with pytest.raises(Denied):
+        registry.lookup(token)
+
+
+@pytest.mark.parametrize('provider', ['claude', 'codex'])
+@pytest.mark.asyncio
+async def test_subscription_proxy_protocol_and_revocation(account, monkeypatch, provider):
+    from broker import gateway
+    seen = []
+    async def upstream(request):
+        seen.append((request.path, dict(request.headers), await request.read()))
+        return web.json_response({'ok': True})
+    app = web.Application()
+    app.router.add_route('*', '/{tail:.*}', upstream)
+    registry = SubscriptionProxyRegistry()
+    filename = '.credentials.json' if provider == 'claude' else 'auth.json'
+    token = registry.register(provider, Path(account['config_dir']) / filename, capability='sample')
+    broker = SimpleNamespace(execute=AsyncMock(return_value={}))
+    async with TestServer(app) as server:
+        monkeypatch.setitem(gateway.SUBSCRIPTION_UPSTREAMS, provider, str(server.make_url('')).rstrip('/'))
+        async with TestClient(TestServer(create_gateway_app(broker, McpProxyRegistry(), registry))) as client:
+            route = 'v1/messages' if provider == 'claude' else 'responses'
+            response = await client.post(f'/sub/{token}/{route}', json={'model': 'synthetic'},
+                                         headers={'Authorization': 'Bearer forged',
+                                                  'X-API-Key': 'forged', 'ChatGPT-Account-Id': 'forged'})
+            assert response.status == 200
+            assert (await response.json()) == {'ok': True}
+            broker.execute.assert_awaited_with('sample', 'subscription.request', provider)
+            assert 'forged' not in json.dumps(seen, default=str)
+            assert seen[0][1]['Authorization'].startswith('Bearer synthetic-')
+            assert 'Set-Cookie' not in response.headers
+            for method, tail in [('post', 'admin'), ('get', route), ('post', route + '?redirect=1')]:
+                response = await getattr(client, method)(f'/sub/{token}/{tail}')
+                assert response.status == 403
+            assert len(seen) == 1
+            registry.revoke(token)
+            response = await client.post(f'/sub/{token}/{route}')
+            assert response.status == 403
+            assert len(seen) == 1
+
+
+@pytest.mark.parametrize('error,status', [(Denied(), 403), (RuntimeError('synthetic'), 503)])
+@pytest.mark.asyncio
+async def test_subscription_authz_error_precedes_credentials(account, monkeypatch, error, status):
+    from broker import gateway
+    read = AsyncMock(side_effect=AssertionError('must not read'))
+    monkeypatch.setattr(gateway, '_claude_subscription_auth', read)
+    registry = SubscriptionProxyRegistry()
+    token = registry.register('claude', account['config_dir'], capability='sample')
+    broker = SimpleNamespace(execute=AsyncMock(side_effect=error))
+    async with TestClient(TestServer(create_gateway_app(broker, McpProxyRegistry(), registry))) as client:
+        response = await client.post(f'/sub/{token}/v1/messages')
+        assert response.status == status
+        read.assert_not_called()
+
+
+@pytest.mark.parametrize('data', [[], {}, {'claudeAiOauth': []}, {'claudeAiOauth': {'accessToken': 123}},
+    {'claudeAiOauth': {'accessToken': 'synthetic', 'expiresAt': 1}}])
+def test_malformed_or_expired_claude_auth_is_rejected(tmp_path, data):
+    path = tmp_path / 'synthetic.json'
+    path.write_text(json.dumps(data))
+    with pytest.raises(Denied):
+        _claude_subscription_auth(str(path))
+
+
+def test_codex_api_key_cannot_silently_replace_subscription(tmp_path):
+    path = tmp_path / 'synthetic.json'
+    path.write_text(json.dumps({'OPENAI_API_KEY': 'synthetic'}))
+    with pytest.raises(Denied):
+        _codex_subscription_auth(str(path))
+
+
+def test_claude_config_never_copies_account_files(account, tmp_path, monkeypatch):
+    from agent.pool import _prepare_worker_subscription_env
+    from broker.controller import RunContext
+    workspace = tmp_path / 'worker'
+    workspace.mkdir()
+    registry = SubscriptionProxyRegistry()
+    monkeypatch.setattr(controller, '_sub_registry', registry)
+    ctx = RunContext(run_id='sample', capability='sample', workspace=workspace, user_email='owner@example.test')
+    handle = controller.current_run.set(ctx)
+    try:
+        env, tokens = _prepare_worker_subscription_env(account, workspace)
+        assert list(Path(env['CLAUDE_CONFIG_DIR']).iterdir()) == []
+        assert 'synthetic-provider-value' not in json.dumps(env)
+        assert tokens == ctx.sub_proxy_tokens
+        assert registry.lookup(tokens[0])['capability'] == ctx.capability
+    finally:
+        controller.current_run.reset(handle)
+
+
+def test_claude_anonymous_or_unavailable_run_cannot_fallback(account, tmp_path, monkeypatch):
+    from agent.pool import _prepare_worker_subscription_env
+    handle = controller.current_run.set(None)
+    monkeypatch.setenv('LOMA_SUBSCRIPTION_PROXY', '0')
+    try:
+        with pytest.raises(controller.ExecutionUnavailable):
+            _prepare_worker_subscription_env(account, tmp_path)
+    finally:
+        controller.current_run.reset(handle)
+
+
+def test_subscription_proxy_reference_redacted():
+    assert 'loma_subproxy_' not in redact_secrets('url /sub/loma_subproxy_synthetic_value/messages')
+
+
+def test_binary_input_is_preserved():
+    raw = bytes(range(256))
+    argv, files = ToolInvoke._validate_params({'argv': [], 'files': {'image.png': {
+        'encoding': 'base64', 'data': base64.b64encode(raw).decode()}}})
+    assert files['image.png'] == raw
+
+
+@pytest.mark.parametrize('value', [{'encoding': 'base64', 'data': '???'},
+    {'encoding': 'base64', 'data': []}, {'encoding': 'file', 'data': '/etc/passwd'},
+    {'encoding': 'base64', 'data': '', 'path': '/etc/passwd'}])
+def test_binary_input_rejects_malformed_envelope(value):
+    with pytest.raises(Denied):
+        ToolInvoke._validate_params({'argv': [], 'files': {'x': value}})
+
+
+def test_posthog_accepts_real_commands_and_repeated_filters():
+    args = ['events', 'test', '--filter', 'x=1', '--filter', 'y=2']
+    assert prepare_argv('posthog', args, {}) == args
+    with pytest.raises(Denied):
+        prepare_argv('posthog', ['query', '--sql', 'select 1'], {})
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('command', ['cmd_download', 'cmd_upload'])
+async def test_agreement_authentication_precedes_personal_token_lookup(command, monkeypatch):
+    from tools import agreement_review
+    monkeypatch.setattr('tools._auth_token.verify_user_auth_token', lambda *a: False)
+    result = await getattr(agreement_review, command)(SimpleNamespace(
+        user_email='other@example.test', auth_token='synthetic-invalid'))
+    assert result == {'error': 'Authentication required'}
+
+@pytest.mark.asyncio
+async def test_codex_worker_gets_no_account_auth(account, tmp_path, monkeypatch):
+    from agent.codex_runtime import CodexWorker
+    from broker import worker
+    monkeypatch.setenv('LOMA_WORKER_ROOT', str(tmp_path / 'workers'))
+    monkeypatch.delenv('LOMA_WORKER_UID_RANGE', raising=False)
+    monkeypatch.delenv('LOMA_WORKER_UID', raising=False)
+    monkeypatch.setattr(controller, '_sub_registry', SubscriptionProxyRegistry())
+    monkeypatch.setattr(controller, 'proxy_mcp_servers_for_worker', lambda x: ({}, [], []))
+    ctx = controller.RunContext(run_id='test', capability='sample', workspace=tmp_path,
+                                user_email='owner@example.test')
+    class StopBeforeVendorCall(Exception):
+        pass
+    async def spawn(*args, **kwargs):
+        home = Path(kwargs['env']['CODEX_HOME'])
+        assert home != Path(account['config_dir'])
+        assert not (home / 'auth.json').exists()
+        import tomllib
+        config = tomllib.loads((home / 'config.toml').read_text())
+        assert config['model_provider'] == 'loma_subscription'
+        assert config['model_providers']['loma_subscription']['requires_openai_auth'] is False
+        assert kwargs['env']['LOMA_RUN_CAPABILITY'] == 'sample'
+        assert 'synthetic-codex-value' not in json.dumps(kwargs['env'])
+        raise StopBeforeVendorCall()
+    monkeypatch.setattr(worker, 'spawn_worker', spawn)
+    handle = controller.current_run.set(ctx)
+    try:
+        instance = CodexWorker(account=account, model='synthetic')
+        with pytest.raises(StopBeforeVendorCall):
+            await instance.connect()
+    finally:
+        controller.current_run.reset(handle)
+        for path in (tmp_path / 'workers').glob('codex-*'):
+            worker.cleanup_workspace(path)
+
+
+def test_opencode_no_longer_copies_provider_credentials(tmp_path, monkeypatch):
+    from agent.opencode_runtime import _prepare_opencode_data_home
+    source = tmp_path / 'backend-data' / 'opencode'
+    source.mkdir(parents=True)
+    (source / 'auth.json').write_text('synthetic-backend-credential')
+    monkeypatch.setenv('XDG_DATA_HOME', str(source.parent))
+    home = _prepare_opencode_data_home(tmp_path / 'worker-config')
+    assert not (home / 'opencode' / 'auth.json').exists()
+    assert (source / 'auth.json').read_text() == 'synthetic-backend-credential'
+
+@pytest.mark.parametrize('tool,args', [
+    ('ashby', ['list-applications', '--job-id', 'synthetic']),
+    ('sentry', ['daily', '1', '--days', '7']),
+    ('pylon', ['create-thread', 'synthetic', 'Example']),
+    ('grafana', ['query', 'lag', 'synthetic', '--range', '30']),
+    ('grafana', ['oncall', 'current']),
+    ('telegram', ['status']),
+    ('monetize_now', ['get-account', 'synthetic']),
+])
+def test_reviewed_adapter_command_groups(tool, args):
+    assert prepare_argv(tool, args, {}) == args
+
+
+def test_undeclared_command_group_cannot_consume_arbitrary_token():
+    with pytest.raises(Denied):
+        prepare_argv('grafana', ['query', 'unknown'], {})
+
+
+def test_opencode_managed_server_credentials_are_distinct(monkeypatch):
+    from agent import opencode_runtime as oc
+    monkeypatch.setattr(oc, '_managed_server_passwords', {
+        'http://127.0.0.1:19001': 'synthetic-one',
+        'http://127.0.0.1:19002': 'synthetic-two',
+    })
+    assert oc._auth('http://127.0.0.1:19001').password == 'synthetic-one'
+    assert oc._auth('http://127.0.0.1:19002').password == 'synthetic-two'
+    assert oc._auth('http://127.0.0.1:19003') is None
+
+
+@pytest.mark.asyncio
+async def test_opencode_teardown_revokes_managed_password(monkeypatch, tmp_path):
+    from agent import opencode_runtime as oc
+    monkeypatch.setattr(oc, '_managed_server_passwords', {'http://127.0.0.1:19001': 'synthetic'})
+    server = oc._OpenCodeServer(config_hash='synthetic', config_home=tmp_path,
+        host='127.0.0.1', port=19001, process=None)
+    await server.terminate()
+    assert oc._managed_server_passwords == {}
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('method,path', [('get', 'v1/files'), ('post', 'v1/fine_tuning/jobs'),
+    ('delete', 'v1/models/synthetic'), ('post', 'v1/responses?redirect=1')])
+async def test_model_grant_is_not_general_provider_account_access(monkeypatch, method, path):
+    monkeypatch.setenv('OPENAI_API_KEY', 'synthetic')
+    broker = SimpleNamespace(execute=AsyncMock(return_value={}))
+    app = create_gateway_app(broker, McpProxyRegistry())
+    async with TestClient(TestServer(app)) as client:
+        response = await getattr(client, method)('/model/openai/' + path,
+            headers={'Authorization': 'Bearer sample'})
+        assert response.status == 403
+        assert (await response.json()) == {'error': 'Unsupported model operation'}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('status', [401, 403, 429, 500])
+async def test_gateway_recovery_only_retries_auth_rejections(account, monkeypatch, status):
+    from broker import gateway, subscription_refresh
+    path = Path(account['config_dir']) / 'auth.json'
+    data = json.loads(path.read_text())
+    data['tokens']['refresh_token'] = 'synthetic-refresh'
+    path.write_text(json.dumps(data))
+    registry = SubscriptionProxyRegistry()
+    token = registry.register('codex', path, capability='sample')
+    broker = SimpleNamespace(execute=AsyncMock(return_value={}))
+    calls = []
+    async def upstream(request):
+        calls.append((request.headers['Authorization'], await request.read()))
+        return web.json_response({'ok': True}, status=status if len(calls) == 1 else 200)
+    exchange = AsyncMock(return_value={'access_token': 'synthetic-renewed'})
+    monkeypatch.setattr(subscription_refresh, '_exchange', exchange)
+    app = web.Application()
+    app.router.add_post('/responses', upstream)
+    async with TestServer(app) as server:
+        monkeypatch.setitem(gateway.SUBSCRIPTION_UPSTREAMS, 'codex', str(server.make_url('')).rstrip('/'))
+        async with TestClient(TestServer(create_gateway_app(broker, McpProxyRegistry(), registry))) as client:
+            response = await client.post(f'/sub/{token}/responses', data=b'synthetic-request')
+            assert response.status == (200 if status == 401 else status)
+            await response.read()
+    assert len(calls) == (2 if status == 401 else 1)
+    if status == 401:
+        exchange.assert_awaited_once()
+        assert calls[1] == ('Bearer synthetic-renewed', b'synthetic-request')
+    else:
+        exchange.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_gateway_never_replays_after_revocation_during_recovery(account, monkeypatch):
+    from broker import gateway, subscription_refresh
+    path = Path(account['config_dir']) / 'auth.json'
+    data = json.loads(path.read_text())
+    data['tokens']['refresh_token'] = 'synthetic-refresh'
+    path.write_text(json.dumps(data))
+    registry = SubscriptionProxyRegistry()
+    token = registry.register('codex', path, capability='sample')
+    broker = SimpleNamespace(execute=AsyncMock(return_value={}))
+    calls = []
+    async def upstream(request):
+        calls.append(True)
+        return web.Response(status=401)
+    async def exchange(*args):
+        registry.revoke(token)
+        return {'access_token': 'synthetic-renewed'}
+    monkeypatch.setattr(subscription_refresh, '_exchange', exchange)
+    app = web.Application()
+    app.router.add_post('/responses', upstream)
+    async with TestServer(app) as server:
+        monkeypatch.setitem(gateway.SUBSCRIPTION_UPSTREAMS, 'codex', str(server.make_url('')).rstrip('/'))
+        async with TestClient(TestServer(create_gateway_app(broker, McpProxyRegistry(), registry))) as client:
+            response = await client.post(f'/sub/{token}/responses')
+            assert response.status == 502
+            assert 'synthetic-renewed' not in await response.text()
+    assert calls == [True]

--- a/tests/test_subscription_refresh.py
+++ b/tests/test_subscription_refresh.py
@@ -1,0 +1,177 @@
+"""Synthetic refresh/rotation and filesystem lifecycle, no live vendor calls."""
+import asyncio
+import base64
+import json
+import os
+import time
+from unittest.mock import AsyncMock
+
+import pytest
+
+from broker import subscription_refresh as refresh
+from broker.service import Denied
+
+
+def jwt(exp):
+    return 'synthetic.' + base64.urlsafe_b64encode(json.dumps({'exp': exp}).encode()).decode().rstrip('=') + '.synthetic'
+
+
+def account(tmp_path, provider, exp):
+    path = tmp_path / ('claude.json' if provider == 'claude' else 'codex.json')
+    if provider == 'claude':
+        data = {'claudeAiOauth': {'accessToken': 'synthetic-old', 'refreshToken': 'synthetic-refresh', 'expiresAt': exp * 1000, 'scopes': ['user:inference']}, 'retained': True}
+    else:
+        data = {'tokens': {'access_token': jwt(exp), 'refresh_token': 'synthetic-refresh', 'account_id': 'synthetic-account'}, 'retained': True}
+    path.write_text(json.dumps(data))
+    return path
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('provider', ['claude', 'codex'])
+async def test_rotation_is_backend_only_and_atomic(tmp_path, monkeypatch, provider):
+    path = account(tmp_path, provider, time.time() - 1)
+    exchange = AsyncMock(return_value={'access_token': jwt(time.time() + 3600) if provider == 'codex' else 'synthetic-new', 'refresh_token': 'synthetic-next', 'expires_in': 3600})
+    monkeypatch.setattr(refresh, '_exchange', exchange)
+    assert await refresh.ensure_fresh(provider, path) is True
+    data = json.loads(path.read_text())
+    assert data['retained']
+    assert os.stat(path).st_mode & 0o777 == 0o600
+    assert not list(tmp_path.glob('.refresh-*'))
+    auth = data['claudeAiOauth' if provider == 'claude' else 'tokens']
+    assert auth['refreshToken' if provider == 'claude' else 'refresh_token'] == 'synthetic-next'
+    if provider == 'codex':
+        assert auth['account_id'] == 'synthetic-account'
+    await refresh.ensure_fresh(provider, path)
+    exchange.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_refreshes_exchange_once(tmp_path, monkeypatch):
+    path = account(tmp_path, 'claude', time.time() - 1)
+    async def exchange(*args):
+        await asyncio.sleep(0.1)
+        return {'access_token': 'synthetic-new', 'refresh_token': 'synthetic-next', 'expires_in': 3600}
+    mocked = AsyncMock(side_effect=exchange)
+    monkeypatch.setattr(refresh, '_exchange', mocked)
+    await asyncio.gather(*(refresh.ensure_fresh('claude', path) for _ in range(5)))
+    mocked.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('response', [{}, {'access_token': 'new', 'expires_in': -1}, {'access_token': 'new\nheader', 'expires_in': 30}, {'access_token': 'new', 'expires_in': float('nan')}])
+async def test_invalid_response_never_replaces_account(tmp_path, monkeypatch, response):
+    path = account(tmp_path, 'claude', time.time() - 1)
+    original = path.read_bytes()
+    monkeypatch.setattr(refresh, '_exchange', AsyncMock(return_value=response))
+    with pytest.raises(Denied):
+        await refresh.ensure_fresh('claude', path)
+    assert path.read_bytes() == original
+
+
+@pytest.mark.asyncio
+async def test_relogin_during_refresh_not_overwritten(tmp_path, monkeypatch):
+    path = account(tmp_path, 'claude', time.time() - 1)
+    async def exchange(*args):
+        path.write_text('{"different_account": true}')
+        return {'access_token': 'synthetic-new', 'expires_in': 3600}
+    monkeypatch.setattr(refresh, '_exchange', exchange)
+    with pytest.raises(Denied):
+        await refresh.ensure_fresh('claude', path)
+    assert json.loads(path.read_text()) == {'different_account': True}
+
+
+@pytest.mark.asyncio
+async def test_symlink_credential_and_lock_paths_rejected(tmp_path, monkeypatch):
+    path = account(tmp_path, 'claude', time.time() - 1)
+    exchange = AsyncMock()
+    monkeypatch.setattr(refresh, '_exchange', exchange)
+    alias = tmp_path / 'alias'
+    alias.symlink_to(path)
+    with pytest.raises(Denied):
+        await refresh.ensure_fresh('claude', alias)
+    (tmp_path / 'claude.json.refresh.lock').symlink_to(path)
+    with pytest.raises(Denied):
+        await refresh.ensure_fresh('claude', path)
+    exchange.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cancellation_releases_refresh_lock(tmp_path, monkeypatch):
+    path = account(tmp_path, 'claude', time.time() - 1)
+    started = asyncio.Event()
+    async def exchange(*args):
+        started.set()
+        await asyncio.sleep(100)
+    monkeypatch.setattr(refresh, '_exchange', exchange)
+    task = asyncio.create_task(refresh.ensure_fresh('claude', path))
+    await started.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    monkeypatch.setattr(refresh, '_exchange', AsyncMock(return_value={'access_token': 'synthetic-new', 'expires_in': 3600}))
+    assert await asyncio.wait_for(refresh.ensure_fresh('claude', path), timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_nonrefreshable_tokens_work_only_until_expiry(tmp_path, monkeypatch):
+    path = account(tmp_path, 'claude', time.time() + 30)
+    data = json.loads(path.read_text())
+    del data['claudeAiOauth']['refreshToken']
+    path.write_text(json.dumps(data))
+    exchange = AsyncMock()
+    monkeypatch.setattr(refresh, '_exchange', exchange)
+    await refresh.ensure_fresh('claude', path)
+    data['claudeAiOauth']['expiresAt'] = 0
+    path.write_text(json.dumps(data))
+    with pytest.raises(Denied):
+        await refresh.ensure_fresh('claude', path)
+    exchange.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize('provider', ['claude', 'codex'])
+async def test_rejected_opaque_tokens_coalesce_recovery(tmp_path, monkeypatch, provider):
+    path = account(tmp_path, provider, time.time() + 3600)
+    data = json.loads(path.read_text())
+    oauth = data['claudeAiOauth' if provider == 'claude' else 'tokens']
+    key = 'accessToken' if provider == 'claude' else 'access_token'
+    oauth[key] = 'test-opaque'
+    if provider == 'claude':
+        del oauth['expiresAt']
+    path.write_text(json.dumps(data))
+    async def exchange(*args):
+        await asyncio.sleep(0.01)
+        return {'access_token': 'test-renewed', 'expires_in': 3600}
+    mock = AsyncMock(side_effect=exchange)
+    monkeypatch.setattr(refresh, '_exchange', mock)
+    assert all(await asyncio.gather(*(refresh.ensure_fresh(
+        provider, path, rejected_access_token='test-opaque') for _ in range(5))))
+    mock.assert_awaited_once()
+    with pytest.raises(Denied):
+        await refresh.ensure_fresh(provider, path, rejected_access_token='test-renewed')
+    mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_failed_recovery_is_throttled_across_attempts(tmp_path, monkeypatch):
+    path = account(tmp_path, 'claude', time.time() + 3600)
+    mock = AsyncMock(side_effect=Denied())
+    monkeypatch.setattr(refresh, '_exchange', mock)
+    for _ in range(2):
+        with pytest.raises(Denied):
+            await refresh.ensure_fresh('claude', path, rejected_access_token='synthetic-old')
+    mock.assert_awaited_once()
+    assert json.loads(path.read_text())['claudeAiOauth']['accessToken'] == 'synthetic-old'
+
+
+@pytest.mark.asyncio
+async def test_nonrefreshable_opaque_token_is_not_retried(tmp_path, monkeypatch):
+    path = account(tmp_path, 'claude', time.time() + 3600)
+    data = json.loads(path.read_text())
+    del data['claudeAiOauth']['refreshToken']
+    path.write_text(json.dumps(data))
+    mock = AsyncMock()
+    monkeypatch.setattr(refresh, '_exchange', mock)
+    with pytest.raises(Denied):
+        await refresh.ensure_fresh('claude', path, rejected_access_token='synthetic-old')
+    mock.assert_not_awaited()

--- a/tests/test_tool_invoke.py
+++ b/tests/test_tool_invoke.py
@@ -1,0 +1,239 @@
+"""Broker tool.invoke / model.request operation tests. Fully synthetic."""
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from broker.operations import (
+    ALL_TOOLS,
+    AUTH_TOOLS,
+    INTEGRATION_TOOLS,
+    PERSONAL_TOOLS,
+    ModelRequest,
+    ToolInvoke,
+    _strip_identity_flags,
+)
+from broker.service import Broker, Denied
+
+EMAIL = "owner@example.test"
+
+
+class FakeProcess:
+    def __init__(self, argv):
+        self.argv = argv
+        self.returncode = 0
+        self.stdout = asyncio.StreamReader()
+        self.stdout.feed_data(json.dumps({"argv": self.argv}).encode())
+        self.stdout.feed_eof()
+        self.stderr = asyncio.StreamReader()
+        self.stderr.feed_eof()
+
+    async def communicate(self):
+        return json.dumps({"argv": self.argv}).encode(), b""
+
+    def kill(self):
+        pass
+
+    async def wait(self):
+        return 0
+
+
+@pytest.fixture
+def captured_exec(monkeypatch):
+    calls = []
+
+    async def fake_exec(*argv, **kwargs):
+        calls.append({"argv": list(argv), "kwargs": kwargs})
+        return FakeProcess(list(argv))
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    return calls
+
+
+def test_tool_registry_shape():
+    # Every registered tool script must exist so the broker can execute it.
+    from broker.operations import PROJECT_ROOT
+    for tool in ALL_TOOLS:
+        assert (PROJECT_ROOT / "tools" / f"{tool}.py").is_file(), tool
+    # The registry never includes private helpers or admin scripts.
+    assert "_auth_token" not in ALL_TOOLS
+    assert "migrate_skills_to_workspace" not in ALL_TOOLS
+    assert PERSONAL_TOOLS <= ALL_TOOLS
+    assert set(INTEGRATION_TOOLS) <= ALL_TOOLS
+
+
+def test_strip_identity_flags():
+    argv = ["send", "--user-email", "victim@example.test", "--title", "x",
+            "--auth-token", "stolen", "--body", "b"]
+    assert _strip_identity_flags(argv) == ["send", "--title", "x", "--body", "b"]
+
+
+@pytest.mark.asyncio
+async def test_tool_invoke_injects_server_minted_identity(captured_exec, monkeypatch):
+    monkeypatch.setattr(
+        "tools._auth_token.create_user_auth_token", lambda email: f"minted-for-{email}",
+    )
+    op = ToolInvoke()
+    result = await op.execute(None, EMAIL, "notify", {
+        "argv": ["--user-email", "victim@example.test", "--auth-token", "forged",
+                 "send", "--title", "hi"],
+        "files": {},
+    })
+    assert result["exit_code"] == 0
+    argv = captured_exec[0]["argv"]
+    # Worker-supplied identity was stripped; the broker's identity appended.
+    assert "victim@example.test" not in argv
+    assert "forged" not in argv
+    assert argv[2:4] == ["--auth-token", f"minted-for-{EMAIL}"]
+    assert argv[-2:] == ["--user-email", EMAIL]
+    assert argv[1].endswith("tools/notify.py")
+
+
+@pytest.mark.asyncio
+async def test_tool_invoke_injects_identity_for_integration_cli_guard(captured_exec, monkeypatch):
+    monkeypatch.setattr(
+        "tools._auth_token.create_user_auth_token", lambda email: "minted",
+    )
+    op = ToolInvoke()
+    db = SimpleNamespace(integrations=SimpleNamespace(find_one=AsyncMock(return_value={"status": "active"})))
+    await op.execute(db, EMAIL, "posthog", {"argv": ["definitions", "--limit", "1"], "files": {}})
+    argv = captured_exec[0]["argv"]
+    assert argv[2:4] == ["--auth-token", "minted"]
+    assert argv[-2:] == ["--user-email", EMAIL]
+    assert "posthog" not in AUTH_TOOLS
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("params", [
+    None,
+    "argv=x",
+    {"argv": "not-a-list"},
+    {"argv": ["ok"], "extra_key": 1},
+    {"argv": [1, 2]},
+    {"argv": ["x"] * 65},
+    {"argv": ["y" * 20_001]},
+    {"argv": [], "files": "nope"},
+    {"argv": [], "files": {i: "x" for i in range(9)}},
+    {"argv": [], "files": {"a": "z" * 1_600_000}},
+])
+async def test_tool_invoke_rejects_malformed_params(params):
+    with pytest.raises(Denied):
+        await ToolInvoke().execute(None, EMAIL, "notify", params)
+
+
+@pytest.mark.asyncio
+async def test_tool_invoke_rejects_unknown_tools():
+    for bad in ("example_tool", "_auth_token", "../../app", "bash", ""):
+        with pytest.raises(Denied):
+            await ToolInvoke().execute(None, EMAIL, bad, {"argv": []})
+
+
+@pytest.mark.asyncio
+async def test_tool_invoke_materializes_worker_files(captured_exec, monkeypatch):
+    monkeypatch.setattr(
+        "tools._auth_token.create_user_auth_token", lambda email: "minted",
+    )
+    op = ToolInvoke()
+    await op.execute(None, EMAIL, "loma_skills", {
+        "argv": ["update-file", "--slug", "s", "--path", "SKILL.md",
+                 "--content-file", "/workspace/skill.md"],
+        "files": {"/workspace/skill.md": "# updated"},
+    })
+    argv = captured_exec[0]["argv"]
+    rewritten = argv[argv.index("--content-file") + 1]
+    # The worker path was rewritten to a server-side private temp copy
+    # (removed after execution; only the rewrite is asserted here).
+    assert rewritten != "/workspace/skill.md"
+    assert "loma-broker-files-" in rewritten
+
+
+# ── Broker integration: params gating and grants ─────────────────────────
+
+
+class Capabilities:
+    def __init__(self):
+        self.docs = {}
+        self.create_index = AsyncMock()
+
+    async def insert_one(self, doc):
+        import copy
+        self.docs[doc["_id"]] = copy.deepcopy(doc)
+
+    async def find_one_and_update(self, query, update):
+        import copy
+        doc = self.docs.get(query["_id"])
+        if not doc or doc["revoked"] or doc["remaining_calls"] <= 0:
+            return None
+        if doc["expires_at"] <= query["expires_at"]["$gt"]:
+            return None
+        if query["scopes"]["$elemMatch"] not in doc["scopes"]:
+            return None
+        old = copy.deepcopy(doc)
+        doc["remaining_calls"] -= 1
+        return old
+
+    async def update_many(self, query, update):
+        for doc in self.docs.values():
+            if all(doc.get(k) == v for k, v in query.items()):
+                doc.update(update["$set"])
+
+
+def make_broker(operations):
+    db = SimpleNamespace(
+        users=SimpleNamespace(find_one=AsyncMock(return_value={"status": "active"})),
+        execution_capabilities=Capabilities(),
+        execution_audit=SimpleNamespace(insert_one=AsyncMock()),
+    )
+    return db, Broker(db, "dep-test", operations)
+
+
+@pytest.mark.asyncio
+async def test_params_denied_for_paramless_operations():
+    op = SimpleNamespace(valid_resource=lambda r: r == "res", execute=AsyncMock())
+    db, broker = make_broker({"legacy.op": op})
+    _, token = await broker.issue(user_email=EMAIL, grants={"legacy.op": ["res"]})
+    with pytest.raises(Denied):
+        await broker.execute(token, "legacy.op", "res", {"argv": []})
+    op.execute.assert_not_awaited()
+    # Without params the same capability works (budget was spent above).
+    assert await broker.execute(token, "legacy.op", "res") is op.execute.return_value
+
+
+@pytest.mark.asyncio
+async def test_params_forwarded_to_supporting_operations():
+    op = ToolInvoke()
+    db, broker = make_broker({"tool.invoke": op})
+    _, token = await broker.issue(user_email=EMAIL, grants={"tool.invoke": ["notify"]})
+    with patch.object(ToolInvoke, "execute", new=AsyncMock(return_value={"exit_code": 0})) as mock_exec:
+        result = await broker.execute(token, "tool.invoke", "notify", {"argv": ["list"], "files": {}})
+    assert result == {"exit_code": 0}
+    mock_exec.assert_awaited_once_with(db, EMAIL, "notify", {"argv": ["list"], "files": {}})
+
+
+@pytest.mark.asyncio
+async def test_ungranted_tool_is_denied_even_if_registered():
+    op = ToolInvoke()
+    db, broker = make_broker({"tool.invoke": op})
+    _, token = await broker.issue(user_email=EMAIL, grants={"tool.invoke": ["notify"]})
+    with pytest.raises(Denied):
+        await broker.execute(token, "tool.invoke", "gmail", {"argv": []})
+
+
+def test_model_request_only_configured_providers():
+    op = ModelRequest({"anthropic"})
+    assert op.valid_resource("anthropic")
+    assert not op.valid_resource("openai")
+    assert not op.valid_resource("")
+    assert not op.valid_resource(None)
+
+
+@pytest.mark.asyncio
+async def test_model_request_execute_denies_unconfigured():
+    op = ModelRequest(set())
+    with pytest.raises(Denied):
+        await op.execute(None, EMAIL, "anthropic")
+    granted = ModelRequest({"openai"})
+    assert (await granted.execute(None, EMAIL, "openai"))["ok"] is True

--- a/tests/test_worker_isolation.py
+++ b/tests/test_worker_isolation.py
@@ -1,0 +1,323 @@
+"""Worker isolation boundary tests: scrubbed env, private workspaces, shims.
+
+All synthetic: fake secret values are planted in the backend env and the
+tests assert they can never reach a worker process by any route.
+"""
+
+import asyncio
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from broker import worker as worker_mod
+from broker.worker import (
+    FORBIDDEN_ENV_NAMES,
+    WorkerIsolationError,
+    assert_worker_env_clean,
+    build_bwrap_argv,
+    build_worker_env,
+    cleanup_workspace,
+    create_workspace,
+    populate_tool_shims,
+    spawn_worker,
+    worker_root,
+    write_cli_launcher,
+)
+
+FAKE_SECRETS = {
+    "OBSERVABILITY_MONGODB_URI": "mongodb://synthetic-host/db",
+    "OAUTH_ENCRYPTION_KEY": "synthetic-fernet-key-000000000000000000000000",
+    "ANTHROPIC_API_KEY": "sk-ant-synthetic-000",
+    "SLACK_BOT_TOKEN": "synthetic-slack-value-000",
+    "OPENAI_API_KEY": "sk-synthetic-000",
+}
+
+
+@pytest.fixture
+def polluted_backend_env(monkeypatch):
+    for key, value in FAKE_SECRETS.items():
+        monkeypatch.setenv(key, value)
+    return FAKE_SECRETS
+
+
+@pytest.fixture
+def workspace(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOMA_WORKER_ROOT", str(tmp_path / "workers"))
+    return create_workspace(prefix="test")
+
+
+# ── Environment construction ─────────────────────────────────────────────
+
+
+def test_worker_env_contains_no_backend_secrets(polluted_backend_env, workspace):
+    env = build_worker_env(workspace)
+    for name in FORBIDDEN_ENV_NAMES:
+        assert name not in env
+    joined = json.dumps(env)
+    for value in polluted_backend_env.values():
+        assert value not in joined
+    # Only the expected allowlist shape.
+    assert env["HOME"] == str(workspace)
+    assert env["TMPDIR"] == str(workspace / "tmp")
+    assert env["LOMA_ISOLATED_WORKER"] == "1"
+
+
+def test_worker_env_rejects_forbidden_extra_keys(workspace):
+    for key in ("OAUTH_ENCRYPTION_KEY", "OBSERVABILITY_MONGODB_URI", "ANTHROPIC_API_KEY"):
+        with pytest.raises(WorkerIsolationError):
+            build_worker_env(workspace, extra={key: "x"})
+
+
+@pytest.mark.parametrize("key", [
+    "MY_SECRET", "SOME_TOKEN", "DB_PASSWORD", "X_API_KEY", "SIGNING_KEY_ID",
+    "SERVICE_CREDENTIAL", "FOO_ACCESS_KEY", "MONGODB_HOST", "SENTRY_DSN_X",
+])
+def test_worker_env_rejects_sensitive_looking_extra_keys(workspace, key):
+    with pytest.raises(WorkerIsolationError):
+        build_worker_env(workspace, extra={key: "x"})
+
+
+def test_worker_env_allows_run_capability_and_runtime_settings(workspace):
+    env = build_worker_env(workspace, extra={
+        "LOMA_RUN_CAPABILITY": "loma_run_v1_" + "a" * 43,
+        "LOMA_BROKER_URL": "http://127.0.0.1:3100",
+        "CLAUDE_CONFIG_DIR": "/opt/claude-users/u@example.test",
+        "XDG_CONFIG_HOME": "/x",
+    })
+    assert env["LOMA_RUN_CAPABILITY"].startswith("loma_run_v1_")
+
+
+def test_env_clean_assertion_catches_smuggled_secret_values(polluted_backend_env, workspace):
+    env = build_worker_env(workspace)
+    env["INNOCENT_LOOKING"] = "prefix " + FAKE_SECRETS["OAUTH_ENCRYPTION_KEY"]
+    with pytest.raises(WorkerIsolationError):
+        assert_worker_env_clean(env)
+
+
+def test_env_clean_assertion_catches_forbidden_names(workspace):
+    env = build_worker_env(workspace)
+    env["ANTHROPIC_API_KEY"] = "anything"
+    with pytest.raises(WorkerIsolationError):
+        assert_worker_env_clean(env)
+
+
+# ── Workspaces ───────────────────────────────────────────────────────────
+
+
+def test_workspaces_are_private_and_unique(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOMA_WORKER_ROOT", str(tmp_path / "workers"))
+    a = create_workspace(prefix="run")
+    b = create_workspace(prefix="run")
+    assert a != b
+    for ws in (a, b):
+        mode = stat.S_IMODE(os.stat(ws).st_mode)
+        assert mode == 0o700
+        assert (ws / "tmp").is_dir()
+        assert (ws / "tools").is_dir()
+
+
+def test_cleanup_refuses_paths_outside_worker_root(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOMA_WORKER_ROOT", str(tmp_path / "workers"))
+    monkeypatch.delenv("LOMA_KEEP_WORKSPACES", raising=False)
+    victim = tmp_path / "not-a-workspace"
+    victim.mkdir()
+    (victim / "data.txt").write_text("keep me")
+    cleanup_workspace(victim)
+    assert (victim / "data.txt").exists()
+
+    ws = create_workspace()
+    cleanup_workspace(ws)
+    assert not ws.exists()
+
+
+# ── Spawning (adversarial: real subprocess dumps its environment) ────────
+
+
+@pytest.mark.asyncio
+async def test_spawned_worker_cannot_see_backend_secrets(polluted_backend_env, workspace):
+    env = build_worker_env(workspace)
+    process = await spawn_worker(
+        ["/usr/bin/env", "python3", "-c",
+         "import os, json; print(json.dumps(dict(os.environ)))"],
+        workspace=workspace,
+        env=env,
+    )
+    stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=30)
+    assert process.returncode == 0, stderr.decode()
+    seen = json.loads(stdout.decode())
+    for name in FORBIDDEN_ENV_NAMES:
+        assert name not in seen
+    dumped = json.dumps(seen)
+    for value in polluted_backend_env.values():
+        assert value not in dumped
+
+
+@pytest.mark.asyncio
+async def test_spawned_worker_runs_in_workspace_with_limits(workspace):
+    env = build_worker_env(workspace)
+    process = await spawn_worker(
+        ["python3", "-c",
+         "import os, resource, json;"
+         "print(json.dumps({'cwd': os.getcwd(),"
+         " 'core': resource.getrlimit(resource.RLIMIT_CORE)[0],"
+         " 'sid_is_own': os.getsid(0) == os.getpid()}))"],
+        workspace=workspace,
+        env=env,
+    )
+    stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=30)
+    assert process.returncode == 0, stderr.decode()
+    info = json.loads(stdout.decode())
+    assert Path(info["cwd"]) == workspace
+    assert info["core"] == 0
+    assert info["sid_is_own"] is True
+
+
+@pytest.mark.asyncio
+async def test_spawn_refuses_dirty_env(workspace):
+    env = build_worker_env(workspace)
+    env["OAUTH_ENCRYPTION_KEY"] = "leak"
+    with pytest.raises(WorkerIsolationError):
+        await spawn_worker(["/bin/true"], workspace=workspace, env=env)
+
+
+# ── SDK CLI launcher ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cli_launcher_scrubs_inherited_environment(polluted_backend_env, workspace):
+    env = build_worker_env(workspace, extra={"LOMA_BROKER_URL": "http://127.0.0.1:3100"})
+    launcher = write_cli_launcher(
+        workspace, "/usr/bin/env", env, passthrough=("CLAUDE_CONFIG_DIR",),
+    )
+    assert os.access(launcher, os.X_OK)
+    # Simulate the SDK: full backend env inherited + its own additions.
+    sdk_env = {**os.environ, "CLAUDE_CONFIG_DIR": "/opt/claude-users/u@example.test"}
+    process = await asyncio.create_subprocess_exec(
+        str(launcher), env=sdk_env,
+        stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=30)
+    assert process.returncode == 0, stderr.decode()
+    printed = stdout.decode()
+    for name in FORBIDDEN_ENV_NAMES:
+        assert f"{name}=" not in printed
+    for value in polluted_backend_env.values():
+        assert value not in printed
+    assert "CLAUDE_CONFIG_DIR=/opt/claude-users/u@example.test" in printed
+    assert "LOMA_BROKER_URL=http://127.0.0.1:3100" in printed
+
+
+def test_cli_launcher_rejects_sensitive_passthrough(workspace):
+    env = build_worker_env(workspace)
+    for name in ("ANTHROPIC_API_KEY", "MY_TOKEN", "OAUTH_ENCRYPTION_KEY", "$(evil)"):
+        with pytest.raises(WorkerIsolationError):
+            write_cli_launcher(workspace, "claude", env, passthrough=(name,))
+
+
+# ── bubblewrap arg construction ──────────────────────────────────────────
+
+
+def test_bwrap_argv_confines_to_workspace(workspace):
+    argv = build_bwrap_argv(["python3", "x.py"], workspace)
+    assert argv[0] == "bwrap"
+    assert "--unshare-pid" in argv
+    joined = " ".join(argv)
+    assert f"--bind {workspace} {workspace}" in joined
+    assert f"--chdir {workspace}" in joined
+    # No home or arbitrary host binds.
+    assert "--bind /root" not in joined and "--bind /home" not in joined
+    assert argv[-2:] == ["python3", "x.py"]
+
+
+# ── Tool shims ───────────────────────────────────────────────────────────
+
+
+def test_tool_shims_are_generated_and_credential_free(workspace):
+    populate_tool_shims(workspace, ["gmail", "notify", "loma_skills"])
+    for tool in ("gmail", "notify", "loma_skills"):
+        shim = workspace / "tools" / f"{tool}.py"
+        assert shim.exists() and os.access(shim, os.X_OK)
+        body = shim.read_text()
+        assert "urllib.request" in body
+        assert "LOMA_BROKER_URL" in body
+        # Shims never reference DB URIs or encryption keys.
+        assert "OBSERVABILITY_MONGODB_URI" not in body
+        assert "OAUTH_ENCRYPTION_KEY" not in body
+
+
+def test_tool_shims_reject_invalid_names(workspace):
+    for bad in ("../evil", "a b", "UPPER", "x" * 65, "tool;rm"):
+        with pytest.raises(WorkerIsolationError):
+            populate_tool_shims(workspace, [bad])
+
+
+@pytest.mark.asyncio
+async def test_shim_fails_closed_without_capability(workspace):
+    populate_tool_shims(workspace, ["notify"])
+    env = build_worker_env(workspace)
+    process = await spawn_worker(
+        ["python3", "tools/notify.py", "send", "--title", "x"],
+        workspace=workspace,
+        env=env,
+    )
+    stdout, _ = await asyncio.wait_for(process.communicate(), timeout=30)
+    assert process.returncode == 1
+    assert "No run capability" in stdout.decode()
+
+
+@pytest.mark.asyncio
+async def test_shim_round_trip_through_broker_http(workspace, monkeypatch):
+    """End-to-end: shim in a worker -> broker HTTP -> tool result back."""
+    from aiohttp import web
+
+    from broker.http import create_app
+
+    class FakeToolOp:
+        accepts_params = True
+
+        @staticmethod
+        def valid_resource(value):
+            return value == "notify"
+
+        async def execute(self, db, email, resource, params=None):
+            assert params["argv"][0] == "list"
+            return {"exit_code": 0, "stdout": json.dumps({"ok": True, "email": email}), "stderr": ""}
+
+    class FakeBroker:
+        async def execute(self, token, operation, resource, params=None):
+            from broker.service import Denied
+            if token != CAPABILITY or operation != "tool.invoke":
+                raise Denied()
+            return await FakeToolOp().execute(None, "owner@example.test", resource, params)
+
+    CAPABILITY = "loma_run_v1_" + "a" * 43
+    app = create_app(FakeBroker())
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    port = runner.addresses[0][1]
+    try:
+        populate_tool_shims(workspace, ["notify"])
+        env = build_worker_env(workspace, extra={
+            "LOMA_BROKER_URL": f"http://127.0.0.1:{port}",
+            "LOMA_RUN_CAPABILITY": CAPABILITY,
+        })
+        process = await spawn_worker(
+            ["python3", "tools/notify.py", "list"],
+            workspace=workspace,
+            env=env,
+        )
+        stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=30)
+        assert process.returncode == 0, stderr.decode()
+        assert json.loads(stdout.decode()) == {"ok": True, "email": "owner@example.test"}
+    finally:
+        await runner.cleanup()
+
+
+def test_worker_root_under_temp_by_default(monkeypatch):
+    monkeypatch.delenv("LOMA_WORKER_ROOT", raising=False)
+    assert "loma-workers" in str(worker_root())

--- a/tests/test_worker_preset_library.py
+++ b/tests/test_worker_preset_library.py
@@ -1,0 +1,53 @@
+"""Caller-owned preset library works without private backend assets."""
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+from pptx import Presentation
+import pytest
+
+RENDERER = Path(__file__).resolve().parents[1] / 'tools/pptx_creator.py'
+
+
+def library(tmp_path):
+    pack = tmp_path / 'uploaded-pack'
+    (pack / 'master').mkdir(parents=True)
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[0])
+    slide.shapes.title.text = 'Synthetic customer-owned slide'
+    prs.save(pack / 'source.pptx')
+    (pack / 'master/slide-index.json').write_text(json.dumps({
+        'slides': [{'id': 'title', 'source_file': 'source.pptx', 'source_slide_index': 1}],
+        'presets': {'example': {'description': 'Synthetic preset', 'product': 'test', 'slides': ['title']}}}))
+    return pack
+
+
+def test_preset_generation_from_uploaded_workspace_library(tmp_path):
+    pack = library(tmp_path)
+    env = {**os.environ, 'HOME': str(tmp_path), 'LOMA_ISOLATED_WORKER': '1'}
+    result = subprocess.run([sys.executable, str(RENDERER), '--library-dir', str(pack),
+        'generate', '--preset', 'example', '--client', 'Synthetic', '--output', 'result.pptx'],
+        env=env, capture_output=True, text=True, timeout=30)
+    assert result.returncode == 0, result.stderr
+    deck = Presentation(tmp_path / 'artifacts/result.pptx')
+    assert len(deck.slides) == 1
+    assert deck.slides[0].shapes.title.text == 'Synthetic customer-owned slide'
+
+
+@pytest.mark.parametrize('kind', ['outside', 'symlink', 'missing'])
+def test_library_must_be_inside_workspace(tmp_path, kind):
+    pack = library(tmp_path)
+    home = tmp_path / 'home'
+    home.mkdir()
+    if kind == 'symlink':
+        (home / 'link').symlink_to(pack, target_is_directory=True)
+        pack = home / 'link'
+    elif kind == 'missing':
+        pack = home
+    result = subprocess.run([sys.executable, str(RENDERER), '--library-dir', str(pack), 'presets'],
+        env={**os.environ, 'HOME': str(home), 'LOMA_ISOLATED_WORKER': '1'},
+        capture_output=True, text=True, timeout=30)
+    assert result.returncode == 2
+    assert 'Invalid library' in result.stderr

--- a/tools/_auth_token.py
+++ b/tools/_auth_token.py
@@ -32,9 +32,9 @@ def create_user_auth_token(email: str) -> str:
     """
     key = _get_key()
     ts = str(int(time.time()))
-    payload = f"{email}:{ts}"
+    payload = f"loma-personal-tool:v1:{email}:{ts}"
     sig = hmac.new(key.encode(), payload.encode(), hashlib.sha256).hexdigest()
-    token_data = json.dumps({"email": email, "ts": ts, "sig": sig})
+    token_data = json.dumps({"purpose": "personal-tool", "version": 1, "email": email, "ts": ts, "sig": sig})
     return base64.urlsafe_b64encode(token_data.encode()).decode()
 
 
@@ -53,11 +53,16 @@ def verify_user_auth_token(
     except Exception:
         return False
 
+    if not isinstance(token_data, dict):
+        return False
+    if token_data.get("purpose") != "personal-tool" or token_data.get("version") != 1:
+        return False
+
     email = token_data.get("email", "")
     ts = token_data.get("ts", "")
     sig = token_data.get("sig", "")
 
-    if not email or not ts or not sig:
+    if not all(isinstance(v, str) and v for v in (email, ts, sig)):
         return False
 
     # Check email matches
@@ -66,13 +71,13 @@ def verify_user_auth_token(
 
     # Check expiry
     try:
-        if int(time.time()) - int(ts) > max_age:
+        if not 0 <= int(time.time()) - int(ts) <= max_age:
             return False
     except ValueError:
         return False
 
     # Verify HMAC
     key = _get_key()
-    payload = f"{email}:{ts}"
+    payload = f"loma-personal-tool:v1:{email}:{ts}"
     expected_sig = hmac.new(key.encode(), payload.encode(), hashlib.sha256).hexdigest()
     return hmac.compare_digest(sig, expected_sig)

--- a/tools/_integration_access.py
+++ b/tools/_integration_access.py
@@ -1,0 +1,93 @@
+"""Identity and sharing checks for direct organization-integration CLIs.
+
+Run before command dispatch, including when environment credentials exist.
+No authorization cache: removal of a user, team, or share takes effect on the
+next invocation. Imported functions are trusted backend code, not CLI entrypoints.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from integrations.access import allows_user
+from tools._auth_token import verify_user_auth_token
+
+
+class IntegrationAccessDenied(PermissionError):
+    pass
+
+
+def split_identity(argv: list[str]) -> tuple[str, str, list[str]]:
+    values = {}
+    clean = []
+    index = 0
+    while index < len(argv):
+        arg = argv[index]
+        flag, sep, value = arg.partition('=')
+        if flag in ('--user-email', '--auth-token'):
+            if flag in values:
+                raise IntegrationAccessDenied('Duplicate identity argument')
+            if not sep:
+                index += 1
+                if index >= len(argv) or argv[index].startswith('--'):
+                    raise IntegrationAccessDenied('Missing identity value')
+                value = argv[index]
+            if not value:
+                raise IntegrationAccessDenied('Missing identity value')
+            values[flag] = value
+        else:
+            clean.append(arg)
+        index += 1
+    if set(values) != {'--user-email', '--auth-token'}:
+        raise IntegrationAccessDenied('Authenticated user credentials required')
+    return values['--user-email'], values['--auth-token'], clean
+
+
+def require_cli_access(provider: str, email: str, token: str) -> None:
+    client = None
+    try:
+        if not verify_user_auth_token(token, email):
+            raise IntegrationAccessDenied()
+        uri = os.environ.get('OBSERVABILITY_MONGODB_URI', '').strip()
+        if not uri:
+            raise IntegrationAccessDenied()
+        from pymongo import MongoClient
+        from config.app_config import OBSERVABILITY_DB_NAME
+        client = MongoClient(uri, serverSelectionTimeoutMS=5000)
+        db = client[OBSERVABILITY_DB_NAME]
+        user = db.users.find_one({'email': email})
+        if not user or user.get('status') != 'active':
+            raise IntegrationAccessDenied()
+        doc = db.integrations.find_one({'provider': provider})
+        if not doc:
+            raise IntegrationAccessDenied()
+        teams = []
+        if (doc.get('shared_with') or {}).get('teams'):
+            teams = [team['team_id'] for team in db.teams.find(
+                {'members': email}, {'team_id': 1},
+            )]
+        if not allows_user(doc, email, teams):
+            raise IntegrationAccessDenied()
+    except Exception as exc:
+        raise IntegrationAccessDenied('Integration access denied or unavailable') from exc
+    finally:
+        if client is not None:
+            client.close()
+
+
+def authorize_cli(provider: str, *, preserve_identity: bool = False) -> None:
+    try:
+        email, token, clean = split_identity(sys.argv[1:])
+        require_cli_access(provider, email, token)
+        # Ashby additionally checks a provider-specific allowlist itself.
+        identity = ['--user-email', email, '--auth-token', token] if preserve_identity else []
+        sys.argv[:] = [sys.argv[0], *clean, *identity]
+    except IntegrationAccessDenied:
+        print(json.dumps({'error': 'Integration access denied. Supply valid --user-email and --auth-token and check the connection sharing settings.'}))
+        raise SystemExit(1) from None

--- a/tools/_public_download.py
+++ b/tools/_public_download.py
@@ -1,0 +1,75 @@
+"""Bounded public HTTPS downloads, without credentials or private-network access."""
+import ipaddress
+import socket
+from urllib.parse import urlsplit
+
+import aiohttp
+
+MAX_DOWNLOAD_BYTES = 1_000_000
+
+
+def _public_address(value):
+    address = ipaddress.ip_address(value)
+    # Also reject IPv4-in-IPv6 and transition mechanisms that can hide a private hop.
+    if not address.is_global or getattr(address, 'ipv4_mapped', None) or getattr(address, 'sixtofour', None) or getattr(address, 'teredo', None):
+        raise ValueError('Download destination must be public')
+
+
+def validate_url(url):
+    if not isinstance(url, str) or len(url) > 8192 or any(ord(c) <= 32 for c in url) or '\\' in url:
+        raise ValueError('Invalid download URL')
+    parsed = urlsplit(url)
+    if parsed.scheme != 'https' or not parsed.hostname or parsed.username is not None or parsed.password is not None or parsed.port not in (None, 443) or parsed.fragment:
+        raise ValueError('Download requires public HTTPS on port 443')
+    if '%' in parsed.hostname or not parsed.hostname.isascii():
+        raise ValueError('Invalid download host')
+    try:
+        ipaddress.ip_address(parsed.hostname)
+    except ValueError:
+        # aiohttp bypasses DNS for numeric-looking hosts, including shorthand
+        # forms which ipaddress does not parse. Do not let those evade the resolver.
+        if ':' in parsed.hostname or parsed.hostname.replace('.', '').isdigit():
+            raise ValueError('Noncanonical numeric download host')
+    else:
+        _public_address(parsed.hostname)
+    return parsed
+
+
+class PublicResolver(aiohttp.abc.AbstractResolver):
+    """Check the exact addresses the connector will use, not an earlier DNS lookup."""
+    def __init__(self):
+        self.resolver = aiohttp.resolver.ThreadedResolver()
+
+    async def resolve(self, host, port=0, family=socket.AF_INET):
+        answers = await self.resolver.resolve(host, port, family)
+        if not answers:
+            raise ValueError('Download host has no addresses')
+        for answer in answers:
+            _public_address(answer['host'])
+        return answers
+
+    async def close(self):
+        await self.resolver.close()
+
+
+async def download_public(url):
+    validate_url(url)
+    resolver = PublicResolver()
+    try:
+        connector = aiohttp.TCPConnector(resolver=resolver, use_dns_cache=False)
+        async with aiohttp.ClientSession(connector=connector, trust_env=False,
+                timeout=aiohttp.ClientTimeout(total=60), auto_decompress=False) as session:
+            # Redirects are deliberately denied: callers must supply the final URL.
+            async with session.get(url, allow_redirects=False) as response:
+                if response.status != 200:
+                    raise ValueError('Download did not return HTTP 200')
+                if response.content_length is not None and response.content_length > MAX_DOWNLOAD_BYTES:
+                    raise ValueError('Download exceeds size limit')
+                content = bytearray()
+                async for chunk in response.content.iter_chunked(65536):
+                    content.extend(chunk)
+                    if len(content) > MAX_DOWNLOAD_BYTES:
+                        raise ValueError('Download exceeds size limit')
+                return bytes(content), response.headers.get('Content-Type', 'application/octet-stream')
+    finally:
+        await resolver.close()

--- a/tools/agreement_review.py
+++ b/tools/agreement_review.py
@@ -88,6 +88,9 @@ def _tracked_insert_text(para_element, text, after_element, author, rev_id, rpr_
 
 async def cmd_download(args):
     """Download a .docx from Google Drive."""
+    from tools._auth_token import verify_user_auth_token
+    if not verify_user_auth_token(getattr(args, "auth_token", ""), getattr(args, "user_email", "")):
+        return {"error": "Authentication required"}
     sys.path.insert(0, os.path.dirname(__file__))
     from _google_auth import get_google_access_token
     import aiohttp
@@ -120,14 +123,24 @@ async def cmd_download(args):
             if resp.status != 200:
                 text = await resp.text()
                 return {"error": f"Failed to download file (HTTP {resp.status}): {text[:300]}"}
-            content = await resp.read()
+            content = bytearray()
+            async for chunk in resp.content.iter_chunked(65536):
+                content.extend(chunk)
+                if len(content) > 1_000_000:
+                    return {"error": "Document exceeds download size limit"}
+            content = bytes(content)
 
     if not file_name.endswith(".docx"):
         file_name = file_name.rsplit(".", 1)[0] + ".docx"
 
-    output_path = f"/tmp/{file_name}"
-    with open(output_path, "wb") as f:
-        f.write(content)
+    output_path = getattr(args, 'output_path', None)
+    if output_path:
+        Path(output_path).write_bytes(content)
+    else:
+        import tempfile
+        with tempfile.NamedTemporaryFile(prefix="loma-agreement-", suffix=".docx", delete=False) as f:
+            output_path = f.name
+            f.write(content)
 
     return {
         "file_path": output_path,
@@ -136,11 +149,23 @@ async def cmd_download(args):
     }
 
 
+def _validate_docx(path):
+    """Reject archive expansion bombs before handing uploads to the XML parser."""
+    from zipfile import ZipFile
+    with ZipFile(path) as archive:
+        entries = archive.infolist()
+        if len(entries) > 2000 or sum(entry.file_size for entry in entries) > 50_000_000:
+            raise ValueError('Document exceeds archive limits')
+        if any(entry.file_size > 20_000_000 for entry in entries):
+            raise ValueError('Document entry exceeds size limit')
+
+
 def cmd_read(args):
     """Read a .docx and return paragraphs as JSON."""
     from docx import Document
 
     try:
+        _validate_docx(args.file_path)
         doc = Document(args.file_path)
     except Exception as e:
         return {"error": f"Failed to open document: {e}"}
@@ -188,6 +213,7 @@ def cmd_annotate(args):
     comments = payload.get("comments", [])
 
     try:
+        _validate_docx(args.file_path)
         doc = Document(args.file_path)
     except Exception as e:
         return {"error": f"Failed to open document: {e}"}
@@ -438,6 +464,9 @@ def cmd_annotate(args):
 
 async def cmd_upload(args):
     """Upload a .docx to Google Drive and return the link."""
+    from tools._auth_token import verify_user_auth_token
+    if not verify_user_auth_token(getattr(args, "auth_token", ""), getattr(args, "user_email", "")):
+        return {"error": "Authentication required"}
     sys.path.insert(0, os.path.dirname(__file__))
     from _google_auth import get_google_access_token
     import aiohttp
@@ -499,14 +528,19 @@ def main():
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
 
     dl = subparsers.add_parser("download", help="Download a .docx from Google Drive")
+    dl.add_argument("--output-path", help="Explicit output file")
     dl.add_argument("--file-id", required=True, help="Google Drive file ID")
     dl.add_argument("--user-email", required=True)
     dl.add_argument("--auth-token", required=True)
 
     rd = subparsers.add_parser("read", help="Read a .docx and return paragraphs as JSON")
+    rd.add_argument("--user-email")
+    rd.add_argument("--auth-token")
     rd.add_argument("--file-path", required=True, help="Path to the .docx file")
 
     an = subparsers.add_parser("annotate", help="Apply tracked changes and comments from stdin JSON")
+    an.add_argument("--user-email")
+    an.add_argument("--auth-token")
     an.add_argument("--file-path", required=True, help="Path to the .docx file")
     an.add_argument("--output-path", required=False, help="Output path (defaults to *_reviewed.docx)")
 

--- a/tools/apollo.py
+++ b/tools/apollo.py
@@ -1397,6 +1397,8 @@ def _parse_json(args: list[str], flag: str) -> Any:
 
 
 if __name__ == "__main__":
+    from _integration_access import authorize_cli
+    authorize_cli('apollo')
     from dotenv import load_dotenv
     load_dotenv()
 

--- a/tools/ashby.py
+++ b/tools/ashby.py
@@ -886,4 +886,6 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    from _integration_access import authorize_cli
+    authorize_cli('ashby', preserve_identity=True)
     main()

--- a/tools/cdn_upload.py
+++ b/tools/cdn_upload.py
@@ -110,20 +110,12 @@ def upload_file(file_path: str, custom_key: str | None = None) -> dict:
 async def upload_from_url(url: str, custom_key: str | None = None) -> dict:
     """Download a file from a URL and upload it to R2."""
     try:
-        async with aiohttp.ClientSession() as session:
-            async with session.get(url, timeout=aiohttp.ClientTimeout(total=60)) as resp:
-                if resp.status != 200:
-                    return {"error": f"Failed to download URL (HTTP {resp.status}): {url}"}
-                data = await resp.read()
-
-                # Determine extension from URL or content-type
-                from urllib.parse import urlparse
-                parsed = urlparse(url)
-                ext = os.path.splitext(parsed.path)[1].lower()
-                if not ext:
-                    ct = resp.headers.get("Content-Type", "")
-                    ext_guess = mimetypes.guess_extension(ct.split(";")[0].strip())
-                    ext = ext_guess or ""
+        from tools._public_download import download_public
+        from urllib.parse import urlparse
+        data, content_type = await download_public(url)
+        ext = os.path.splitext(urlparse(url).path)[1].lower()
+        if not ext or not ext[1:].isalnum() or len(ext) > 12:
+            ext = mimetypes.guess_extension(content_type.split(';')[0].strip()) or ''
 
         # Write to temp file
         suffix = ext if ext else ""
@@ -137,8 +129,8 @@ async def upload_from_url(url: str, custom_key: str | None = None) -> dict:
         finally:
             os.unlink(tmp_path)
 
-    except aiohttp.ClientError as e:
-        return {"error": f"Failed to download URL: {e}"}
+    except (aiohttp.ClientError, ValueError, asyncio.TimeoutError):
+        return {"error": "Public HTTPS download failed or exceeded its limits"}
 
 
 # -- CLI entry point -----------------------------------------------------------
@@ -152,6 +144,8 @@ def _parse_flag(args, flag, default=""):
 
 
 if __name__ == "__main__":
+    from _integration_access import authorize_cli
+    authorize_cli('cdn_r2')
     from dotenv import load_dotenv
     load_dotenv()
 

--- a/tools/dataroom.py
+++ b/tools/dataroom.py
@@ -815,6 +815,8 @@ def _print_usage():
 
 
 if __name__ == "__main__":
+    from _integration_access import authorize_cli
+    authorize_cli('dataroom')
     from dotenv import load_dotenv
     load_dotenv()
 

--- a/tools/diagrams.py
+++ b/tools/diagrams.py
@@ -126,33 +126,16 @@ async def render_diagram(
         params["bgColor"] = bg_color
 
     try:
-        async with aiohttp.ClientSession() as session:
-            async with session.get(
-                url,
-                params=params,
-                timeout=aiohttp.ClientTimeout(total=30),
-            ) as resp:
-                if resp.status == 400:
-                    text = await resp.text()
-                    return {"error": "Mermaid syntax error: " + text[:500]}
-                if resp.status == 431:
-                    encoded_b64 = _encode_base64(diagram_code)
-                    url_b64 = MERMAID_INK_BASE + "/" + endpoint + "/" + encoded_b64
-                    async with session.get(
-                        url_b64, params=params,
-                        timeout=aiohttp.ClientTimeout(total=30),
-                    ) as resp2:
-                        if resp2.status != 200:
-                            text = await resp2.text()
-                            return {"error": "mermaid.ink error (HTTP " + str(resp2.status) + "): " + text[:500]}
-                        data = await resp2.read()
-                elif resp.status == 503:
-                    return {"error": "mermaid.ink rendering timed out. Try a simpler diagram."}
-                elif resp.status != 200:
-                    text = await resp.text()
-                    return {"error": "mermaid.ink error (HTTP " + str(resp.status) + "): " + text[:500]}
-                else:
-                    data = await resp.read()
+        # Fixed public renderer, bounded response, no redirects or credentials.
+        # Parsing/rendering runs at the provider, never in the trusted backend.
+        from urllib.parse import urlencode
+        try:
+            from _public_download import download_public
+        except ImportError:
+            from tools._public_download import download_public
+        if params:
+            url += '?' + urlencode(params)
+        data, _ = await download_public(url)
 
         with open(output_path, "wb") as f:
             f.write(data)
@@ -164,8 +147,8 @@ async def render_diagram(
             "type": img_type,
         }
 
-    except aiohttp.ClientError as e:
-        return {"error": "Failed to connect to mermaid.ink: " + str(e)}
+    except (aiohttp.ClientError, ValueError):
+        return {"error": "Diagram rendering failed or exceeded its size limit."}
 
 
 # -- Upload command (Google Drive) ---------------------------------------------

--- a/tools/github_pr_resolve.py
+++ b/tools/github_pr_resolve.py
@@ -87,4 +87,6 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    from _integration_access import authorize_cli
+    authorize_cli('github')
     sys.exit(main())

--- a/tools/grafana.py
+++ b/tools/grafana.py
@@ -1322,6 +1322,8 @@ def _parse_flag(args: List[str], flag: str) -> Optional[str]:
 
 
 if __name__ == "__main__":
+    from _integration_access import authorize_cli
+    authorize_cli('grafana')
     from dotenv import load_dotenv
     load_dotenv()
 

--- a/tools/grain.py
+++ b/tools/grain.py
@@ -5,7 +5,7 @@ Provides CLI commands for the Loma agent:
   2. grain.py transcript <id> [--text]    — Get transcript for a recording
   3. grain.py recent [days]               — List recordings from last N days (default 7)
 
-Requires GRAIN_API_TOKEN environment variable (Workspace Access Token).
+Requires --user-email and --auth-token and a personal Grain OAuth connection.
 API docs: https://developers.grain.com
 Rate limit: 300 requests/min
 
@@ -21,6 +21,15 @@ import json
 import os
 import sys
 import logging
+import argparse
+import re
+from contextvars import ContextVar
+from pathlib import Path
+
+if str(Path(__file__).resolve().parent.parent) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+_access_token: ContextVar[str | None] = ContextVar("grain_access_token", default=None)
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -39,15 +48,46 @@ DEFAULT_INCLUDE = {
 
 
 def _get_api_token() -> str:
-    token = os.environ.get("GRAIN_API_TOKEN", "")
+    token = _access_token.get()
     if not token:
-        from tools._integration_key import get_integration_key
-        token = get_integration_key("grain")
-    if not token:
-        raise ValueError(
-            "GRAIN_API_TOKEN not set and no Grain integration found on the dashboard."
-        )
+        raise ValueError("Connect your personal Grain account and supply authenticated user credentials.")
     return token
+
+
+async def run_personal(command: str, values: list[str], email: str, auth_token: str) -> dict:
+    from tools._auth_token import verify_user_auth_token
+    if not verify_user_auth_token(auth_token, email):
+        raise ValueError("Invalid personal-tool authentication")
+    from motor.motor_asyncio import AsyncIOMotorClient
+    from api.oauth_helpers import get_valid_provider_token
+    uri = os.environ.get("OBSERVABILITY_MONGODB_URI", "")
+    if not uri:
+        raise ValueError("Personal integration storage unavailable")
+    client = AsyncIOMotorClient(uri, serverSelectionTimeoutMS=5000)
+    try:
+        db = client.loma_observability
+        user = await db.users.find_one({"email": email, "status": "active"})
+        if not user:
+            raise ValueError("Active account required")
+        token = await get_valid_provider_token(email, "grain", db=db)
+        if not token:
+            raise ValueError("Connect or reconnect your personal Grain account in Integrations.")
+        marker = _access_token.set(token)
+        try:
+            if command == "search":
+                return await search_recordings(" ".join(values))
+            if command == "recent":
+                days = int(values[0]) if values else 7
+                if not 1 <= days <= 365:
+                    raise ValueError("days must be between 1 and 365")
+                return await recent_recordings(days)
+            if command == "transcript" and values:
+                return await get_transcript(values[0], "text" if "--text" in values else "json")
+            raise ValueError("Unknown or incomplete Grain command")
+        finally:
+            _access_token.reset(marker)
+    finally:
+        client.close()
 
 
 def _headers() -> dict[str, str]:
@@ -130,6 +170,7 @@ async def _fetch_all_recordings(
                     f"{GRAIN_BASE_URL}/recordings",
                     json=body,
                     headers=_headers(),
+                    allow_redirects=False,
                     timeout=aiohttp.ClientTimeout(total=30),
                 ) as resp:
                     if resp.status == 429:
@@ -180,6 +221,8 @@ async def search_recordings(query: str) -> dict[str, Any]:
 
 async def get_transcript(recording_id: str, fmt: str = "json") -> dict[str, Any]:
     """Get the transcript for a specific recording."""
+    if not re.fullmatch(r"[a-fA-F0-9]{8}(?:-[a-fA-F0-9]{4}){3}-[a-fA-F0-9]{12}", recording_id):
+        raise ValueError("Invalid recording ID")
     if fmt == "text":
         url = f"{GRAIN_BASE_URL}/recordings/{recording_id}/transcript.txt"
     else:
@@ -195,6 +238,7 @@ async def get_transcript(recording_id: str, fmt: str = "json") -> dict[str, Any]
             async with session.get(
                 url,
                 headers=headers,
+                allow_redirects=False,
                 timeout=aiohttp.ClientTimeout(total=60),
             ) as resp:
                 if resp.status == 429:
@@ -281,37 +325,19 @@ def _print_usage():
 if __name__ == "__main__":
     from dotenv import load_dotenv
     load_dotenv()
-
-    if len(sys.argv) < 2:
-        _print_usage()
-
-    command = sys.argv[1]
-    rest = sys.argv[2:]
-
-    if command == "search":
-        if not rest:
-            print("Error: search requires a query string")
-            sys.exit(1)
-        query = " ".join(rest)
-        result = asyncio.run(search_recordings(query))
-        print(json.dumps(result, indent=2))
-
-    elif command == "transcript":
-        if not rest:
-            print("Error: transcript requires a recording_id")
-            sys.exit(1)
-        recording_id = rest[0]
-        fmt = "text" if "--text" in rest else "json"
-        result = asyncio.run(get_transcript(recording_id, fmt=fmt))
-        print(json.dumps(result, indent=2))
-
-    elif command == "recent":
-        days = 7
-        if rest and rest[0].isdigit():
-            days = int(rest[0])
-        result = asyncio.run(recent_recordings(days))
-        print(json.dumps(result, indent=2))
-
-    else:
-        print(f"Unknown command: {command}")
-        _print_usage()
+    parser = argparse.ArgumentParser(allow_abbrev=False)
+    parser.add_argument("--user-email", required=True)
+    parser.add_argument("--auth-token", required=True)
+    parser.add_argument("command", choices=("search", "recent", "transcript"))
+    parser.add_argument("values", nargs="*")
+    parser.add_argument("--text", action="store_true")
+    args = parser.parse_args()
+    try:
+        values = args.values + (["--text"] if args.text else [])
+        result = asyncio.run(run_personal(args.command, values, args.user_email, args.auth_token))
+        from utils.secret_redaction import redact_secrets
+        print(redact_secrets(json.dumps(result, indent=2)))
+    except Exception as exc:
+        # Do not relay provider responses, URLs or authentication material.
+        print(json.dumps({"error": "Personal Grain request failed. Check your connection and command arguments."}))
+        sys.exit(1)

--- a/tools/linear.py
+++ b/tools/linear.py
@@ -361,5 +361,7 @@ async def _cli():
 
 
 if __name__ == "__main__":
+    from _integration_access import authorize_cli
+    authorize_cli('linear')
     logging.basicConfig(level=logging.INFO)
     asyncio.run(_cli())

--- a/tools/loma_skills.py
+++ b/tools/loma_skills.py
@@ -50,7 +50,9 @@ async def _require_maintainer(db, user_email: str | None, auth_token: str | None
     if not verify_user_auth_token(auth_token, user_email):
         raise skill_service.SkillError("Invalid or expired auth token", status=403)
     user = await db.users.find_one({"email": user_email})
-    role = (user or {}).get("system_role", "chatter")
+    if not user or user.get("status") != "active":
+        raise skill_service.SkillError("Active account required", status=403)
+    role = user.get("system_role", "chatter")
     if ROLE_HIERARCHY.get(role, 0) < ROLE_HIERARCHY["maintainer"]:
         raise skill_service.SkillError("Maintainer access required", status=403)
     return user_email
@@ -67,15 +69,33 @@ def _compact_skill(skill: dict) -> dict:
     }
 
 
+def _readable(skill: dict, email: str) -> bool:
+    return skill.get("scope") != "personal" or skill.get("created_by") == email
+
+
+async def _require_reader(db, user_email, auth_token):
+    if not user_email or not auth_token or not verify_user_auth_token(auth_token, user_email):
+        raise skill_service.SkillError("Authenticated user required", status=403)
+    user = await db.users.find_one({"email": user_email})
+    if not user or user.get("status") != "active":
+        raise skill_service.SkillError("Active account required", status=403)
+    return user_email
+
+
 async def _run(args) -> int:
     client, db = _connect_db()
     try:
+        email = await _require_reader(db, args.user_email, args.auth_token)
+        if getattr(args, "slug", None):
+            existing = await db.skills.find_one({"slug": args.slug})
+            if existing and not _readable(existing, email):
+                raise skill_service.SkillError("Skill not available", status=403)
         if args.command == "list":
-            return _json({"skills": [_compact_skill(s) for s in await skill_service.list_skills(db)]})
+            return _json({"skills": [_compact_skill(s) for s in await skill_service.list_skills(db) if _readable(s, email)]})
 
         if args.command == "search":
             query = args.query or args.query_text or ""
-            return _json({"skills": [_compact_skill(s) for s in await skill_service.search_skills(db, query)]})
+            return _json({"skills": [_compact_skill(s) for s in await skill_service.search_skills(db, query) if _readable(s, email)]})
 
         if args.command == "get":
             skill = await skill_service.get_skill(db, args.slug)
@@ -191,10 +211,10 @@ def main() -> int:
     sub = parser.add_subparsers(dest="command", required=True)
 
     def add_auth(p):
-        p.add_argument("--user-email")
-        p.add_argument("--auth-token")
+        p.add_argument("--user-email", default=argparse.SUPPRESS)
+        p.add_argument("--auth-token", default=argparse.SUPPRESS)
 
-    sub.add_parser("list")
+    add_auth(sub.add_parser("list"))
     search = sub.add_parser("search")
     search.add_argument("query_text", nargs="?")
     search.add_argument("--query")

--- a/tools/migrate_skills_to_workspace.py
+++ b/tools/migrate_skills_to_workspace.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """One-off: move all personal-scoped skills to workspace scope."""
 
+import argparse
 import asyncio
 import os
 import sys
@@ -21,6 +22,14 @@ from api import skill_service
 
 
 async def main():
+    from tools._auth_token import verify_user_auth_token
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--user-email', required=True)
+    parser.add_argument('--auth-token', required=True)
+    parser.add_argument('--apply', action='store_true', help='Apply changes; default is dry-run')
+    args = parser.parse_args()
+    if not verify_user_auth_token(args.auth_token, args.user_email):
+        raise SystemExit("Authentication required")
     uri = os.environ.get("OBSERVABILITY_MONGODB_URI", "").strip()
     if not uri:
         print("OBSERVABILITY_MONGODB_URI not set")
@@ -29,6 +38,11 @@ async def main():
     client = AsyncIOMotorClient(uri)
     db = client[OBSERVABILITY_DB_NAME]
 
+    user = await db.users.find_one({'email': args.user_email})
+    if not user or user.get('status') != 'active' or user.get('system_role') != 'admin':
+        client.close()
+        raise SystemExit("Active administrator required")
+
     skills = await skill_service.list_skills(db)
     personal = [s for s in skills if s.get("scope") == "personal"]
 
@@ -36,15 +50,20 @@ async def main():
         print("No personal-scoped skills found.")
         return
 
+    if not args.apply:
+        print(f"Dry run: {len(personal)} personal skills would move. Use --apply to proceed.")
+        client.close()
+        return
     print(f"Moving {len(personal)} personal skills to workspace scope:")
     for s in personal:
         slug = s["slug"]
         try:
-            await skill_service.update_skill_scope(db, slug=slug, scope="workspace", actor="migration")
+            await skill_service.update_skill_scope(db, slug=slug, scope="workspace", actor=args.user_email)
             print(f"  ✓ {slug}")
         except Exception as e:
             print(f"  ✗ {slug}: {e}")
 
+    client.close()
     print("Done.")
 
 

--- a/tools/monetize_now.py
+++ b/tools/monetize_now.py
@@ -378,6 +378,8 @@ def _parse_common_flags(args: list[str]) -> dict[str, Any]:
 
 
 if __name__ == "__main__":
+    from _integration_access import authorize_cli
+    authorize_cli('monetize_now')
     from dotenv import load_dotenv
     load_dotenv()
 

--- a/tools/phantombuster.py
+++ b/tools/phantombuster.py
@@ -332,6 +332,8 @@ async def check_status(phantom_type: str = "connect") -> dict:
 
 
 if __name__ == "__main__":
+    from _integration_access import authorize_cli
+    authorize_cli('phantombuster')
     load_dotenv()
 
     if len(sys.argv) < 2:

--- a/tools/posthog.py
+++ b/tools/posthog.py
@@ -433,6 +433,8 @@ def _extract_project_flag(args: list[str]) -> list[str]:
 
 
 if __name__ == "__main__":
+    from _integration_access import authorize_cli
+    authorize_cli('posthog')
     from dotenv import load_dotenv
     load_dotenv()
 

--- a/tools/pptx_creator.py
+++ b/tools/pptx_creator.py
@@ -49,7 +49,7 @@ from pptx.util import Inches, Pt, Emu
 PROJECT_ROOT = Path(__file__).parent.parent
 PPT_DIR = PROJECT_ROOT / "ppt"
 MASTER_DIR = PPT_DIR / "master"
-OUTPUT_DIR = PPT_DIR / "output"
+OUTPUT_DIR = Path.home() / "artifacts" if os.environ.get("LOMA_ISOLATED_WORKER") == "1" else PPT_DIR / "output"
 ASSETS_DIR = PPT_DIR / "assets"
 SLIDE_INDEX_PATH = MASTER_DIR / "slide-index.json"
 
@@ -425,7 +425,12 @@ def cmd_compose(args):
     with open(spec_path) as f:
         spec = json.load(f)
 
-    index = _load_slide_index()
+    # Blank, locally-created slides need no proprietary slide library.
+    # Existing presets/templates still require the operator-provided asset pack.
+    if not SLIDE_INDEX_PATH.exists() and all(entry.get('action') == 'create' for entry in spec.get('slides', [])):
+        index = {'slides': []}
+    else:
+        index = _load_slide_index()
     _execute_compose(spec, index)
 
 
@@ -665,10 +670,32 @@ def _create_slide_from_layout(prs: Presentation, layout_id: str, content: dict):
 # CLI entry point
 # ---------------------------------------------------------------------------
 
+def configure_library(directory: str):
+    """Select a caller-supplied library inside the isolated workspace.
+
+    The original proprietary asset pack is never copied from backend storage.
+    An uploaded/extracted pack uses master/slide-index.json plus the source decks
+    and assets referenced by that index.
+    """
+    global PPT_DIR, MASTER_DIR, ASSETS_DIR, SLIDE_INDEX_PATH
+    selected = Path(directory).resolve(strict=True)
+    if not selected.is_dir():
+        raise ValueError("Library must be a directory")
+    if os.environ.get("LOMA_ISOLATED_WORKER") == "1":
+        selected.relative_to(Path.home().resolve())
+    index = selected / "master" / "slide-index.json"
+    if not index.is_file():
+        raise ValueError("Library requires master/slide-index.json")
+    PPT_DIR, MASTER_DIR, ASSETS_DIR = selected, selected / "master", selected / "assets"
+    SLIDE_INDEX_PATH = index
+    _prs_cache.clear()
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="PPTX Presentation Generator — Compose client-specific product decks",
     )
+    parser.add_argument("--library-dir", help="Uploaded library directory in this worker workspace")
     subparsers = parser.add_subparsers(dest="command")
 
     # catalog
@@ -697,6 +724,11 @@ def main():
     comp_parser.add_argument("--spec", "-s", required=True, help="Path to deck spec JSON")
 
     args = parser.parse_args()
+    if args.library_dir:
+        try:
+            configure_library(args.library_dir)
+        except (OSError, ValueError):
+            parser.error("Invalid library: use a workspace directory containing master/slide-index.json")
 
     if args.command == "catalog":
         cmd_catalog(args)

--- a/tools/pylon.py
+++ b/tools/pylon.py
@@ -486,6 +486,8 @@ def _collect_flag_list(args: list[str], flag: str) -> list[str]:
 
 
 if __name__ == "__main__":
+    from _integration_access import authorize_cli
+    authorize_cli('pylon')
     from dotenv import load_dotenv
     load_dotenv()
 

--- a/tools/sentry.py
+++ b/tools/sentry.py
@@ -340,5 +340,7 @@ async def _cli():
 
 
 if __name__ == "__main__":
+    from _integration_access import authorize_cli
+    authorize_cli('sentry')
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
     asyncio.run(_cli())

--- a/tools/slack_reader.py
+++ b/tools/slack_reader.py
@@ -425,6 +425,8 @@ def _print_usage():
 
 
 if __name__ == "__main__":
+    from _integration_access import authorize_cli
+    authorize_cli('slack_bot')
     from dotenv import load_dotenv
     load_dotenv()
 

--- a/tools/stitch.py
+++ b/tools/stitch.py
@@ -215,31 +215,19 @@ async def download_file(url: str, output_path: str) -> dict:
     request the original full-resolution image instead of Google's default
     downscaled thumbnail.
     """
-    # Google's image CDN (lh3.googleusercontent.com) serves downscaled thumbnails
-    # by default. Appending '=s0' requests the original full-resolution image.
-    download_url = url
-    if "lh3.googleusercontent.com" in url and "=s" not in url:
-        download_url = url + "=s0"
-
+    from tools._public_download import download_public, validate_url
     try:
-        async with aiohttp.ClientSession() as session:
-            async with session.get(
-                download_url,
-                timeout=aiohttp.ClientTimeout(total=60),
-            ) as resp:
-                if resp.status != 200:
-                    return {"error": f"Download failed — HTTP {resp.status}"}
-                data = await resp.read()
-                with open(output_path, "wb") as f:
-                    f.write(data)
-                return {
-                    "success": True,
-                    "output": output_path,
-                    "size_bytes": len(data),
-                    "content_type": resp.headers.get("Content-Type", "unknown"),
-                }
-    except aiohttp.ClientError as e:
-        return {"error": f"Download failed: {str(e)}"}
+        parsed = validate_url(url)
+        download_url = url
+        if parsed.hostname == 'lh3.googleusercontent.com' and '=s' not in url:
+            download_url += '=s0'
+        data, content_type = await download_public(download_url)
+        with open(output_path, 'wb') as output:
+            output.write(data)
+        return {'success': True, 'output': output_path,
+                'size_bytes': len(data), 'content_type': content_type}
+    except (aiohttp.ClientError, ValueError, asyncio.TimeoutError):
+        return {'error': 'Public HTTPS download failed or exceeded its limits'}
 
 
 # -- CLI entry point -----------------------------------------------------------
@@ -253,6 +241,8 @@ def _parse_flag(args: list, flag: str, default: str = "") -> str:
 
 
 if __name__ == "__main__":
+    from _integration_access import authorize_cli
+    authorize_cli('stitch')
     from dotenv import load_dotenv
     load_dotenv()
 

--- a/tools/zoho_books.py
+++ b/tools/zoho_books.py
@@ -558,6 +558,8 @@ def _parse_flag(args: list[str], flag: str) -> str | None:
 
 
 if __name__ == "__main__":
+    from _integration_access import authorize_cli
+    authorize_cli('zoho_books')
     from dotenv import load_dotenv
 
     load_dotenv()

--- a/utils/secret_redaction.py
+++ b/utils/secret_redaction.py
@@ -1,0 +1,46 @@
+"""Best-effort log redaction. Not a substitute for isolating credential access."""
+import base64
+import json
+import re
+
+REDACTED = "[REDACTED]"
+_SECRET_KEYS = {
+    "auth_token", "access_token", "refresh_token", "id_token", "client_secret",
+    "x_auth_signature", "auth_signature", "api_key", "password", "password_hash", "local_auth", "authorization",
+}
+_BASE64 = re.compile(r"[A-Za-z0-9_-]{40,}={0,2}")
+_ASSIGNMENT = re.compile(
+    r'''(?i)((?:--(?:auth-token|api-key|access-token|refresh-token|client-secret)|'''
+    r'''(?:auth_token|access_token|refresh_token|client_secret|api_key|password))'''
+    r'''["']?\s*(?:[:=]\s*|\s+))(?:"[^"\n]*"|'[^'\n]*'|[^\s,;\]}"']+)'''
+)
+_BEARER = re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]+")
+# Run-scoped execution capabilities and gateway proxy tokens must never
+# survive into logs/transcripts.
+_RUN_CAPABILITY = re.compile(r"\b(?:loma_run_v1|loma_mcpproxy|loma_subproxy|loma_ocserver)_[A-Za-z0-9_-]+")
+
+
+def _redact_personal_token(match):
+    text = match.group()
+    try:
+        data = json.loads(base64.urlsafe_b64decode(text + "=" * (-len(text) % 4)))
+        if isinstance(data, dict) and {"email", "ts", "sig"} <= data.keys():
+            return REDACTED
+    except (ValueError, UnicodeError):
+        pass
+    return text
+
+
+def redact_secrets(value):
+    """Return a sanitized copy, including historical personal-tool token formats."""
+    if isinstance(value, str):
+        value = _RUN_CAPABILITY.sub(REDACTED, value)
+        value = _BASE64.sub(_redact_personal_token, value)
+        value = _ASSIGNMENT.sub(lambda m: m[1] + REDACTED, value)
+        return _BEARER.sub("Bearer " + REDACTED, value)
+    if isinstance(value, dict):
+        return {k: REDACTED if str(k).lower().replace("-", "_") in _SECRET_KEYS
+                else redact_secrets(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [redact_secrets(v) for v in value]
+    return value

--- a/webhooks/grain.py
+++ b/webhooks/grain.py
@@ -54,12 +54,12 @@ async def handle_grain_webhook(request: web.Request) -> web.Response:
 
     logger.info("[GRAIN-WEBHOOK] received recording_id=%s", recording_id)
 
-    # Fire-and-forget: ingestion fetches transcript + recording details from Grain API.
-    asyncio.create_task(ingest_grain_webhook(body, recording_id))
-
-    return web.json_response({"status": "accepted", "recording_id": recording_id})
+    # No verified personal principal is bound to legacy organization webhooks.
+    return web.json_response({"error": "Grain webhook enrichment requires a per-user subscription"}, status=503)
 
 
 def setup_grain_webhook_routes(app: web.Application) -> None:
     """Register the Grain webhook route."""
     app.router.add_post("/webhooks/grain", handle_grain_webhook)
+    from webhooks.grain_personal import setup_routes
+    setup_routes(app)

--- a/webhooks/grain_personal.py
+++ b/webhooks/grain_personal.py
@@ -1,0 +1,142 @@
+"""Owner-bound Grain ingestion. Personal transcripts never enter org changestreams."""
+import asyncio
+import hashlib
+import json
+import re
+import secrets
+from datetime import datetime, timedelta, timezone
+
+from aiohttp import web
+
+from api.auth_helpers import get_user_email
+from api.oauth_helpers import get_valid_provider_token
+from observability.db import get_db
+from tools import grain
+from webhooks.grain import _extract_recording_id
+from webhooks.grain_ingestion import normalize_grain_event
+
+
+def _db():
+    db = get_db()
+    if db is None:
+        raise web.HTTPServiceUnavailable(text='Integration storage unavailable')
+    return db
+
+
+async def _active(db, email):
+    if not email or not await db.users.find_one({'email': email, 'status': 'active'}):
+        raise web.HTTPForbidden(text='Active account required')
+
+
+async def configure(request):
+    db = _db()
+    owner = get_user_email(request)
+    await _active(db, owner)
+    if request.method == 'GET':
+        subscription = await db.grain_webhook_subscriptions.find_one(
+            {'_id': owner}, {'expires_at': 1})
+        expiry = subscription.get('expires_at') if subscription else None
+        if expiry and expiry.tzinfo is None:
+            expiry = expiry.replace(tzinfo=timezone.utc)
+        response = web.json_response({
+            'enabled': bool(expiry and expiry > datetime.now(timezone.utc)),
+            'expires_at': expiry.isoformat() if expiry else None,
+            'path': '/webhooks/grain/personal',
+        })
+        response.headers['Cache-Control'] = 'no-store'
+        return response
+    if request.method == 'DELETE':
+        await db.grain_webhook_subscriptions.delete_one({'_id': owner})
+        return web.json_response({'disabled': True})
+    if not await get_valid_provider_token(owner, 'grain', db=db):
+        raise web.HTTPConflict(text='Connect your personal Grain account first')
+    secret = secrets.token_urlsafe(32)
+    expiry = datetime.now(timezone.utc) + timedelta(days=90)
+    await db.grain_webhook_subscriptions.replace_one({'_id': owner}, {
+        '_id': owner, 'token_hash': hashlib.sha256(secret.encode()).hexdigest(),
+        'expires_at': expiry,
+    }, upsert=True)
+    response = web.json_response({
+        'path': '/webhooks/grain/personal', 'authorization': 'Bearer ' + secret,
+        'expires_at': expiry.isoformat(),
+        'notice': 'Save this header now. Rotation immediately invalidates the previous header.',
+    })
+    response.headers['Cache-Control'] = 'no-store'
+    return response
+
+
+async def ingest(request):
+    db = _db()
+    authorization = request.headers.get('Authorization', '')
+    if not re.fullmatch(r'Bearer [A-Za-z0-9_-]{43}', authorization):
+        raise web.HTTPUnauthorized(text='Webhook authentication required')
+    digest = hashlib.sha256(authorization[7:].encode()).hexdigest()
+    now = datetime.now(timezone.utc)
+    subscription = await db.grain_webhook_subscriptions.find_one({
+        'token_hash': digest, 'expires_at': {'$gt': now},
+    })
+    if not subscription:
+        raise web.HTTPUnauthorized(text='Webhook authentication required')
+    owner = subscription['_id']
+    await _active(db, owner)
+    # Read at most a small event payload. Never accept an owner from the body.
+    raw = bytearray()
+    async for chunk in request.content.iter_chunked(4096):
+        raw.extend(chunk)
+        if len(raw) > 16_384:
+            raise web.HTTPRequestEntityTooLarge(max_size=16_384, actual_size=len(raw))
+    try:
+        recording_id = _extract_recording_id(json.loads(raw))
+    except (ValueError, TypeError):
+        raise web.HTTPBadRequest(text='Invalid event') from None
+    if not recording_id or not re.fullmatch(r'[A-Za-z0-9_-]{1,128}', recording_id):
+        raise web.HTTPBadRequest(text='Invalid recording id')
+    access = await get_valid_provider_token(owner, 'grain', db=db)
+    if not access:
+        raise web.HTTPConflict(text='Reconnect personal Grain account')
+    event_id = hashlib.sha256((owner + '\0' + recording_id).encode()).hexdigest()
+    if await db.personal_grain_events.find_one({'_id': event_id, 'owner': owner}, {'_id': 1}):
+        return web.json_response({'received': True, 'duplicate': True})
+    marker = grain._access_token.set(access)
+    try:
+        async with asyncio.timeout(45):
+            transcript = await grain.get_transcript(recording_id, fmt='text')
+            if not isinstance(transcript, dict) or transcript.get('error') or not isinstance(transcript.get('transcript'), str):
+                raise web.HTTPBadGateway(text='Personal Grain recording unavailable')
+            metadata = await grain.find_recording_by_id(recording_id, days=2)
+        metadata = metadata or {'id': recording_id, 'title': 'Untitled meeting'}
+        if metadata.get('id') != recording_id:
+            raise web.HTTPBadGateway(text='Personal Grain recording unavailable')
+        # Do not persist arbitrary sender-controlled fields or credentials.
+        event = normalize_grain_event({'recording_id': recording_id}, metadata, transcript['transcript'])
+        if not event or len(json.dumps(event, default=str).encode()) > 4_000_000:
+            raise web.HTTPBadGateway(text='Recording exceeds ingestion limits')
+        event.update({'owner': owner, 'visibility': 'private'})
+        await _active(db, owner)
+        if not await db.grain_webhook_subscriptions.find_one({'_id': owner, 'token_hash': digest, 'expires_at': {'$gt': datetime.now(timezone.utc)}}):
+            raise web.HTTPUnauthorized(text='Webhook revoked')
+        # The _id unique index provides per-owner idempotency on concurrent deliveries.
+        await db.personal_grain_events.update_one({'_id': event_id}, {'$setOnInsert': event}, upsert=True)
+    except web.HTTPException:
+        raise
+    except Exception:
+        raise web.HTTPBadGateway(text='Personal Grain ingestion unavailable') from None
+    finally:
+        grain._access_token.reset(marker)
+    return web.json_response({'received': True})
+
+
+async def recordings(request):
+    db = _db()
+    owner = get_user_email(request)
+    await _active(db, owner)
+    events = await db.personal_grain_events.find({'owner': owner}, {'_id': 0}).sort('ingested_at', -1).limit(50).to_list(length=50)
+    return web.json_response({'recordings': events}, dumps=lambda value: json.dumps(value, default=str))
+
+
+def setup_routes(app):
+    app.router.add_get('/api/integrations/grain/webhook', configure)
+    app.router.add_put('/api/integrations/grain/webhook', configure)
+    app.router.add_delete('/api/integrations/grain/webhook', configure)
+    app.router.add_get('/api/integrations/grain/recordings', recordings)
+    app.router.add_post('/webhooks/grain/personal', ingest)


### PR DESCRIPTION
## Summary
- Restore the release from #157 after the build-only rollback in #158.
- Copy the OpenCode executable into `/usr/local/bin`; do not rely on installer shell-profile edits or an inaccessible symlink under `/root`.
- Check OpenCode, Claude and Codex version startup with a clean environment and unprivileged identity during the worker image build. Build failures stop deployment before replacement.

## Testing
- Python 3.12 backend: **1,019 passed, 5 skipped**.
- Fresh OpenCode installer download, executable copy, and actual non-root startup: **passed (1.18.29)**.
- Secret/public-content scans and diff whitespace checks: passed.
- No local Docker daemon is available. Full image construction will run in the deployment pipeline; this is not a claim of a completed local image build.
- Five real-sandbox tests remain skipped; live vendor compatibility remains unverified. Existing isolation safeguards are retained.
- Preview deployment testing is explicitly waived by the requester. User explicitly requested production merge and redeployment with this fix.

## Rollback
Current pre-release main: `14edc16`. Revert this replacement PR's merge to restore that code if deployment fails. A rollback does not reverse external data changes.
