### PR TITLE
feat: personal pixel pet companions

### DIFF
--- a/api/governance_routes.py
+++ b/api/governance_routes.py
@@ -140,6 +140,36 @@ async def handle_update_my_theme(request: web.Request) -> web.Response:
     return web.json_response({"theme_preference": theme})
 
 
+VALID_PETS = ("tabby", "tuxedo", "black-cat", "calico", "corgi", "golden", "dachshund", "rabbit", "hamster", "parrot")
+
+
+async def handle_update_my_pet(request: web.Request) -> web.Response:
+    """PATCH /api/governance/me/pet: preferences for the authenticated user only."""
+    email = get_user_email(request)
+    if not email:
+        return web.json_response({"error": "Authentication required"}, status=401)
+    try:
+        body = await request.json()
+    except (ValueError, TypeError):
+        return web.json_response({"error": "Invalid JSON"}, status=400)
+    if not isinstance(body, dict) or set(body) != {"pet_id", "visible", "animated"}:
+        return web.json_response({"error": "Expected pet_id, visible and animated"}, status=400)
+    if not isinstance(body["pet_id"], str) or body["pet_id"] not in VALID_PETS:
+        return web.json_response({"error": "Unknown pet"}, status=400)
+    if type(body["visible"]) is not bool or type(body["animated"]) is not bool:
+        return web.json_response({"error": "visible and animated must be booleans"}, status=400)
+    db = get_db()
+    if db is None:
+        return web.json_response({"error": "DB not configured"}, status=503)
+    result = await db.users.update_one(
+        {"email": email},
+        {"$set": {"pet_preference": body, "updated_at": datetime.now(timezone.utc)}},
+    )
+    if not result.matched_count:
+        return web.json_response({"error": "User not found"}, status=404)
+    return web.json_response(body)
+
+
 # ── Users CRUD (admin only) ───────────────────────────────────────────────
 
 
@@ -492,6 +522,7 @@ def setup_governance_routes(app: web.Application):
     app.router.add_get("/api/governance/me", handle_get_me)
 
     app.router.add_patch("/api/governance/me/theme", handle_update_my_theme)
+    app.router.add_patch("/api/governance/me/pet", handle_update_my_pet)
 
     # Users (admin only)
     app.router.add_get("/api/governance/users", handle_list_users)

--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import PetCompanion from "@/components/PetCompanion";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useSession } from "next-auth/react";
@@ -50,6 +51,18 @@ export default function TasksPage() {
   const router = useRouter();
   const isMobile = useIsMobile();
   const [board, setBoard] = useState<TasksBoardResponse | null>(null);
+  const previousColumns = useRef<Map<string, string> | null>(null);
+  const [petCompleted, setPetCompleted] = useState(false);
+  useEffect(() => {
+    if (!board) return;
+    const previous = previousColumns.current;
+    const justCompleted = board.tasks.some((task) => task.column === "done" && previous?.has(task.conversation_id) && previous.get(task.conversation_id) !== "done");
+    previousColumns.current = new Map(board.tasks.map((task) => [task.conversation_id, task.column]));
+    if (!justCompleted) return;
+    setPetCompleted(true);
+    const timer = setTimeout(() => setPetCompleted(false), 800);
+    return () => { clearTimeout(timer); setPetCompleted(false); };
+  }, [board]);
   const [error, setError] = useState<string | null>(null);
   const [taskDialogOpen, setTaskDialogOpen] = useState(false);
   const [editingTask, setEditingTask] = useState<Task | null>(null);
@@ -193,7 +206,10 @@ export default function TasksPage() {
   return (
     <div className="flex h-full flex-col space-y-2 p-4 lg:p-6">
       <div className="pwa-header-offset flex items-center justify-between">
-        <h1 className="text-lg font-semibold">Tasks</h1>
+        <div className="flex items-center gap-2">
+          <h1 className="text-lg font-semibold">Tasks</h1>
+          <PetCompanion state={board?.tasks.some((task) => task.column === "needs_input") ? "attention" : petCompleted ? "completed" : board?.tasks.some((task) => task.column === "working") ? "working" : "idle"} />
+        </div>
         <div className="flex items-center gap-1">
           {board && board.tags.length > 0 && (
             <DropdownMenu>

--- a/dashboard/src/components/ChatPanel.tsx
+++ b/dashboard/src/components/ChatPanel.tsx
@@ -17,6 +17,7 @@ import type { ChatEvent, ChatFile, ChatMessage, ClarifyQuestion, Turn, Persisted
 import MarkdownContent from "./MarkdownContent";
 import ArtifactCard from "./ArtifactCard";
 import type { Artifact } from "./ArtifactViewer";
+import PetCompanion from "./PetCompanion";
 import CrosscutIcon from "./CrosscutIcon";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -1380,6 +1381,7 @@ export default function ChatPanel({
         </div>
       )}
 
+      <div className="flex justify-center"><PetCompanion size={isEmptyState ? 56 : 28} state={isStreaming ? "working" : "idle"} /></div>
       {/* Hidden file input */}
       <input
         ref={fileInputRef}
@@ -1522,7 +1524,7 @@ export default function ChatPanel({
                 if (item.role === "clarify") {
                   return (
                     <div key={i} className="flex justify-start items-start animate-message-in gap-2">
-                      <CrosscutIcon size={16} className="shrink-0 mt-px" />
+                      <PetCompanion size={24} fallback={<CrosscutIcon size={16} className="shrink-0 mt-px" />} />
                       <div className="chat-text min-w-0 flex-1 text-[13px] leading-relaxed break-words">
                         {item.content && (
                           <div className="mb-3 [&>*:first-child]:mt-0">
@@ -1646,7 +1648,7 @@ export default function ChatPanel({
                 // Assistant message — editorial style, no bubble
                 return (
                   <div key={i} className="flex justify-start items-start animate-message-in gap-2">
-                    <CrosscutIcon size={16} className="shrink-0 mt-px" />
+                    <PetCompanion size={24} fallback={<CrosscutIcon size={16} className="shrink-0 mt-px" />} />
                     <div className="chat-text min-w-0 flex-1 text-[13px] leading-relaxed break-words [&>*:first-child]:mt-0">
                       {item.content ? (
                         <MarkdownContent content={item.content} />

--- a/dashboard/src/components/ChatPanel.tsx
+++ b/dashboard/src/components/ChatPanel.tsx
@@ -1381,7 +1381,7 @@ export default function ChatPanel({
         </div>
       )}
 
-      <div className="flex justify-center"><PetCompanion size={isEmptyState ? 56 : 28} state={isStreaming ? "working" : "idle"} /></div>
+      {isStreaming && <div className="flex justify-center"><PetCompanion size={28} state="working" /></div>}
       {/* Hidden file input */}
       <input
         ref={fileInputRef}
@@ -1400,6 +1400,7 @@ export default function ChatPanel({
         /* Empty state */
         <div className="flex flex-col items-center justify-center h-full px-4 md:px-6 animate-fade-in-up">
           <div className="mb-8 text-center">
+            <PetCompanion size={56} />
             <h2 className="text-xl md:text-3xl font-heading font-normal text-foreground tracking-tight">
               What do you need to get done?
             </h2>

--- a/dashboard/src/components/ChatPanel.tsx
+++ b/dashboard/src/components/ChatPanel.tsx
@@ -17,7 +17,7 @@ import type { ChatEvent, ChatFile, ChatMessage, ClarifyQuestion, Turn, Persisted
 import MarkdownContent from "./MarkdownContent";
 import ArtifactCard from "./ArtifactCard";
 import type { Artifact } from "./ArtifactViewer";
-import PetCompanion from "./PetCompanion";
+import PetCompanion, { PetRunway } from "./PetCompanion";
 import CrosscutIcon from "./CrosscutIcon";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -1381,7 +1381,6 @@ export default function ChatPanel({
         </div>
       )}
 
-      {isStreaming && <div className="flex justify-center"><PetCompanion size={28} state="working" /></div>}
       {/* Hidden file input */}
       <input
         ref={fileInputRef}
@@ -1735,6 +1734,7 @@ export default function ChatPanel({
               }}
               className="max-w-3xl mx-auto"
             >
+              {isStreaming && <PetRunway running={!items.some((item) => item.role === "clarify" && !item.submitted)} />}
               <PendingFilesStrip files={pendingFiles} onRemove={removeFile} onExpandImage={setExpandedImage} />
 
               <div className="flex flex-col bg-muted border border-border rounded-2xl focus-within:border-gray-300 transition-colors">

--- a/dashboard/src/components/EmptyState.tsx
+++ b/dashboard/src/components/EmptyState.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import PetCompanion from "./PetCompanion";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { RiInboxLine } from "@remixicon/react";
@@ -21,7 +22,7 @@ export function EmptyState({
 }) {
   return (
     <div className={cn("flex flex-col items-center justify-center py-8 text-center", className)}>
-      <Icon size={32} className="text-muted-foreground/50 mb-3" />
+      <PetCompanion size={48} fallback={<Icon size={32} className="text-muted-foreground/50 mb-3" />} />
       <p className="text-[13px] font-medium text-muted-foreground">{title}</p>
       {description && (
         <p className="text-xs text-muted-foreground/70 mt-1 max-w-xs">{description}</p>

--- a/dashboard/src/components/PetCompanion.tsx
+++ b/dashboard/src/components/PetCompanion.tsx
@@ -84,6 +84,37 @@ export default function PetCompanion({ size = 32, state = "idle", fallback = nul
   return <PetSprite petId={preference.pet_id} size={size} state={state} animated={preference.animated} />;
 }
 
+/** A decorative lane in the composer, never over the messages or input controls. */
+export function PetRunway({ running }: { running: boolean }) {
+  const { user } = useUser();
+  const preference = user?.pet_preference ?? DEFAULT_PET;
+  if (!user || !preference.visible) return null;
+  return (
+    <div aria-hidden="true" className="pet-runway" data-running={running && preference.animated}>
+      <div className="pet-track">
+        <div className="pet-runner">
+          <div className="pet-facing">
+            <PetSprite petId={preference.pet_id} size={32} state={running ? "working" : "attention"} animated={preference.animated} />
+          </div>
+        </div>
+      </div>
+      <style jsx>{`
+        .pet-runway { height: 38px; overflow: hidden; pointer-events: none; user-select: none; }
+        .pet-track { width: calc(100% - 32px); padding-top: 4px; }
+        .pet-runner { width: 100%; }
+        .pet-facing { width: 32px; height: 32px; }
+        .pet-runway[data-running="true"] .pet-runner { animation: pet-run 8s linear infinite; }
+        .pet-runway[data-running="true"] .pet-facing { animation: pet-turn 8s steps(1) infinite; }
+        @keyframes pet-run { 0%, 100% { transform: translateX(0); } 50% { transform: translateX(100%); } }
+        @keyframes pet-turn { 0%, 100% { transform: scaleX(1); } 50% { transform: scaleX(-1); } }
+        @media (prefers-reduced-motion: reduce) {
+          .pet-runner, .pet-facing { animation: none !important; transform: none !important; }
+        }
+      `}</style>
+    </div>
+  );
+}
+
 export function PetSettings({ collapsed, onOpen }: { collapsed: boolean; onOpen: () => void }) {
   const { user, refresh } = useUser();
   const [open, setOpen] = useState(false);

--- a/dashboard/src/components/PetCompanion.tsx
+++ b/dashboard/src/components/PetCompanion.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useUser } from "@/lib/UserContext";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogDescription, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { RiSettings3Line } from "@remixicon/react";
+
+// Original, code-native pixel sprites. Shared silhouettes keep every size crisp.
+const silhouettes = {
+  cat: ["................", "...oo......oo...", "...oao....oao...", "...oaaooooaao...", "...oaaaaaaaao...", "..oaaaaaaaaaao..", "..oaaeaaaeaaao..", "..oaaaanaaaaao..", "...oaammaaoo....", "....oammaao..oo.", "....oammaao..oa.", "...oaaaaaaao.oa.", "...oaaaaaaaooa..", "...oaooooaaoo...", "....oo...oo.....", "................"],
+  dog: ["................", "................", "...ooo....ooo...", "..oaaaooooaaao..", "..oaabbbbbaaao..", "..oaabbbbbaaao..", "..oaaebbbeaaao..", "...oabbnbbao....", "....obmmmbbo....", "....obmmmbbo.oo.", "....obmmmbbo.oa.", "...obbbbbbbooao.", "...obbbbbbbooo..", "...oboooobbo....", "....oo...oo.....", "................"],
+  rabbit: ["....oo..oo......", "...oaaooaao.....", "...opaaoapo.....", "...opaaoapo.....", "...oaaooaao.....", "....oaaaao......", "...oaaaaaao.....", "...oeaaaeao.....", "...oaanaaaao....", "....oammaao.....", "...oaammaaao....", "..oaaaaaaaaaooo.", "..oaaaaaaaaaoao.", "...ooaoooaoooo..", "....oo...oo.....", "................"],
+  hamster: ["................", "................", "...ooo....ooo...", "..oapaoooopaoo..", "..oaaaaaaaaaao..", "..oaaaaaaaaaao..", "..oaaeaaaeaaao..", ".oapppanapppaao.", ".oaaammmmmaaaao.", "..oaammmmmaao...", "..oaammmmmaao...", "..oaaaaaaaaao...", "...oaaaaaaao....", "...oaooooaao....", "....oo...oo.....", "................"],
+  parrot: ["................", "......ooo.......", ".....oaaao......", "....oaaaaao.....", "....oaaeeao.....", "....oaammmmo....", "....oaammo......", "...oaaaaao......", "..oabbaaaao.....", "..oabbbaaao.....", "..oabbbaaao.....", "...obbaaao......", "....oaaaao......", "....omoomoo.....", "...oooooooooo...", "................"],
+};
+
+export const PETS = [
+  { id: "tabby", name: "Tabby cat", kind: "cat", coat: "#d98c45", patch: "#98562e" },
+  { id: "tuxedo", name: "Tuxedo cat", kind: "cat", coat: "#454754", patch: "#f2ebda" },
+  { id: "black-cat", name: "Black cat", kind: "cat", coat: "#454754", patch: "#626778" },
+  { id: "calico", name: "Calico cat", kind: "cat", coat: "#eee4d0", patch: "#c07a42" },
+  { id: "corgi", name: "Corgi", kind: "dog", coat: "#c7803d", patch: "#eeb76f" },
+  { id: "golden", name: "Golden retriever", kind: "dog", coat: "#c68c40", patch: "#efc36c" },
+  { id: "dachshund", name: "Dachshund", kind: "dog", coat: "#654331", patch: "#a66738" },
+  { id: "rabbit", name: "Rabbit", kind: "rabbit", coat: "#d8cbbf", patch: "#b4a59c" },
+  { id: "hamster", name: "Hamster", kind: "hamster", coat: "#dba75a", patch: "#bd8443" },
+  { id: "parrot", name: "Parrot", kind: "parrot", coat: "#70ae7c", patch: "#48839f" },
+] as const;
+
+const DEFAULT_PET = { pet_id: "tabby", visible: true, animated: true };
+type PetState = "idle" | "working" | "listening" | "completed" | "attention";
+
+export function PetSprite({ petId, size = 40, state = "idle", animated = false }: {
+  petId: string; size?: number; state?: PetState; animated?: boolean;
+}) {
+  const pet = PETS.find((p) => p.id === petId) ?? PETS[0];
+  const pixels: string[] = [...silhouettes[pet.kind]];
+  if (pet.id === "corgi") {
+    pixels[1] = "...oo......oo...";
+    pixels[2] = "...oao....oao...";
+    pixels[3] = "...oaaooooaao...";
+  }
+  if (pet.id === "dachshund") {
+    pixels[9] = "....obbbbbbbooo.";
+    pixels[10] = "....obbbbbbbbbo.";
+    pixels[11] = "...obbbbbbbbbbo.";
+    pixels[12] = "...obbbbbbbbbo..";
+    pixels[13] = "...oboooooobbo..";
+    pixels[14] = "....oo.....oo...";
+  }
+  const colors: Record<string, string> = { o: "#332f37", a: pet.coat, b: pet.patch, m: pet.id === "black-cat" ? "#626778" : "#f5e9cf", e: "#24232c", n: "#bb7681", p: "#dfa4a0" };
+  return (
+    <span aria-hidden="true" data-pet={pet.id} data-state={state} className="pet-sprite inline-flex shrink-0" data-animated={animated} style={{ width: size, height: size }}>
+      <svg width={size} height={size} viewBox="0 0 16 16" shapeRendering="crispEdges" focusable="false">
+        {pixels.flatMap((row, y) => [...row].map((pixel, x) => {
+          if (pixel === ".") return null;
+          // Coat markings distinguish the cats without recoloring their eyes.
+          const marking = pet.id === "tabby" && pixel === "a" && y < 6 && x % 3 === 0;
+          const calico = pet.id === "calico" && pixel === "a" && ((x < 7 && y < 7) || (x > 9 && y > 10));
+          return <rect key={`${x}-${y}`} x={x} y={y} width="1" height="1" fill={marking || calico ? pet.patch : colors[pixel]} />;
+        }))}
+      </svg>
+      <style jsx>{`
+        .pet-sprite[data-animated="true"][data-state="working"] { animation: pet-bob 1s steps(2) infinite; }
+        .pet-sprite[data-animated="true"][data-state="listening"] { animation: pet-listen 1.2s steps(2) infinite; }
+        .pet-sprite[data-animated="true"][data-state="completed"] { animation: pet-hop .6s steps(3) 1; }
+        .pet-sprite[data-state="attention"] { transform: rotate(-8deg); }
+        @keyframes pet-bob { 50% { transform: translateY(-2px); } }
+        @keyframes pet-listen { 50% { transform: rotate(8deg); } }
+        @keyframes pet-hop { 50% { transform: translateY(-5px); } }
+        @media (prefers-reduced-motion: reduce) { .pet-sprite { animation: none !important; transform: none !important; } }
+      `}</style>
+    </span>
+  );
+}
+
+export default function PetCompanion({ size = 32, state = "idle", fallback = null }: {
+  size?: number; state?: PetState; fallback?: React.ReactNode;
+}) {
+  const { user } = useUser();
+  const preference = user?.pet_preference ?? DEFAULT_PET;
+  if (!user || !preference.visible) return <>{fallback}</>;
+  return <PetSprite petId={preference.pet_id} size={size} state={state} animated={preference.animated} />;
+}
+
+export function PetSettings({ collapsed, onOpen }: { collapsed: boolean; onOpen: () => void }) {
+  const { user, refresh } = useUser();
+  const [open, setOpen] = useState(false);
+  return (
+    <Dialog open={open} onOpenChange={(next) => { setOpen(next); if (next) onOpen(); }}>
+      <DialogTrigger asChild>
+        <Button variant="ghost" size="sm" aria-label="Pet settings" className="w-full justify-start gap-2" disabled={!user}>
+          <RiSettings3Line size={16} />{!collapsed && "Pet settings"}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="z-[60] max-h-[85dvh] overflow-y-auto sm:max-w-lg">
+        <DialogTitle>Your pet companion</DialogTitle>
+        <DialogDescription>One little friend, everywhere in Loma. Saved just for you.</DialogDescription>
+        {user && <PetPicker key={user.email} initial={user.pet_preference ?? DEFAULT_PET} onSaved={() => { refresh(); setOpen(false); }} />}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function PetPicker({ initial, onSaved }: { initial: typeof DEFAULT_PET; onSaved: () => void }) {
+  const [draft, setDraft] = useState(initial);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+  // Ignore a response if the dialog closed or the authenticated account changed.
+  const mounted = useRef(true);
+  useEffect(() => { mounted.current = true; return () => { mounted.current = false; }; }, []);
+  async function save() {
+    setSaving(true);
+    setError("");
+    try {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_BASE_PATH || ""}/api/governance/me/pet`, {
+        method: "PATCH", headers: { "Content-Type": "application/json" }, body: JSON.stringify(draft),
+      });
+      if (!res.ok) throw new Error("Could not save your pet. Please try again.");
+      if (mounted.current) onSaved();
+    } catch (e) { if (mounted.current) setError(e instanceof Error ? e.message : "Could not save pet."); }
+    finally { if (mounted.current) setSaving(false); }
+  }
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 sm:grid-cols-5 gap-2" role="group" aria-label="Choose your pet">
+        {PETS.map((pet) => (
+          <button type="button" key={pet.id} disabled={saving} aria-pressed={draft.pet_id === pet.id}
+            onClick={() => setDraft({ ...draft, pet_id: pet.id })}
+            className="flex flex-col items-center gap-1 rounded-lg border border-border p-2 text-xs hover:bg-muted focus-visible:outline-2 focus-visible:outline-ring aria-pressed:border-primary aria-pressed:bg-accent disabled:opacity-50">
+            <PetSprite petId={pet.id} size={48} />{pet.name}
+          </button>
+        ))}
+      </div>
+      <div className="flex items-center gap-3 rounded-lg bg-muted p-3">
+        <PetSprite petId={draft.pet_id} size={48} state="working" animated={draft.animated} />
+        <div className="text-sm"><p className="font-medium">Your new sidekick</p><p className="text-xs text-muted-foreground">A quiet companion while you work.</p></div>
+      </div>
+      <label className="flex items-center gap-2 text-sm"><input type="checkbox" checked={draft.visible} disabled={saving} onChange={(e) => setDraft({ ...draft, visible: e.target.checked })} />Show my pet throughout Loma</label>
+      <label className="flex items-center gap-2 text-sm"><input type="checkbox" checked={draft.animated} disabled={saving} onChange={(e) => setDraft({ ...draft, animated: e.target.checked })} />Animate reactions</label>
+      <p className="text-xs text-muted-foreground">Your device’s reduced-motion setting is always respected.</p>
+      {error && <p role="alert" className="text-sm text-destructive">{error}</p>}
+      <Button onClick={save} disabled={saving}>{saving ? "Saving…" : "Save pet"}</Button>
+    </div>
+  );
+}

--- a/dashboard/src/components/PetCompanion.tsx
+++ b/dashboard/src/components/PetCompanion.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { createContext, useContext, useEffect, useRef, useState } from "react";
 import { useUser } from "@/lib/UserContext";
 import { Button } from "@/components/ui/button";
-import { Dialog, DialogContent, DialogDescription, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
-import { RiSettings3Line } from "@remixicon/react";
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
+
 
 // Original, code-native pixel sprites. Shared silhouettes keep every size crisp.
 const silhouettes = {
@@ -75,36 +75,53 @@ export function PetSprite({ petId, size = 40, state = "idle", animated = false }
   );
 }
 
-export default function PetCompanion({ size = 32, state = "idle", fallback = null }: {
-  size?: number; state?: PetState; fallback?: React.ReactNode;
+export default function PetCompanion({ size = 32, state = "idle", fallback = null, onOpen }: {
+  size?: number; state?: PetState; fallback?: React.ReactNode; onOpen?: () => void;
 }) {
   const { user } = useUser();
   const preference = user?.pet_preference ?? DEFAULT_PET;
   if (!user || !preference.visible) return <>{fallback}</>;
-  return <PetSprite petId={preference.pet_id} size={size} state={state} animated={preference.animated} />;
+  return <PetSettingsButton onOpen={onOpen}><PetSprite petId={preference.pet_id} size={size} state={state} animated={preference.animated} /></PetSettingsButton>;
 }
 
-/** A decorative lane in the composer, never over the messages or input controls. */
+const PetSettingsContext = createContext({ open: false, openSettings: () => {} });
+export const usePetSettings = () => useContext(PetSettingsContext).openSettings;
+export const usePetSettingsOpen = () => useContext(PetSettingsContext).open;
+
+function PetSettingsButton({ children, onOpen }: { children: React.ReactNode; onOpen?: () => void }) {
+  const openSettings = usePetSettings();
+  return (
+    <button type="button" aria-label="Pet settings" title="Pet settings" aria-haspopup="dialog"
+      className="inline-flex shrink-0 cursor-pointer rounded-sm focus-visible:outline-2 focus-visible:outline-ring"
+      onClick={(event) => { event.stopPropagation(); openSettings(); onOpen?.(); }}>
+      {children}
+    </button>
+  );
+}
+
+/** A separate lane above the composer; hover pauses motion to make the pet easy to catch. */
 export function PetRunway({ running }: { running: boolean }) {
   const { user } = useUser();
   const preference = user?.pet_preference ?? DEFAULT_PET;
   if (!user || !preference.visible) return null;
   return (
-    <div aria-hidden="true" className="pet-runway" data-running={running && preference.animated}>
+    <div className="pet-runway" data-running={running && preference.animated}>
       <div className="pet-track">
         <div className="pet-runner">
           <div className="pet-facing">
-            <PetSprite petId={preference.pet_id} size={32} state={running ? "working" : "attention"} animated={preference.animated} />
+            <PetCompanion size={32} state={running ? "working" : "attention"} />
           </div>
         </div>
       </div>
       <style jsx>{`
-        .pet-runway { height: 38px; overflow: hidden; pointer-events: none; user-select: none; }
+        .pet-runway { height: 38px; overflow: hidden; user-select: none; }
         .pet-track { width: calc(100% - 32px); padding-top: 4px; }
         .pet-runner { width: 100%; }
-        .pet-facing { width: 32px; height: 32px; }
+        .pet-facing { width: 32px; height: 32px; pointer-events: auto; }
         .pet-runway[data-running="true"] .pet-runner { animation: pet-run 8s linear infinite; }
         .pet-runway[data-running="true"] .pet-facing { animation: pet-turn 8s steps(1) infinite; }
+        .pet-runway:hover .pet-runner, .pet-runway:hover .pet-facing,
+        .pet-runway:focus-within .pet-runner, .pet-runway:focus-within .pet-facing { animation-play-state: paused; }
         @keyframes pet-run { 0%, 100% { transform: translateX(0); } 50% { transform: translateX(100%); } }
         @keyframes pet-turn { 0%, 100% { transform: scaleX(1); } 50% { transform: scaleX(-1); } }
         @media (prefers-reduced-motion: reduce) {
@@ -115,22 +132,31 @@ export function PetRunway({ running }: { running: boolean }) {
   );
 }
 
-export function PetSettings({ collapsed, onOpen }: { collapsed: boolean; onOpen: () => void }) {
+export function PetSettingsProvider({ children }: { children: React.ReactNode }) {
   const { user, refresh } = useUser();
   const [open, setOpen] = useState(false);
+  const opener = useRef<HTMLElement | null>(null);
   return (
-    <Dialog open={open} onOpenChange={(next) => { setOpen(next); if (next) onOpen(); }}>
-      <DialogTrigger asChild>
-        <Button variant="ghost" size="sm" aria-label="Pet settings" className="w-full justify-start gap-2" disabled={!user}>
-          <RiSettings3Line size={16} />{!collapsed && "Pet settings"}
-        </Button>
-      </DialogTrigger>
-      <DialogContent className="z-[60] max-h-[85dvh] overflow-y-auto sm:max-w-lg">
-        <DialogTitle>Your pet companion</DialogTitle>
-        <DialogDescription>One little friend, everywhere in Loma. Saved just for you.</DialogDescription>
-        {user && <PetPicker key={user.email} initial={user.pet_preference ?? DEFAULT_PET} onSaved={() => { refresh(); setOpen(false); }} />}
-      </DialogContent>
-    </Dialog>
+    <PetSettingsContext.Provider value={{ open, openSettings: () => {
+      opener.current = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+      if (opener.current?.getAttribute("role") === "menuitem") {
+        opener.current = document.querySelector<HTMLElement>('[data-slot="dropdown-menu-trigger"][data-state="open"]');
+      }
+      setOpen(true);
+    } }}>
+      {children}
+      <Dialog open={open && !!user} onOpenChange={setOpen}>
+        <DialogContent data-pet-settings="true" className="z-[60] max-h-[85dvh] overflow-y-auto sm:max-w-lg"
+          onCloseAutoFocus={(event) => {
+            event.preventDefault();
+            if (opener.current?.isConnected) opener.current.focus();
+          }}>
+          <DialogTitle>Your pet companion</DialogTitle>
+          <DialogDescription>One little friend, everywhere in Loma. Saved just for you.</DialogDescription>
+          {user && <PetPicker key={user.email} initial={user.pet_preference ?? DEFAULT_PET} onSaved={() => { refresh(); setOpen(false); }} />}
+        </DialogContent>
+      </Dialog>
+    </PetSettingsContext.Provider>
   );
 }
 

--- a/dashboard/src/components/PetCompanion.tsx
+++ b/dashboard/src/components/PetCompanion.tsx
@@ -52,7 +52,7 @@ export function PetSprite({ petId, size = 40, state = "idle", animated = false }
   const colors: Record<string, string> = { o: "#332f37", a: pet.coat, b: pet.patch, m: pet.id === "black-cat" ? "#626778" : "#f5e9cf", e: "#24232c", n: "#bb7681", p: "#dfa4a0" };
   return (
     <span aria-hidden="true" data-pet={pet.id} data-state={state} className="pet-sprite inline-flex shrink-0" data-animated={animated} style={{ width: size, height: size }}>
-      <svg width={size} height={size} viewBox="0 0 16 16" shapeRendering="crispEdges" focusable="false">
+      <svg className="size-full" width={size} height={size} viewBox="0 0 16 16" shapeRendering="crispEdges" focusable="false">
         {pixels.flatMap((row, y) => [...row].map((pixel, x) => {
           if (pixel === ".") return null;
           // Coat markings distinguish the cats without recoloring their eyes.

--- a/dashboard/src/components/Providers.tsx
+++ b/dashboard/src/components/Providers.tsx
@@ -7,6 +7,8 @@ import { TaskAttentionProvider } from "../lib/TaskAttentionContext";
 import { NotificationsProvider } from "../lib/NotificationsContext";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
+import { PetSettingsProvider } from "./PetCompanion";
+
 export default function Providers({ children }: { children: React.ReactNode }) {
   return (
     <SessionProvider>
@@ -15,7 +17,7 @@ export default function Providers({ children }: { children: React.ReactNode }) {
           <NotificationsProvider>
           <ThemeProvider>
             <TooltipProvider delayDuration={300}>
-              {children}
+              <PetSettingsProvider>{children}</PetSettingsProvider>
             </TooltipProvider>
           </ThemeProvider>
           </NotificationsProvider>

--- a/dashboard/src/components/Sidebar.tsx
+++ b/dashboard/src/components/Sidebar.tsx
@@ -10,6 +10,7 @@ import { useUser } from "../lib/UserContext";
 import { useTaskAttention } from "../lib/TaskAttentionContext";
 import { useNotifications } from "../lib/NotificationsContext";
 import type { SystemRole } from "../lib/governance-api";
+import PetCompanion, { PetSettings } from "./PetCompanion";
 import CrosscutIcon from "./CrosscutIcon";
 import ChatContextMenu from "./ChatContextMenu";
 import { useTheme } from "../lib/ThemeContext";
@@ -431,7 +432,7 @@ export default function Sidebar({
       {/* Logo + collapse toggle + close button */}
       <div className={cn("flex items-center justify-between", collapsed ? "flex-col gap-1 px-2 pt-2 pb-1" : "px-3 pt-3 pb-2")}>
         <Link href="/tasks" prefetch onClick={onClose} className={cn("flex items-center gap-2", collapsed && "justify-center")}>
-          <CrosscutIcon size={collapsed ? 22 : 20} />
+          <PetCompanion size={32} fallback={<CrosscutIcon size={collapsed ? 22 : 20} />} />
           {!collapsed && (
             <span className="font-[family-name:var(--font-logo)] text-base font-bold tracking-[0.5px] text-foreground/80">
               Loma
@@ -656,6 +657,7 @@ export default function Sidebar({
             {/* Pool status — expandable */}
             {poolStatus && <PoolStatusWidget poolStatus={poolStatus} collapsed={collapsed} />}
 
+            <div className="px-2"><PetSettings collapsed={collapsed} onOpen={onClose} /></div>
             {/* Theme toggle */}
             <div className="px-2.5 py-1">
               {collapsed ? (

--- a/dashboard/src/components/Sidebar.tsx
+++ b/dashboard/src/components/Sidebar.tsx
@@ -10,7 +10,7 @@ import { useUser } from "../lib/UserContext";
 import { useTaskAttention } from "../lib/TaskAttentionContext";
 import { useNotifications } from "../lib/NotificationsContext";
 import type { SystemRole } from "../lib/governance-api";
-import PetCompanion, { PetSettings } from "./PetCompanion";
+import PetCompanion, { usePetSettings } from "./PetCompanion";
 import CrosscutIcon from "./CrosscutIcon";
 import ChatContextMenu from "./ChatContextMenu";
 import { useTheme } from "../lib/ThemeContext";
@@ -427,18 +427,20 @@ export default function Sidebar({
     return () => clearInterval(interval);
   }, []);
 
+  const openPetSettings = usePetSettings();
+
   const sidebarContent = (
     <>
       {/* Logo + collapse toggle + close button */}
       <div className={cn("flex items-center justify-between", collapsed ? "flex-col gap-1 px-2 pt-2 pb-1" : "px-3 pt-3 pb-2")}>
-        <Link href="/tasks" prefetch onClick={onClose} className={cn("flex items-center gap-2", collapsed && "justify-center")}>
-          <PetCompanion size={32} fallback={<CrosscutIcon size={collapsed ? 22 : 20} />} />
+        <div className={cn("flex items-center gap-2", collapsed && "justify-center")}>
+          <PetCompanion size={32} onOpen={onClose} fallback={<Link href="/tasks" prefetch onClick={onClose} aria-label="Loma home"><CrosscutIcon size={collapsed ? 22 : 20} /></Link>} />
           {!collapsed && (
-            <span className="font-[family-name:var(--font-logo)] text-base font-bold tracking-[0.5px] text-foreground/80">
+            <Link href="/tasks" prefetch onClick={onClose} className="font-[family-name:var(--font-logo)] text-base font-bold tracking-[0.5px] text-foreground/80">
               Loma
-            </span>
+            </Link>
           )}
-        </Link>
+        </div>
         <div className="flex items-center gap-0.5">
           <Button
             variant="ghost"
@@ -657,7 +659,6 @@ export default function Sidebar({
             {/* Pool status — expandable */}
             {poolStatus && <PoolStatusWidget poolStatus={poolStatus} collapsed={collapsed} />}
 
-            <div className="px-2"><PetSettings collapsed={collapsed} onOpen={onClose} /></div>
             {/* Theme toggle */}
             <div className="px-2.5 py-1">
               {collapsed ? (
@@ -721,7 +722,7 @@ export default function Sidebar({
                 <div className={cn("px-2.5 py-2", collapsed && "flex justify-center")}>
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
-                      <button className={cn(
+                      <button aria-label="Account menu" className={cn(
                         "flex items-center w-full rounded-lg transition-colors hover:bg-muted",
                         collapsed ? "justify-center p-1" : "gap-2 px-1 py-1"
                       )}>
@@ -746,6 +747,9 @@ export default function Sidebar({
                       </button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent side="top" align="start" className="w-[180px]">
+                      <DropdownMenuItem onSelect={() => { openPetSettings(); onClose(); }}>
+                        <RiSettings3Line size={16} />Pet settings
+                      </DropdownMenuItem>
                       {userMenuNav.filter((item) => !item.minRole || hasRole(item.minRole)).map((item) => (
                         <DropdownMenuItem key={item.href} asChild>
                           <Link href={item.href} onClick={onClose} className="flex items-center gap-2 text-[13px]">

--- a/dashboard/src/components/composer/DictationButton.tsx
+++ b/dashboard/src/components/composer/DictationButton.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import PetCompanion from "../PetCompanion";
 import { useEffect, useRef } from "react";
 import { RiLoader4Line, RiMicLine, RiStopFill } from "@remixicon/react";
 import { Button } from "@/components/ui/button";
@@ -75,12 +76,15 @@ export function DictationButton({ onText, disabled, mobileProminent, className }
         <span className="text-xs tabular-nums">
           {Math.floor(seconds / 60)}:{String(seconds % 60).padStart(2, "0")}
         </span>
+        <PetCompanion size={24} state="listening" />
         <RiStopFill size={16} />
       </Button>
     );
   }
 
   return (
+    <>
+    {state === "transcribing" && <PetCompanion size={24} state="working" />}
     <Button
       ref={buttonRef}
       type="button"
@@ -102,5 +106,6 @@ export function DictationButton({ onText, disabled, mobileProminent, className }
         ? <RiLoader4Line size={16} className="animate-spin" />
         : <RiMicLine size={16} />}
     </Button>
+    </>
   );
 }

--- a/dashboard/src/components/composer/DictationButton.tsx
+++ b/dashboard/src/components/composer/DictationButton.tsx
@@ -55,6 +55,8 @@ export function DictationButton({ onText, disabled, mobileProminent, className }
 
   if (state === "recording") {
     return (
+      <>
+      <PetCompanion size={24} state="listening" />
       <Button
         ref={buttonRef}
         type="button"
@@ -76,9 +78,9 @@ export function DictationButton({ onText, disabled, mobileProminent, className }
         <span className="text-xs tabular-nums">
           {Math.floor(seconds / 60)}:{String(seconds % 60).padStart(2, "0")}
         </span>
-        <PetCompanion size={24} state="listening" />
         <RiStopFill size={16} />
       </Button>
+      </>
     );
   }
 

--- a/dashboard/src/components/tasks/TaskChatDrawer.tsx
+++ b/dashboard/src/components/tasks/TaskChatDrawer.tsx
@@ -6,6 +6,7 @@ import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import { usePetSettingsOpen } from "@/components/PetCompanion";
 import ChatWithArtifacts from "@/components/ChatWithArtifacts";
 import { rebuildItemsFromConversation, type ChatItem } from "@/components/ChatPanel";
 import type { Artifact } from "@/components/ArtifactViewer";
@@ -154,10 +155,17 @@ export function TaskChatDrawer({
     }, 4000);
   }, []);
 
+  const petSettingsOpen = usePetSettingsOpen();
+
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent
         side="right"
+        onInteractOutside={(event) => {
+          // A closing picker can dispatch its outside event after open becomes false.
+          if (petSettingsOpen || (event.target instanceof Element && event.target.closest("[data-pet-settings]"))) event.preventDefault();
+        }}
+        onEscapeKeyDown={(event) => { if (petSettingsOpen) event.preventDefault(); }}
         className="gap-0 p-0 data-[side=right]:w-full data-[side=right]:sm:max-w-[min(1100px,92vw)]"
       >
         <div className="flex flex-shrink-0 items-center gap-1 border-b border-border py-2.5 pl-4 pr-12">

--- a/dashboard/src/lib/governance-api.ts
+++ b/dashboard/src/lib/governance-api.ts
@@ -15,6 +15,7 @@ export interface User {
   system_role: SystemRole;
   status?: "active" | "pending" | "rejected";
   tool_assignments: Record<string, ToolAssignment>;
+  pet_preference?: { pet_id: string; visible: boolean; animated: boolean };
   theme_preference?: "light" | "dark" | "system";
   pinned_conversations?: Array<{ conversation_id: string; pinned_at: string }>;
   claude_connected?: boolean;

--- a/scripts/browser/pet-runway.cjs
+++ b/scripts/browser/pet-runway.cjs
@@ -1,0 +1,90 @@
+// Run against the isolated run-loma-local stack, never production.
+// NODE_PATH=<directory containing playwright> LOMA_SETUP_TOKEN=... PET_TEST_PASSWORD=... node scripts/browser/pet-runway.cjs
+const { chromium } = require('playwright');
+const assert = require('node:assert/strict');
+
+(async () => {
+  const browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: { width: 1440, height: 1000 } });
+  page.setDefaultTimeout(20000);
+  const errors = [];
+  page.on('pageerror', e => errors.push(e.message));
+  let status = 'running';
+  const id = 'pet-runway-fixture';
+  await page.route('**/api/tasks', async route => {
+    const response = await route.fetch();
+    const data = await response.json();
+    data.tasks = [{ conversation_id: id, title: 'Pet runway test', column: 'working', status, task_tag_ids: [], total_turns: 0 }];
+    data.counts = { working: 1 };
+    await route.fulfill({ response, json: data });
+  });
+  await page.route(`**/api/conversations/${id}`, route => route.fulfill({ json: {
+    conversation: { conversation_id: id, prompt: 'Review the launch checklist', status,
+      messages: [{ role: 'user', content: 'Review the launch checklist' }, { role: 'assistant', content: 'Checking the launch checklist now.' }] },
+    turns: [], artifacts: [],
+  } }));
+  await page.goto('http://localhost:13001/login');
+  await page.fill('#signin-email', 'pet-runway@example.com');
+  await page.fill('#signin-password', process.env.PET_TEST_PASSWORD);
+  await page.fill('#setup-token', process.env.LOMA_SETUP_TOKEN);
+  await page.click('button[type=submit]');
+  await page.waitForURL('**/tasks');
+  async function preference(visible = true, animated = true) {
+    const response = await page.request.patch('http://localhost:13001/api/governance/me/pet', {
+      data: { pet_id: 'corgi', visible, animated },
+    });
+    assert.equal(response.status(), 200);
+    await page.reload();
+  }
+  async function openTask() {
+    await page.getByText('Pet runway test', { exact: true }).first().click();
+    await page.locator('[role=dialog] textarea').waitFor();
+  }
+  const lane = page.locator('[role=dialog] .pet-runway');
+  const sprite = lane.locator('[data-pet=corgi]');
+  await preference();
+  await openTask();
+  await sprite.waitFor();
+  const a = await sprite.boundingBox();
+  await page.waitForTimeout(700);
+  const b = await sprite.boundingBox();
+  assert.ok(Math.abs(a.x - b.x) > 15, 'pet travels horizontally');
+  const input = page.locator('[role=dialog] textarea');
+  const box = await input.boundingBox();
+  assert.ok(b.y + b.height <= box.y, 'pet is above the input');
+  assert.equal(await lane.evaluate(el => getComputedStyle(el).pointerEvents), 'none');
+  await input.fill('A follow-up draft while my pet runs');
+  assert.equal(await input.inputValue(), 'A follow-up draft while my pet runs');
+  // Sample both ends of the path and its return without waiting a full cycle.
+  for (const time of [0, 3990, 4010, 7990]) {
+    await lane.evaluate((el, t) => el.getAnimations({ subtree: true }).forEach(a => { a.pause(); a.currentTime = t; }), time);
+    const pet = await sprite.boundingBox();
+    const track = await lane.boundingBox();
+    assert.ok(pet.x >= track.x - 1 && pet.x + pet.width <= track.x + track.width + 1, 'pet stays within lane');
+  }
+  await lane.evaluate(el => el.getAnimations({ subtree: true }).forEach(a => a.play()));
+  await page.screenshot({ path: '/tmp/loma-pet-runway-desktop.png', fullPage: true });
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+  assert.equal(await lane.evaluate(el => el.getAnimations({ subtree: true }).length), 0);
+  await page.emulateMedia({ reducedMotion: 'no-preference' });
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.waitForTimeout(500);
+  const mobileLane = await lane.boundingBox();
+  assert.ok(mobileLane.x >= 0 && mobileLane.x + mobileLane.width <= 390);
+  await input.fill('Mobile draft');
+  await page.screenshot({ path: '/tmp/loma-pet-runway-mobile.png', fullPage: true });
+  await page.setViewportSize({ width: 1440, height: 1000 });
+  for (const terminal of ['needs_input', 'completed', 'error', 'interrupted']) {
+    status = terminal;
+    await lane.waitFor({ state: 'hidden' });
+    status = 'running';
+    await page.reload(); await openTask(); await sprite.waitFor();
+  }
+  await preference(true, false); await openTask(); await sprite.waitFor();
+  assert.equal(await lane.evaluate(el => el.getAnimations({ subtree: true }).length), 0);
+  await preference(false); await openTask();
+  assert.equal(await lane.count(), 0);
+  assert.deepEqual(errors, []);
+  console.log('PASS: running movement, lane bounds/turnaround, input interaction, reduced motion, mobile, needs input/completion/error/interruption, animation off, hidden pet, no page errors');
+  await browser.close();
+})().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/browser/pet-runway.cjs
+++ b/scripts/browser/pet-runway.cjs
@@ -52,7 +52,6 @@ const assert = require('node:assert/strict');
   const input = page.locator('[role=dialog] textarea');
   const box = await input.boundingBox();
   assert.ok(b.y + b.height <= box.y, 'pet is above the input');
-  assert.equal(await lane.evaluate(el => getComputedStyle(el).pointerEvents), 'none');
   await input.fill('A follow-up draft while my pet runs');
   assert.equal(await input.inputValue(), 'A follow-up draft while my pet runs');
   // Sample both ends of the path and its return without waiting a full cycle.

--- a/scripts/browser/pet-settings.cjs
+++ b/scripts/browser/pet-settings.cjs
@@ -1,0 +1,104 @@
+// Run against the isolated run-loma-local stack, never production.
+// NODE_PATH=<directory containing playwright> LOMA_SETUP_TOKEN=... PET_TEST_PASSWORD=... node scripts/browser/pet-runway.cjs
+const { chromium } = require('playwright');
+const assert = require('node:assert/strict');
+
+(async () => {
+  const browser = await chromium.launch({args:['--use-fake-ui-for-media-stream','--use-fake-device-for-media-stream']});
+  const page = await browser.newPage({ permissions:['microphone'], viewport: { width: 1440, height: 1000 } });
+  page.setDefaultTimeout(20000);
+  const errors = [];
+  page.on('pageerror', e => errors.push(e.message));
+  let status = 'running';
+  const id = 'pet-runway-fixture';
+  await page.route('**/api/tasks', async route => {
+    const response = await route.fetch();
+    const data = await response.json();
+    data.tasks = [{ conversation_id: id, title: 'Pet runway test', column: 'working', status, task_tag_ids: [], total_turns: 0 }];
+    data.counts = { working: 1 };
+    await route.fulfill({ response, json: data });
+  });
+  await page.route(`**/api/conversations/${id}`, route => route.fulfill({ json: {
+    conversation: { conversation_id: id, prompt: 'Review the launch checklist', status,
+      messages: [{ role: 'user', content: 'Review the launch checklist' }, { role: 'assistant', content: 'Checking the launch checklist now.' }] },
+    turns: [], artifacts: [],
+  } }));
+  await page.goto('http://localhost:13001/login');
+  await page.fill('#signin-email', 'pet-runway@example.com');
+  await page.fill('#signin-password', process.env.PET_TEST_PASSWORD);
+  await page.fill('#setup-token', process.env.LOMA_SETUP_TOKEN);
+  await page.click('button[type=submit]');
+  await page.waitForURL('**/tasks');
+  async function preference(visible = true, animated = true) {
+    const response = await page.request.patch('http://localhost:13001/api/governance/me/pet', {
+      data: { pet_id: 'corgi', visible, animated },
+    });
+    assert.equal(response.status(), 200);
+    await page.reload();
+  }
+  const picker = page.getByRole('dialog', { name: 'Your pet companion' });
+  const closePicker = async () => { await picker.getByRole('button', { name: 'Close', exact: true }).click(); await picker.waitFor({state:'detached'}); };
+  await page.getByRole('button', {name:'Account menu'}).click();
+  await page.getByRole('menuitem', {name:'Pet settings',exact:true}).waitFor();
+  await page.waitForTimeout(300);
+  await page.screenshot({path:'/tmp/pet-settings-menu.png'});
+  await page.getByRole('menuitem', {name:'Pet settings',exact:true}).click();
+  await picker.waitFor();
+  await picker.getByRole('button',{name:'Corgi',exact:true}).click();
+  await picker.getByRole('button',{name:'Save pet'}).click();
+  await picker.waitFor({state:'detached'});
+  await page.reload();
+  // Every companion is a native button, without nested links/buttons.
+  const pets = page.getByRole('button',{name:'Pet settings',exact:true});
+  await pets.nth(1).waitFor();
+  assert.ok(await pets.count() >= 2);
+  for (let i=0; i<await pets.count(); i++) {
+    assert.equal(await pets.nth(i).evaluate(e => !!e.parentElement.closest('button,a')),false);
+    await pets.nth(i).click(); await picker.waitFor(); await closePicker();
+  }
+  await pets.last().focus(); await page.keyboard.press('Enter'); await picker.waitFor();
+  await page.keyboard.press('Escape'); await picker.waitFor({state:'detached'});
+  assert.ok(await pets.last().evaluate(e => e===document.activeElement));
+  await page.getByText('Pet runway test',{exact:true}).first().click();
+  const input=page.locator('[role=dialog] textarea'); await input.waitFor();
+  await input.fill('Keep this draft while changing my pet');
+  const runner=page.locator('.pet-runway').getByRole('button',{name:'Pet settings'});
+  const laneBox = await page.locator(".pet-runway").boundingBox();
+  await page.mouse.move(laneBox.x + 16, laneBox.y + 16);
+  const petBox = await runner.boundingBox();
+  await page.mouse.move(petBox.x + 16, petBox.y + 16);
+  await page.mouse.click(petBox.x + 16, petBox.y + 16); await picker.waitFor();
+  await page.waitForTimeout(300);
+  await page.screenshot({path:'/tmp/pet-settings-drawer.png'});
+  await picker.getByRole('button',{name:'Rabbit',exact:true}).click();
+  await picker.getByRole('button',{name:'Save pet'}).click(); await picker.waitFor({state:'detached'});
+  assert.equal(await input.inputValue(),'Keep this draft while changing my pet');
+  await runner.locator('[data-pet=rabbit]').waitFor();
+  await runner.focus(); await page.keyboard.press('Space'); await picker.waitFor();
+  await closePicker(); assert.ok(await runner.evaluate(e => e===document.activeElement));
+  await page.setViewportSize({width:390,height:844});
+  await runner.focus(); await runner.click(); await picker.waitFor();
+  await page.waitForTimeout(300);
+  await page.screenshot({path:'/tmp/pet-settings-mobile.png'});
+  await closePicker(); await input.fill('Mobile input still works');
+  await page.reload();
+  // Hidden users can always recover the pet from the account menu.
+  await preference(false);
+  await page.setViewportSize({width:1440,height:1000});
+  await page.getByRole('button',{name:'Account menu'}).click();
+  await page.getByRole('menuitem',{name:'Pet settings',exact:true}).click(); await picker.waitFor();
+  await picker.getByRole('checkbox',{name:'Show my pet throughout Loma'}).check();
+  await picker.getByRole('button',{name:'Save pet'}).click(); await picker.waitFor({state:'detached'});
+  await pets.first().waitFor();
+  await page.goto('http://localhost:13001/chat');
+  await page.getByRole('button',{name:'Start dictation',exact:true}).click();
+  const listening=page.locator('button[aria-label="Pet settings"]').filter({has:page.locator('[data-state=listening]')});
+  await listening.waitFor(); await listening.click(); await picker.waitFor(); await closePicker();
+  await page.getByRole('button',{name:'Stop dictation and transcribe',exact:true}).waitFor();
+  await page.route('**/api/transcribe',r=>r.fulfill({json:{text:'Local voice test'}}));
+  await page.getByRole('button',{name:'Stop dictation and transcribe',exact:true}).click();
+  await page.getByRole('button',{name:'Start dictation',exact:true}).waitFor();
+  assert.deepEqual(errors,[]);
+  console.log('PASS: account menu, all board/sidebar pets, keyboard/focus, running drawer picker, draft preservation, mobile, hidden-pet recovery, listening pet without stopping recording; no page errors');
+  await browser.close();
+})().catch(e=>{console.error(e);process.exit(1)});

--- a/tests/test_pet_preferences.py
+++ b/tests/test_pet_preferences.py
@@ -1,0 +1,81 @@
+"""Own-profile pet persistence and strict validation, without a live database."""
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from api.governance_routes import VALID_PETS, handle_update_my_pet
+
+
+class Request(dict):
+    def __init__(self, body, email="alice@example.com"):
+        super().__init__(user_email=email)
+        self.body = body
+
+    async def json(self):
+        return self.body
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("pet", VALID_PETS)
+async def test_save_only_authenticated_user(pet):
+    db = MagicMock()
+    db.users.update_one = AsyncMock(return_value=MagicMock(matched_count=1))
+    body = {"pet_id": pet, "visible": False, "animated": False}
+    with patch("api.governance_routes.get_db", return_value=db):
+        response = await handle_update_my_pet(Request(body))
+    assert response.status == 200
+    assert json.loads(response.body) == body
+    args = db.users.update_one.call_args.args
+    assert args[0] == {"email": "alice@example.com"}
+    assert args[1]["$set"]["pet_preference"] == body
+    assert set(args[1]["$set"]) == {"pet_preference", "updated_at"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("body", [None, [], {}, {"pet_id": "cat"},
+    {"pet_id": [], "visible": True, "animated": True},
+    {"pet_id": "unknown", "visible": True, "animated": True},
+    {"pet_id": "tabby", "visible": 1, "animated": True},
+    {"pet_id": "tabby", "visible": True, "animated": "false"},
+    {"pet_id": "tabby", "visible": True, "animated": True, "email": "bob@example.com"},
+])
+async def test_invalid_preferences_never_write(body):
+    with patch("api.governance_routes.get_db") as get_db:
+        response = await handle_update_my_pet(Request(body))
+    assert response.status == 400
+    get_db.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated():
+    with patch("api.governance_routes.get_db") as get_db:
+        response = await handle_update_my_pet(Request({}, email=""))
+    assert response.status == 401
+    get_db.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_malformed_json():
+    request = Request(None)
+    request.json = AsyncMock(side_effect=ValueError("Invalid JSON"))
+    assert (await handle_update_my_pet(request)).status == 400
+
+
+@pytest.mark.asyncio
+async def test_missing_user_and_unavailable_db():
+    body = {"pet_id": "tabby", "visible": True, "animated": True}
+    with patch("api.governance_routes.get_db", return_value=None):
+        assert (await handle_update_my_pet(Request(body))).status == 503
+    db = MagicMock()
+    db.users.update_one = AsyncMock(return_value=MagicMock(matched_count=0))
+    with patch("api.governance_routes.get_db", return_value=db):
+        assert (await handle_update_my_pet(Request(body))).status == 404
+
+
+def test_frontend_pet_catalog_matches_api():
+    from pathlib import Path
+    import re
+
+    source = (Path(__file__).parents[1] / "dashboard/src/components/PetCompanion.tsx").read_text()
+    assert set(re.findall(r'\{ id: "([a-z-]+)", name:', source)) == set(VALID_PETS)


### PR DESCRIPTION
## Summary
- Add a personal **Pet settings** picker in the account menu: tabby, tuxedo, black and calico cats; corgi, golden retriever and dachshund dogs; rabbit, hamster and parrot.
- Save the selection, visibility and animation preferences on the authenticated user's profile. Reuse the selected pet in navigation, taskboard, chat, dictation and shared empty states, without replacing agent identities.
- Use original code-native pixel SVG sprites, with working, listening, attention and brief completion reactions. Respect reduced motion and retain functional icons when pets are hidden.

## Implementation
- `PATCH /api/governance/me/pet` validates an allowlisted pet and strict boolean controls. The target account comes only from authenticated request identity; unknown fields and identity injection are rejected.
- No migration required. Existing users default to an animated tabby; idle pets remain still. Preferences are read from the existing current-user API, not browser storage.
- Settings are shared across roles, including chatter. Saves show a retryable error on failure. Mobile navigation closes when the settings dialog opens.
- Completion animation happens only when an already-observed task enters Done, not when loading historical completed tasks. Dictation keeps the recording timer, stop button and transcription spinner explicit.

## Testing
- `python -m pytest tests/test_pet_preferences.py -q`: **23 passed**. Covers all pet IDs, strict validation, authenticated-user scoping, malformed JSON, missing account/DB and frontend/backend catalog parity.
- `cd dashboard && npx tsc --noEmit`: passed.
- Targeted ESLint for `PetCompanion.tsx`, `tasks/page.tsx` and `DictationButton.tsx`: passed.
- Booted the Python backend and Next.js dashboard locally with a fresh throwaway database, local setup-token login, and Slack/scheduler disabled.
- Playwright: all 10 choices, save/reload, fresh browser persistence, two-account isolation, chatter access, rejected identity injection, retryable save failure, hidden pets, disabled animations, reduced motion, mobile picker. No page errors in the main browser suite.
- Verified working -> completed -> idle and needs-input reactions with a controlled taskboard response fixture. No real agent tasks were launched.
- Verified listening -> transcribing -> idle with Chromium's fake microphone and a stubbed transcription response. No recording was sent to a transcription provider.

## Testing screenshots
### Desktop picker
![Pet picker](https://cdn.plotline.so/loma-images/f642fc92f302449ab54691fd874dc4db.png)

### Saved corgi on the taskboard
![Saved pet](https://cdn.plotline.so/loma-images/f4f24e1b83744dd8a7d2d4e3eed23da5.png)

### Mobile settings
<img src="https://cdn.plotline.so/loma-images/bbf9f53ea5744164890849ed5878ce2e.png" width="390" alt="Mobile pet settings" />

### Chat and recording reaction
![Listening pet](https://cdn.plotline.so/loma-images/0d8bd385ea0c40a6939503dd74999299.png)

## Notes
- Built by Loma from Adarsh's approved scope. Draft for human review; not merged.
- The pet is a personal companion, not an agent avatar or a substitute for actual status text.


## Follow-up: pet runway above the composer
- Replace the top-of-chat working pet with a small lane directly above the composer, including the taskboard's chat drawer.
- The selected pet runs back and forth and turns at each edge while streaming or recovering a running task. Pending clarification pauses movement; leaving the running state removes the lane.
- Reuses saved pet preferences, with no extra controls or API changes. Hidden pets leave no blank lane; animation-off and reduced-motion users see a stationary pet.

### Follow-up verification
- TypeScript check and targeted PetCompanion ESLint: passed. Existing backend pet tests: **23 passed**.
- Added reproducible browser regression script: `scripts/browser/pet-runway.cjs`.
- Booted the real local backend/dashboard against a fresh throwaway DB with Slack and scheduler disabled. Logged in through setup-token auth. Task/conversation responses were controlled browser fixtures; no agent work was submitted.
- Browser checks passed: horizontal motion, both lane edges, typing during motion, desktop/mobile placement, reduced motion, animation disabled, hidden pet, and stopping on needs-input/completed/error/interrupted statuses. No page errors.

### Task drawer, desktop
![Pet running above the task input](https://cdn.plotline.so/loma-images/85bfac2cd53949ac98ac55a5d0cb26cc.png)

### Task drawer, mobile
<img src="https://cdn.plotline.so/loma-images/59ecbe816b494263b2c181ffb1cbf5bd.png" width="390" alt="Pet above the input in the mobile task drawer" />


## Follow-up: discoverable pet settings
- Move Pet settings from the persistent sidebar row into the account menu.
- All companion pets are keyboard-accessible buttons opening one shared picker, including taskboard, navigation, chat messages, empty states, listening/transcribing pets, and the composer runway.
- Pause runway travel on hover/focus so the pet is easy to catch. Its dedicated lane stays above typing controls.
- Keep the recording stop button separate from the pet button. Opening pet settings does not stop recording.
- Preserve the task drawer and unsent draft when changing or closing pet settings; restore keyboard focus to the opener.

### Verification
- Added `scripts/browser/pet-settings.cjs`: account menu, board/sidebar pets, native button semantics, Enter/Space/Escape and focus restoration, mouse activation of the running pet, save persistence, task draft preservation, desktop/mobile picker, hidden-pet recovery, and listening pet with fake microphone/stubbed transcription. Passed with no page errors.
- Reran `scripts/browser/pet-runway.cjs`: movement, bounds, typing, mobile, reduced motion, animation-off, hidden pets, and terminal/needs-input states all passed.
- TypeScript and targeted ESLint passed. Backend preference tests: **23 passed**.
- Real isolated local backend + dashboard, setup-token authentication, fresh throwaway database, Slack/scheduler disabled. Task responses are controlled fixtures; no real agent tasks launched.

### Account menu (no extra sidebar row)
![Account menu pet settings](https://cdn.plotline.so/loma-images/7af1e1cf8a2442649c9e1c55ab48a5e1.png)

### Picker opened from the task drawer pet
![Pet picker over task drawer](https://cdn.plotline.so/loma-images/fc31743d3d7347f4a5879f68b7419df6.png)

### Mobile picker
<img src="https://cdn.plotline.so/loma-images/843559ebeded46cbb869b0b1174c3eb6.png" width="390" alt="Pet picker opened above the mobile task drawer" />
