### PR TITLE
feat: refresh the whole Loma dashboard with the botanical brand theme

### DIFF
--- a/dashboard/DESIGN.md
+++ b/dashboard/DESIGN.md
@@ -12,6 +12,12 @@ Every element on screen must earn its place. If removing something doesn't hurt 
 
 ---
 
+## Preserve Loma identity
+
+- Theme refreshes must retain the existing `CrosscutIcon` logo and Red Hat Display `Loma` wordmark unless a logo change is explicitly requested.
+- Keep pet companions, the composer runway, and pet settings intact. Respect each user's visibility and animation preferences.
+- Verify and screenshot the default pet-enabled experience on desktop, mobile, and dark mode, as well as the original logo fallback with pets hidden. Do not hide pets just to match a design reference.
+
 ## Rules
 
 ### 1. Every word earns its place

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -867,11 +867,10 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -1071,11 +1070,10 @@
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "1.19.17",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.17.tgz",
+      "integrity": "sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
       },
@@ -1084,25 +1082,36 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
-      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
       "engines": {
         "node": ">=18.18.0"
       }
@@ -1163,14 +1172,13 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
-      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.4.tgz",
+      "integrity": "sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -1182,18 +1190,17 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.3.2"
+        "@img/sharp-libvips-darwin-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
-      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.4.tgz",
+      "integrity": "sha512-hWniXY3bG5qKpkKrAwPe4y+VTPmf086YQAnkxWh7uA1YrlRouWGa0M0Mxj3ZjnXFkv7/TD1bTy9lGUK26vRvWw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -1205,21 +1212,20 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.3.2"
+        "@img/sharp-libvips-darwin-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-freebsd-wasm32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
-      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.4.tgz",
+      "integrity": "sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==",
       "dev": true,
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "freebsd"
       ],
       "dependencies": {
-        "@img/sharp-wasm32": "0.35.3"
+        "@img/sharp-wasm32": "0.35.4"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -1229,14 +1235,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
-      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.3.tgz",
+      "integrity": "sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "darwin"
@@ -1246,14 +1251,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
-      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.3.tgz",
+      "integrity": "sha512-FVJZ5mITMobmXIz/hPDTw0EintTW5H3WfrxwLqEqjiIihlu+hVRyGrFQ60xl0Lxn7Bt3zdpevPaQi0HEzqz9fw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "darwin"
@@ -1263,14 +1267,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
-      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.3.tgz",
+      "integrity": "sha512-3rbU4vqXXc3hY/OiXdl52xZvT0F1yEngWfvqudtPJg/KkyiaQw2DRsFrNzpmLvfavbwOq3qXn36GP8obHRULQA==",
       "cpu": [
         "arm"
       ],
       "dev": true,
-      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -1280,14 +1283,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
-      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.3.tgz",
+      "integrity": "sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -1297,14 +1299,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
-      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.3.tgz",
+      "integrity": "sha512-cdn1OvUBwsXhbC0zSzJnNzf5MZ/mTrobawDvNXBTxe8VtqKAm0sRuEY2Evzovb/w9JMk4TvRxqt1mekSuJz64w==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -1314,14 +1315,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
-      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.3.tgz",
+      "integrity": "sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
-      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -1331,14 +1331,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
-      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.3.tgz",
+      "integrity": "sha512-neWLh+3yCNThxnfy3c4BbVBeGgt9aftno+XbT56iK28RgeDs3UOFWviLWlUu0bArYVYJaFDK+RRohbicUNCm8Q==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
-      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -1348,14 +1347,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
-      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.3.tgz",
+      "integrity": "sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -1365,14 +1363,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
-      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.3.tgz",
+      "integrity": "sha512-Y9kQaLMuNoB0bPYOOdcZMaseNrFpPodIWWMrx+CZyydf2xn68j9WYc6sWWRrDwNkzCQjKYfc68L7jKjGlHMibw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -1382,14 +1379,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
-      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.3.tgz",
+      "integrity": "sha512-fj8Mv0HHfD1Rr+4I68+3agJynxDWtBFgicTbSOb9Bke6pIwzGcJ+RX/yHjmiEGFMCavY/dxvem7MyNaJF+wDiw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -1399,14 +1395,13 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
-      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.4.tgz",
+      "integrity": "sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==",
       "cpu": [
         "arm"
       ],
       "dev": true,
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -1418,18 +1413,17 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.3.2"
+        "@img/sharp-libvips-linux-arm": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
-      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.4.tgz",
+      "integrity": "sha512-De4jpEnAU8Hd5oT0j1G3uL4ZvTuipVMn7YC6vPaJhy6/7EwEae0SVAoBrUMYQbkLGDm85taVWwuPc1a44LTzCQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -1441,18 +1435,17 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.3.2"
+        "@img/sharp-libvips-linux-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
-      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.4.tgz",
+      "integrity": "sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -1464,18 +1457,17 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.3.2"
+        "@img/sharp-libvips-linux-ppc64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
-      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.4.tgz",
+      "integrity": "sha512-cPbNChoRURAWdebDIHSenxRpgEdy7JkPydSnUxRm9VvKD7m0/xVaR/8Fzlu81pk5nHEvHH87UZUA7cTtwnbJSA==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -1487,18 +1479,17 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.3.2"
+        "@img/sharp-libvips-linux-riscv64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
-      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.4.tgz",
+      "integrity": "sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -1510,18 +1501,17 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.3.2"
+        "@img/sharp-libvips-linux-s390x": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
-      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.4.tgz",
+      "integrity": "sha512-9qvvEAuk8k89TfWUoX2htWjbAMX8p+NxCppjpcg5k6xMsjhBQPTsoIh36h9Qde4WRuGpJeYnOjdosDn/cnv+OA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -1533,18 +1523,17 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.3.2"
+        "@img/sharp-libvips-linux-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
-      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.4.tgz",
+      "integrity": "sha512-KB5jxpfWQTr0nc3xdHtWChdbifHrBGsd2SM62Eyxrl8afikm+f5qGBU75SJIZBT/S1MC8XyacdlXBMSWq6OURA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -1556,18 +1545,17 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
-      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.4.tgz",
+      "integrity": "sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -1579,18 +1567,17 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
-      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.4.tgz",
+      "integrity": "sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==",
       "dev": true,
-      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.11.1"
+        "@emnapi/runtime": "^1.11.3"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -1600,17 +1587,16 @@
       }
     },
     "node_modules/@img/sharp-webcontainers-wasm32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
-      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.4.tgz",
+      "integrity": "sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==",
       "cpu": [
         "wasm32"
       ],
       "dev": true,
-      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@img/sharp-wasm32": "0.35.3"
+        "@img/sharp-wasm32": "0.35.4"
       },
       "engines": {
         "node": ">=20.9.0"
@@ -1620,14 +1606,13 @@
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
-      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.4.tgz",
+      "integrity": "sha512-iNdlBX9gLVvqe2I3uIJSIKTq6wckP/DYxZtcqxm09x5Gi24DnFBmPAWZmr60ZyYMG0xlzo6goG3670ar+RXvRw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "win32"
@@ -1640,14 +1625,13 @@
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
-      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.4.tgz",
+      "integrity": "sha512-kqRsbaa5CS6KHlpxnN7WhE6vAAugXyZButpRdvDWetlv6Qv4N9WTcrWzF7tXfB9T7MsoadqdI8hmwLq6UlLvtw==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "win32"
@@ -1660,14 +1644,13 @@
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
-      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.4.tgz",
+      "integrity": "sha512-XtmnYhBcrORsJ4XJngyzr/EWP0hRZLAZRFaApdKuviyqF78+ylxh2y06ZmtULAMOnObJ3ucpN0AcwSWnMowTRg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "win32"
@@ -1825,9 +1808,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.3.0.tgz",
-      "integrity": "sha512-o9r1S0BNiNreHP9Vs+Qnqd9kviDkJh8xIACY7UFZSmiGbbQRzPBBosvHzAU4TULHOIuOj/18RSsyz2qrREmIFw=="
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.3.4.tgz",
+      "integrity": "sha512-cjWZnUUa6jZq2kFaNe/ZyJdZonOZ/QoN0Zka2nz/FLOrfx14pQuM9c5RaSVkWMqgdt4ksgPAMWPyHSs/CyV48Q=="
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "16.2.9",
@@ -1840,9 +1823,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.3.0.tgz",
-      "integrity": "sha512-55hpqq18bEVAlxedlTt3tFqZmKg2nUXT1kn1G/BGEy0R13h3LwtwHPVzzjG6P4LLeOHE32PFDQUVaJEWvBEZBw==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.3.4.tgz",
+      "integrity": "sha512-iBr3I5LZNk5/bgl5//iTgD2tcym14MX0Xo7fD//u9dYAEgGzza1y9oywluPtf74YnOswVdH1908aK9xVz7zQTw==",
       "cpu": [
         "arm64"
       ],
@@ -1855,9 +1838,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.3.0.tgz",
-      "integrity": "sha512-SOi96kSaF5T+0wW4koiM1bWzSPwjzTesC1p3df+FjdOi5LIQkBK/blxh7HdoKnNuI4PURF1OO7TZqtfnbWDSgw==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.3.4.tgz",
+      "integrity": "sha512-2dpiSyl2Jw/NrBPaU2MAKGSa+2MR82pJIn4Sm5Rjr+gxAeuh0z158Su3Z2O8zn7UNNq+ej4bToed6RcRN/Lydg==",
       "cpu": [
         "x64"
       ],
@@ -1870,9 +1853,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.3.0.tgz",
-      "integrity": "sha512-P0gZAoPMF4dyTRzhmkV4PrqVzSOB6t4mC1oI3c4dqijJ+OVEVx5clIXAKR4/uQpsqw2KKM/0D5tVumcR2r5blg==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.3.4.tgz",
+      "integrity": "sha512-+t+U8HZT+fApePCS5h89CSH3datz29MkzyfCn+6fpsZBG/oiEOhINcb9rtkv6sdpToLGFn2e6146NzaKCXkqrA==",
       "cpu": [
         "arm64"
       ],
@@ -1885,9 +1868,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.3.0.tgz",
-      "integrity": "sha512-tXXGKJw0m37O0eKJARVTX/TheKPhz0QFVtVVZXmOig+9YKLQOSP6hvf2pxv5DO7CLEJyTHx3Pg043CDQkv1G4Q==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.3.4.tgz",
+      "integrity": "sha512-mx03GNs1ocQA5JQ4FxDMmIsNkdrZh8cuezKCrId28e5/gIPU/l7Kcy2+vmCCzdjnnmXJy+iOAu+7K0QppO6Urg==",
       "cpu": [
         "arm64"
       ],
@@ -1900,9 +1883,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.3.0.tgz",
-      "integrity": "sha512-pjGxK5EY7yWml78ALejFkWmgHsU7wbFQrISiugpH6FbUJhgEvw3xFZ/EBAtLl7QtL0WdQKiG9eWJ3mOKGTukHw==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.3.4.tgz",
+      "integrity": "sha512-YIhGY6fSMfha52bnVxnzc9zaVBzJg+cqQTOD8tXIBSx4fuv0pVMxQTE0PaS59YhnMOiYiG09IMwxJAf/CFm/Dw==",
       "cpu": [
         "x64"
       ],
@@ -1915,9 +1898,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.3.0.tgz",
-      "integrity": "sha512-sjo++Xx+lomlPs3HRsHWhVDyGG6ms1kGW5EtHLERdII8AyG1i+f6aq68xHREO6AEMlhjTNEWBSmfJfqm9orf7g==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.3.4.tgz",
+      "integrity": "sha512-+eaaX6axpDb0yF1GCpiERe6njplvdC+nks/fKfcHu3XPGRrald8P3/X7yv7QLdjA51knnxwl9pxdIJsg+w1L+Q==",
       "cpu": [
         "x64"
       ],
@@ -1930,9 +1913,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.3.0.tgz",
-      "integrity": "sha512-C5JSgiO54wURdaxdEUIXqkz04uMqC9UmPX1gtDrV/5Tf1UowdWYI8uA5hfFbPolTlp0q4KZ60xlHePNibf0VIw==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.3.4.tgz",
+      "integrity": "sha512-0jcXW7Xs/uzICrmgV3MhDYDeRy++1CqnpDIerlPIqYO4bhzB4WNbX/aRnQclustsAyTkFKB0z6rbcjmNg5tR8A==",
       "cpu": [
         "arm64"
       ],
@@ -1945,9 +1928,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.3.0.tgz",
-      "integrity": "sha512-fDOggsweNb5SSw0ZKVk6U+gxSyGFFlIBY/LBc1r8GUj4u/6t6oArL+Pmkg0MBnsgR+KkdsURilVH4F3GXUGepA==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.3.4.tgz",
+      "integrity": "sha512-vvBzwu1pYQCp92maZCFCIw/XgOTMR5tur9GjakwIo2cmwRTMKajRZZDS9+e4KsUZWKu1E007WUeAFXRRjZeuzw==",
       "cpu": [
         "x64"
       ],
@@ -3593,10 +3576,9 @@
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
-      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
-      "license": "Apache-2.0",
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -3975,16 +3957,15 @@
       }
     },
     "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@ts-morph/common/node_modules/fast-glob": {
@@ -4624,9 +4605,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -4989,10 +4970,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
-      "license": "MIT",
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+      "integrity": "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -5446,10 +5426,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.38",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
-      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
-      "license": "Apache-2.0",
+      "version": "2.11.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.21.tgz",
+      "integrity": "sha512-uh8vpY/1/YyFkunIDFH/12p7/7VdPKA1hejMVEbdkEaWnUz0Hesvx5EbiU6XxjyHZIOju+ZMbQJkRh+es3/spQ==",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
       },
@@ -5520,9 +5499,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -5543,9 +5522,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.9",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.9.tgz",
+      "integrity": "sha512-EWazOblFYUvlGZcfGhPUPmYh3nikUxBVb+y9MJun5f3hBi812X+8MSQTujLBtgK3cf51fJWbWfOjyeO954d+Eg==",
       "dev": true,
       "funding": [
         {
@@ -5561,13 +5540,12 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.20",
+        "caniuse-lite": "^1.0.30001810",
+        "electron-to-chromium": "^1.5.420",
+        "node-releases": "^2.0.54",
+        "update-browserslist-db": "^1.3.2"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -5672,9 +5650,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001799",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
-      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "funding": [
         {
           "type": "opencollective",
@@ -5688,8 +5666,7 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ],
-      "license": "CC-BY-4.0"
+      ]
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -7017,11 +6994,10 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.376",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.376.tgz",
-      "integrity": "sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==",
-      "dev": true,
-      "license": "ISC"
+      "version": "1.5.425",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.425.tgz",
+      "integrity": "sha512-QvPtl41EUOnuT1HBvMKgxXRIaHNcagBPs50u7VULzhZXaGfqTbZyE16LQsctZ/RQHlGu+FOWeDTR4mY6YbeF1g==",
+      "dev": true
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -7280,7 +7256,6 @@
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -7940,9 +7915,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {
@@ -8529,11 +8504,10 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.27",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
-      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
       }
@@ -8681,11 +8655,10 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
@@ -9370,9 +9343,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -11183,12 +11156,12 @@
       }
     },
     "node_modules/next": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.3.0.tgz",
-      "integrity": "sha512-NEdGOzH+08eTXMUp9UYkA99Nhi5N6Thrhc1jgFOQgfgnGK/dA2hRwBpXep+exdFQrnwlRf/3Wixyp8lLBUpE2A==",
+      "version": "16.3.4",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.3.4.tgz",
+      "integrity": "sha512-/Ztf6CeRH+ejEXUrYtqI4gkS66eFIHuSwqi60RgcpWKodxFZx2/dqVCMKBwILfAHXQ+F1b1vAudgj3mnxqtoIA==",
       "dependencies": {
-        "@next/env": "16.3.0",
-        "@swc/helpers": "0.5.15",
+        "@next/env": "16.3.4",
+        "@swc/helpers": "0.5.23",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.5.23",
@@ -11201,15 +11174,15 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.3.0",
-        "@next/swc-darwin-x64": "16.3.0",
-        "@next/swc-linux-arm64-gnu": "16.3.0",
-        "@next/swc-linux-arm64-musl": "16.3.0",
-        "@next/swc-linux-x64-gnu": "16.3.0",
-        "@next/swc-linux-x64-musl": "16.3.0",
-        "@next/swc-win32-arm64-msvc": "16.3.0",
-        "@next/swc-win32-x64-msvc": "16.3.0",
-        "sharp": "^0.35.3"
+        "@next/swc-darwin-arm64": "16.3.4",
+        "@next/swc-darwin-x64": "16.3.4",
+        "@next/swc-linux-arm64-gnu": "16.3.4",
+        "@next/swc-linux-arm64-musl": "16.3.4",
+        "@next/swc-linux-x64-gnu": "16.3.4",
+        "@next/swc-linux-x64-musl": "16.3.4",
+        "@next/swc-win32-arm64-msvc": "16.3.4",
+        "@next/swc-win32-x64-msvc": "16.3.4",
+        "sharp": "^0.35.4"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -11260,39 +11233,11 @@
         }
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.5.22",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
-      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "dependencies": {
-        "nanoid": "^3.3.16",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-releases": {
-      "version": "2.0.48",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
-      "integrity": "sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==",
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
@@ -11995,7 +11940,6 @@
       "version": "8.5.26",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
       "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -12164,11 +12108,10 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",
         "side-channel": "^1.1.1"
@@ -13182,11 +13125,10 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.35.3",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
-      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
+      "version": "0.35.4",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.4.tgz",
+      "integrity": "sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==",
       "devOptional": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
@@ -13199,31 +13141,31 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.35.3",
-        "@img/sharp-darwin-x64": "0.35.3",
-        "@img/sharp-freebsd-wasm32": "0.35.3",
-        "@img/sharp-libvips-darwin-arm64": "1.3.2",
-        "@img/sharp-libvips-darwin-x64": "1.3.2",
-        "@img/sharp-libvips-linux-arm": "1.3.2",
-        "@img/sharp-libvips-linux-arm64": "1.3.2",
-        "@img/sharp-libvips-linux-ppc64": "1.3.2",
-        "@img/sharp-libvips-linux-riscv64": "1.3.2",
-        "@img/sharp-libvips-linux-s390x": "1.3.2",
-        "@img/sharp-libvips-linux-x64": "1.3.2",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
-        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
-        "@img/sharp-linux-arm": "0.35.3",
-        "@img/sharp-linux-arm64": "0.35.3",
-        "@img/sharp-linux-ppc64": "0.35.3",
-        "@img/sharp-linux-riscv64": "0.35.3",
-        "@img/sharp-linux-s390x": "0.35.3",
-        "@img/sharp-linux-x64": "0.35.3",
-        "@img/sharp-linuxmusl-arm64": "0.35.3",
-        "@img/sharp-linuxmusl-x64": "0.35.3",
-        "@img/sharp-webcontainers-wasm32": "0.35.3",
-        "@img/sharp-win32-arm64": "0.35.3",
-        "@img/sharp-win32-ia32": "0.35.3",
-        "@img/sharp-win32-x64": "0.35.3"
+        "@img/sharp-darwin-arm64": "0.35.4",
+        "@img/sharp-darwin-x64": "0.35.4",
+        "@img/sharp-freebsd-wasm32": "0.35.4",
+        "@img/sharp-libvips-darwin-arm64": "1.3.3",
+        "@img/sharp-libvips-darwin-x64": "1.3.3",
+        "@img/sharp-libvips-linux-arm": "1.3.3",
+        "@img/sharp-libvips-linux-arm64": "1.3.3",
+        "@img/sharp-libvips-linux-ppc64": "1.3.3",
+        "@img/sharp-libvips-linux-riscv64": "1.3.3",
+        "@img/sharp-libvips-linux-s390x": "1.3.3",
+        "@img/sharp-libvips-linux-x64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.3",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.3",
+        "@img/sharp-linux-arm": "0.35.4",
+        "@img/sharp-linux-arm64": "0.35.4",
+        "@img/sharp-linux-ppc64": "0.35.4",
+        "@img/sharp-linux-riscv64": "0.35.4",
+        "@img/sharp-linux-s390x": "0.35.4",
+        "@img/sharp-linux-x64": "0.35.4",
+        "@img/sharp-linuxmusl-arm64": "0.35.4",
+        "@img/sharp-linuxmusl-x64": "0.35.4",
+        "@img/sharp-webcontainers-wasm32": "0.35.4",
+        "@img/sharp-win32-arm64": "0.35.4",
+        "@img/sharp-win32-ia32": "0.35.4",
+        "@img/sharp-win32-x64": "0.35.4"
       },
       "peerDependenciesMeta": {
         "@types/node": {
@@ -14237,11 +14179,10 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.1.tgz",
+      "integrity": "sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
       }
@@ -14409,9 +14350,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "dev": true,
       "funding": [
         {
@@ -14427,7 +14368,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "escalade": "^3.2.0",
         "picocolors": "^1.1.1"

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -587,7 +587,6 @@
 }
 
 :root {
-  --font-logo: var(--font-body);
   --background: #F7F4EF;
   --foreground: #061B20;
   --card: #FFFFFF;
@@ -726,8 +725,6 @@
   --ring: var(--sidebar-ring);
   color: var(--sidebar-foreground);
 }
-.loma-sidebar .loma-mark { color: var(--sidebar-primary); }
-.loma-mark { color: var(--primary); }
 
 ::selection { background: #C8E98F; color: #061B20; }
 @media (prefers-reduced-motion: reduce) {

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -7,79 +7,79 @@
 
 @theme {
   /* Gray: warm neutrals */
-  --color-gray-50: #FDFBF7;
+  --color-gray-50: #FBF9F5;
   --color-gray-100: #F7F4EF;
-  --color-gray-200: #E8E4DD;
-  --color-gray-300: #D4CFC7;
-  --color-gray-400: #B8B1A8;
-  --color-gray-500: #8C857D;
-  --color-gray-600: #5C5650;
-  --color-gray-700: #1F1D1A;
-  --color-gray-800: #0A0A0A;
-  --color-gray-900: #0A0A0A;
+  --color-gray-200: #EEE8E0;
+  --color-gray-300: #D8D2C9;
+  --color-gray-400: #918A81;
+  --color-gray-500: #706B65;
+  --color-gray-600: #565D57;
+  --color-gray-700: #263D3B;
+  --color-gray-800: #12312F;
+  --color-gray-900: #061B20;
 
-  /* Brand: warm neutral for active/selected states */
-  --color-brand-50: #FDFBF7;
-  --color-brand-100: #F7F4EF;
-  --color-brand-200: #E8E4DD;
-  --color-brand-300: #D4CFC7;
-  --color-brand-400: #B8B1A8;
-  --color-brand-500: #8C857D;
-  --color-brand-600: #5C5650;
-  --color-brand-700: #1F1D1A;
-  --color-brand-800: #0A0A0A;
-  --color-brand-900: #0A0A0A;
+  /* Botanical brand: evergreen actions and moss selections */
+  --color-brand-50: #F0F5EC;
+  --color-brand-100: #E5EFDA;
+  --color-brand-200: #C8E0B5;
+  --color-brand-300: #A6C99A;
+  --color-brand-400: #79A780;
+  --color-brand-500: #4A8065;
+  --color-brand-600: #226750;
+  --color-brand-700: #055147;
+  --color-brand-800: #073B35;
+  --color-brand-900: #061B20;
 
-  /* Accent: yellow-green for primary actions */
-  --color-accent-50: #fdfff0;
-  --color-accent-100: #f5ffd6;
-  --color-accent-200: #E8FF5A;
-  --color-accent-300: #F0FF85;
-  --color-accent-400: #c5e04a;
-  --color-accent-500: #8FB800;
-  --color-accent-600: #7A8F00;
+  /* Leaf highlight: selected navigation and composer actions */
+  --color-accent-50: #F5F9EF;
+  --color-accent-100: #E7F2D6;
+  --color-accent-200: #C8E98F;
+  --color-accent-300: #B5D77A;
+  --color-accent-400: #9BBF63;
+  --color-accent-500: #567C38;
+  --color-accent-600: #3F612A;
 
   /* Surface: cards, panels, modals (white in light, warm dark in dark) */
   --color-surface: #FFFFFF;
 
   /* Text on accent backgrounds — always dark regardless of theme */
-  --color-accent-on: #1F1D1A;
+  --color-accent-on: #061B20;
 }
 
 /* ── Dark mode palette inversion ─────────────────────────────────────────── */
 
 [data-theme="dark"] {
-  --color-gray-50: #0A0A0A;
-  --color-gray-100: #141311;
-  --color-gray-200: #2A2723;
-  --color-gray-300: #3A3632;
-  --color-gray-400: #8C857D;
-  --color-gray-500: #B8B1A8;
-  --color-gray-600: #D4CFC7;
-  --color-gray-700: #E8E4DD;
-  --color-gray-800: #F7F4EF;
-  --color-gray-900: #FDFBF7;
+  --color-gray-50: #091D21;
+  --color-gray-100: #10282B;
+  --color-gray-200: #284143;
+  --color-gray-300: #3C5353;
+  --color-gray-400: #91A49C;
+  --color-gray-500: #A8B9AF;
+  --color-gray-600: #C1CEC3;
+  --color-gray-700: #DDE4D9;
+  --color-gray-800: #EDF0E7;
+  --color-gray-900: #F7F4EF;
 
-  --color-brand-50: #0A0A0A;
-  --color-brand-100: #141311;
-  --color-brand-200: #2A2723;
-  --color-brand-300: #3A3632;
-  --color-brand-400: #8C857D;
-  --color-brand-500: #B8B1A8;
-  --color-brand-600: #D4CFC7;
-  --color-brand-700: #E8E4DD;
-  --color-brand-800: #F7F4EF;
-  --color-brand-900: #FDFBF7;
+  --color-brand-50: #10282B;
+  --color-brand-100: #193A34;
+  --color-brand-200: #2C5546;
+  --color-brand-300: #45705B;
+  --color-brand-400: #7CA286;
+  --color-brand-500: #91B89A;
+  --color-brand-600: #ACCDAA;
+  --color-brand-700: #C8E0B5;
+  --color-brand-800: #E0EBCF;
+  --color-brand-900: #F0F5EC;
 
-  --color-accent-50: #0d0f00;
-  --color-accent-100: #1a1f00;
-  --color-accent-200: #E8FF5A;
-  --color-accent-300: #c5e04a;
-  --color-accent-400: #F0FF85;
-  --color-accent-500: #8FB800;
-  --color-accent-600: #7A8F00;
+  --color-accent-50: #132A25;
+  --color-accent-100: #253F2F;
+  --color-accent-200: #C8E98F;
+  --color-accent-300: #B5D77A;
+  --color-accent-400: #D7EFAE;
+  --color-accent-500: #A6C97D;
+  --color-accent-600: #C8E98F;
 
-  --color-surface: #1C1A17;
+  --color-surface: #122D30;
 
   /* Semantic color badge overrides: flip light bg/border to dark equivalents.
      -50 (badge bg) → very dark tint | -100 → slightly brighter | -200 (border) → muted dark
@@ -428,10 +428,9 @@
 }
 
 @media (max-width: 767px) {
-  /* The floating menu button replaces the top bar — page headers shift right
-     so their first row clears it. */
+  /* LayoutShell now reserves a mobile menu row for every route. */
   .pwa-header-offset {
-    padding-left: 2.75rem;
+    padding-left: 0;
   }
 
   /* Chat reads small on a phone — bump message text. */
@@ -443,10 +442,10 @@
 
 /* ── Agent Graph ───────────────────────────────────────────────────── */
 
-/* Loma breathing glow — yellow energy */
+/* Loma breathing glow: leaf highlight */
 @keyframes centerGlow {
-  0%, 100% { box-shadow: 0 0 20px rgba(232, 255, 90, 0.3), 0 0 50px rgba(232, 255, 90, 0.1); }
-  50% { box-shadow: 0 0 35px rgba(232, 255, 90, 0.5), 0 0 80px rgba(232, 255, 90, 0.2); }
+  0%, 100% { box-shadow: 0 0 20px rgba(200, 233, 143, 0.3), 0 0 50px rgba(200, 233, 143, 0.1); }
+  50% { box-shadow: 0 0 35px rgba(200, 233, 143, 0.5), 0 0 80px rgba(200, 233, 143, 0.2); }
 }
 
 .center-node {
@@ -588,43 +587,44 @@
 }
 
 :root {
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.147 0.004 49.25);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.147 0.004 49.25);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.147 0.004 49.25);
-  --primary: oklch(0.216 0.006 56.043);
-  --primary-foreground: oklch(0.985 0.001 106.423);
-  --secondary: oklch(0.97 0.001 106.424);
-  --secondary-foreground: oklch(0.216 0.006 56.043);
-  --muted: oklch(0.97 0.001 106.424);
-  --muted-foreground: oklch(0.553 0.013 58.071);
-  --accent: oklch(0.97 0.001 106.424);
-  --accent-foreground: oklch(0.216 0.006 56.043);
+  --font-logo: var(--font-body);
+  --background: #F7F4EF;
+  --foreground: #061B20;
+  --card: #FFFFFF;
+  --card-foreground: #061B20;
+  --popover: #FFFFFF;
+  --popover-foreground: #061B20;
+  --primary: #055147;
+  --primary-foreground: #FFFFFF;
+  --secondary: #EEE8E0;
+  --secondary-foreground: #263D3B;
+  --muted: #EEE8E0;
+  --muted-foreground: #706B65;
+  --accent: #E7F2D6;
+  --accent-foreground: #073B35;
   --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.923 0.003 48.717);
-  --input: oklch(0.923 0.003 48.717);
-  --ring: oklch(0.709 0.01 56.259);
-  --chart-1: oklch(0.869 0.005 56.366);
-  --chart-2: oklch(0.553 0.013 58.071);
-  --chart-3: oklch(0.444 0.011 73.639);
-  --chart-4: oklch(0.374 0.01 67.558);
-  --chart-5: oklch(0.268 0.007 34.298);
+  --border: #E7E1D9;
+  --input: #D8D2C9;
+  --ring: #226750;
+  --chart-1: #055147;
+  --chart-2: #79A780;
+  --chart-3: #567C38;
+  --chart-4: #A18A5B;
+  --chart-5: #647D8A;
   --radius: 0.45rem;
-  --sidebar: oklch(0.985 0.001 106.423);
-  --sidebar-foreground: oklch(0.147 0.004 49.25);
-  --sidebar-primary: oklch(0.216 0.006 56.043);
-  --sidebar-primary-foreground: oklch(0.985 0.001 106.423);
-  --sidebar-accent: oklch(0.97 0.001 106.424);
-  --sidebar-accent-foreground: oklch(0.216 0.006 56.043);
-  --sidebar-border: oklch(0.923 0.003 48.717);
-  --sidebar-ring: oklch(0.709 0.01 56.259);
+  --sidebar: #061B20;
+  --sidebar-foreground: #BECBC7;
+  --sidebar-primary: #C8E98F;
+  --sidebar-primary-foreground: #061B20;
+  --sidebar-accent: #193036;
+  --sidebar-accent-foreground: #F7F4EF;
+  --sidebar-border: #284143;
+  --sidebar-ring: #C8E98F;
 }
 
 @theme inline {
-  --font-sans: var(--font-sans);
-  --font-heading: var(--font-heading);
+  --font-sans: var(--font-body);
+  --font-heading: var(--font-display);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -666,35 +666,75 @@
 }
 
 [data-theme="dark"] {
-  --background: oklch(0.147 0.004 49.25);
-  --foreground: oklch(0.985 0.001 106.423);
-  --card: oklch(0.216 0.006 56.043);
-  --card-foreground: oklch(0.985 0.001 106.423);
-  --popover: oklch(0.216 0.006 56.043);
-  --popover-foreground: oklch(0.985 0.001 106.423);
-  --primary: oklch(0.923 0.003 48.717);
-  --primary-foreground: oklch(0.216 0.006 56.043);
-  --secondary: oklch(0.268 0.007 34.298);
-  --secondary-foreground: oklch(0.985 0.001 106.423);
-  --muted: oklch(0.268 0.007 34.298);
-  --muted-foreground: oklch(0.709 0.01 56.259);
-  --accent: oklch(0.268 0.007 34.298);
-  --accent-foreground: oklch(0.985 0.001 106.423);
+  --background: #091D21;
+  --foreground: #F7F4EF;
+  --card: #122D30;
+  --card-foreground: #F7F4EF;
+  --popover: #163237;
+  --popover-foreground: #F7F4EF;
+  --primary: #C8E98F;
+  --primary-foreground: #061B20;
+  --secondary: #213B3C;
+  --secondary-foreground: #DDE4D9;
+  --muted: #1A3437;
+  --muted-foreground: #A8B9AF;
+  --accent: #294638;
+  --accent-foreground: #E7F2D6;
   --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.553 0.013 58.071);
-  --chart-1: oklch(0.869 0.005 56.366);
-  --chart-2: oklch(0.553 0.013 58.071);
-  --chart-3: oklch(0.444 0.011 73.639);
-  --chart-4: oklch(0.374 0.01 67.558);
-  --chart-5: oklch(0.268 0.007 34.298);
-  --sidebar: oklch(0.216 0.006 56.043);
-  --sidebar-foreground: oklch(0.985 0.001 106.423);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0.001 106.423);
-  --sidebar-accent: oklch(0.268 0.007 34.298);
-  --sidebar-accent-foreground: oklch(0.985 0.001 106.423);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.553 0.013 58.071);
+  --border: #284143;
+  --input: #3C5353;
+  --ring: #A6C97D;
+  --chart-1: #C8E98F;
+  --chart-2: #91B89A;
+  --chart-3: #76B5A5;
+  --chart-4: #CAB47F;
+  --chart-5: #98B7C6;
+  --sidebar: #061B20;
+  --sidebar-foreground: #BECBC7;
+  --sidebar-primary: #C8E98F;
+  --sidebar-primary-foreground: #061B20;
+  --sidebar-accent: #193036;
+  --sidebar-accent-foreground: #F7F4EF;
+  --sidebar-border: #284143;
+  --sidebar-ring: #C8E98F;
+}
+
+/* Shared editorial hierarchy, including routes that predate font-heading.
+   User-authored markdown and compact conversation titles retain their own scale. */
+.loma-dashboard h1:not(:where(.prose h1, .break-words h1, .chat-text h1)) {
+  font-family: var(--font-display), Georgia, serif;
+  font-size: clamp(1.75rem, 2.6vw, 2.5rem);
+  line-height: 1.15;
+  font-weight: 400;
+  letter-spacing: -0.025em;
+}
+.loma-dashboard h1.truncate { font-size: 1.5rem; }
+.loma-dashboard h2.font-heading {
+  font-family: var(--font-body), sans-serif;
+}
+
+/* Sidebar-scoped tokens also theme nested controls, without affecting portaled
+   menus/dialogs, which retain the page's light/dark surface tokens. */
+.loma-sidebar {
+  --background: var(--sidebar);
+  --foreground: var(--sidebar-accent-foreground);
+  --muted: var(--sidebar-accent);
+  --muted-foreground: var(--sidebar-foreground);
+  --accent: var(--sidebar-accent);
+  --accent-foreground: var(--sidebar-accent-foreground);
+  --border: var(--sidebar-border);
+  --ring: var(--sidebar-ring);
+  color: var(--sidebar-foreground);
+}
+.loma-sidebar .loma-mark { color: var(--sidebar-primary); }
+.loma-mark { color: var(--primary); }
+
+::selection { background: #C8E98F; color: #061B20; }
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/dashboard/src/app/layout.tsx
+++ b/dashboard/src/app/layout.tsx
@@ -1,24 +1,18 @@
 import type { Metadata, Viewport } from "next";
-import { JetBrains_Mono, Red_Hat_Display, Roboto, Instrument_Serif } from "next/font/google";
+import { JetBrains_Mono, DM_Sans, Instrument_Serif } from "next/font/google";
 import "./globals.css";
 import Providers from "../components/Providers";
 import LayoutShell from "../components/LayoutShell";
 import ServiceWorkerRegistrar from "../components/ServiceWorkerRegistrar";
 import { cn } from "@/lib/utils";
 
-const instrumentSerifHeading = Instrument_Serif({subsets:['latin'],weight:['400'],variable:'--font-heading'});
+const instrumentSerifHeading = Instrument_Serif({subsets:['latin'],weight:['400'],variable:'--font-display'});
 
-const roboto = Roboto({subsets:['latin'],variable:'--font-sans'});
+const dmSans = DM_Sans({subsets:['latin'],variable:'--font-body'});
 
 const jetbrainsMono = JetBrains_Mono({
   variable: "--font-jetbrains",
   subsets: ["latin"],
-});
-
-const redHatDisplay = Red_Hat_Display({
-  variable: "--font-logo",
-  subsets: ["latin"],
-  weight: ["700", "800", "900"],
 });
 
 export const metadata: Metadata = {
@@ -46,8 +40,8 @@ export const viewport: Viewport = {
   // opens (ViewportHeightSync's --app-h covers browsers that ignore this).
   interactiveWidget: "resizes-content",
   themeColor: [
-    { media: "(prefers-color-scheme: light)", color: "#F5F5F4" },
-    { media: "(prefers-color-scheme: dark)", color: "#292524" },
+    { media: "(prefers-color-scheme: light)", color: "#F7F4EF" },
+    { media: "(prefers-color-scheme: dark)", color: "#061B20" },
   ],
 };
 
@@ -57,7 +51,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" suppressHydrationWarning className={cn("font-sans", roboto.variable, instrumentSerifHeading.variable, jetbrainsMono.variable, redHatDisplay.variable)}>
+    <html lang="en" suppressHydrationWarning className={cn("font-sans", dmSans.variable, instrumentSerifHeading.variable, jetbrainsMono.variable)}>
       <head>
         <script
           dangerouslySetInnerHTML={{

--- a/dashboard/src/app/layout.tsx
+++ b/dashboard/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from "next";
-import { JetBrains_Mono, DM_Sans, Instrument_Serif } from "next/font/google";
+import { JetBrains_Mono, DM_Sans, Instrument_Serif, Red_Hat_Display } from "next/font/google";
 import "./globals.css";
 import Providers from "../components/Providers";
 import LayoutShell from "../components/LayoutShell";
@@ -13,6 +13,12 @@ const dmSans = DM_Sans({subsets:['latin'],variable:'--font-body'});
 const jetbrainsMono = JetBrains_Mono({
   variable: "--font-jetbrains",
   subsets: ["latin"],
+});
+
+const redHatDisplay = Red_Hat_Display({
+  variable: "--font-logo",
+  subsets: ["latin"],
+  weight: ["700", "800", "900"],
 });
 
 export const metadata: Metadata = {
@@ -51,7 +57,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" suppressHydrationWarning className={cn("font-sans", dmSans.variable, instrumentSerifHeading.variable, jetbrainsMono.variable)}>
+    <html lang="en" suppressHydrationWarning className={cn("font-sans", dmSans.variable, instrumentSerifHeading.variable, jetbrainsMono.variable, redHatDisplay.variable)}>
       <head>
         <script
           dangerouslySetInnerHTML={{

--- a/dashboard/src/components/BottomNav.tsx
+++ b/dashboard/src/components/BottomNav.tsx
@@ -40,15 +40,16 @@ export default function BottomNav() {
   ];
 
   return (
-    <nav className="md:hidden shrink-0 grid grid-cols-3 border-t border-border bg-background pb-[max(0.25rem,env(safe-area-inset-bottom))]">
+    <nav className="md:hidden shrink-0 grid grid-cols-3 border-t border-sidebar-border bg-sidebar pb-[max(0.25rem,env(safe-area-inset-bottom))]">
       {tabs.map((tab) => (
         <Link
           key={tab.name}
           href={tab.href}
           prefetch
+          aria-current={tab.active ? "page" : undefined}
           className={cn(
             "flex flex-col items-center gap-0.5 pt-2 pb-1 press-scale",
-            tab.active ? "text-foreground" : "text-muted-foreground",
+            tab.active ? "text-sidebar-primary" : "text-sidebar-foreground",
           )}
         >
           <span className="relative">

--- a/dashboard/src/components/ChatPanel.tsx
+++ b/dashboard/src/components/ChatPanel.tsx
@@ -1431,13 +1431,13 @@ export default function ChatPanel({
                   className="w-full bg-transparent px-4 md:px-5 pt-4 md:pt-5 pb-3 text-[15px] text-foreground placeholder-muted-foreground focus:outline-none resize-none overflow-hidden leading-relaxed border-0 focus-visible:ring-0 focus-visible:border-transparent rounded-none min-h-0"
                   style={{ maxHeight: "200px" }}
                 />
-                <div className="flex items-center justify-between gap-2 px-3 pb-3">
-                  <div className="flex min-w-0 items-center gap-0.5">
+                <div className="flex items-center justify-between gap-2 px-3 pb-3 max-md:flex-wrap">
+                  <div className="flex min-w-0 items-center gap-0.5 max-md:w-full max-md:flex-wrap">
                     <AgentPicker agents={agentIdentities} selectedAgentId={selectedAgentId} onSelect={selectAgent} loadState={agentLoadState} disabled={isStreaming} />
                     <ModelPicker models={agentModels} selectedModel={selectedModel} onSelect={selectModel} loadState={modelLoadState} disabled={isStreaming} />
                     <ToolsPicker tools={availableTools} skills={availableSkills} selection={toolsSelection} onToggleTool={toggleTool} onToggleSkill={toggleSkill} onEnableAll={enableAllTools} onOpen={loadToolsCatalog} isAllEnabled={allToolsEnabled} disabledCount={toolsDisabledCount} loadState={toolsLoadState} disabled={isStreaming} isAlwaysEnabled={isAlwaysEnabled} />
                   </div>
-                  <div className="flex items-center gap-1 max-md:gap-2 shrink-0">
+                  <div className="ml-auto flex items-center gap-1 max-md:gap-2 shrink-0">
                     <DictationButton
                       onText={(t) => setInput((prev) => appendDictation(prev, t))}
                       mobileProminent
@@ -1737,7 +1737,7 @@ export default function ChatPanel({
               {isStreaming && <PetRunway running={!items.some((item) => item.role === "clarify" && !item.submitted)} />}
               <PendingFilesStrip files={pendingFiles} onRemove={removeFile} onExpandImage={setExpandedImage} />
 
-              <div className="flex flex-col bg-muted border border-border rounded-2xl focus-within:border-gray-300 transition-colors">
+              <div className="flex flex-col bg-card border border-input rounded-xl shadow-sm focus-within:border-ring focus-within:ring-1 focus-within:ring-ring/20 transition-colors">
                 <Textarea
                   ref={inputRef}
                   value={input}
@@ -1754,13 +1754,13 @@ export default function ChatPanel({
                   className="w-full bg-transparent px-3 pt-3 pb-1.5 text-[13px] text-foreground placeholder-muted-foreground focus:outline-none resize-none overflow-hidden border-0 focus-visible:ring-0 focus-visible:border-transparent rounded-none min-h-0"
                   style={{ maxHeight: "160px" }}
                 />
-                <div className="flex items-center justify-between gap-2 px-2 pb-2">
-                  <div className="flex min-w-0 items-center gap-0.5">
+                <div className="flex items-center justify-between gap-2 px-2 pb-2 max-md:flex-wrap">
+                  <div className="flex min-w-0 items-center gap-0.5 max-md:w-full max-md:flex-wrap">
                     <AgentPicker agents={agentIdentities} selectedAgentId={selectedAgentId} onSelect={selectAgent} loadState={agentLoadState} disabled={isStreaming} />
                     <ModelPicker models={agentModels} selectedModel={selectedModel} onSelect={selectModel} loadState={modelLoadState} disabled={isStreaming} />
                     <ToolsPicker tools={availableTools} skills={availableSkills} selection={toolsSelection} onToggleTool={toggleTool} onToggleSkill={toggleSkill} onEnableAll={enableAllTools} onOpen={loadToolsCatalog} isAllEnabled={allToolsEnabled} disabledCount={toolsDisabledCount} loadState={toolsLoadState} disabled={isStreaming} isAlwaysEnabled={isAlwaysEnabled} />
                   </div>
-                  <div className="flex items-center gap-1 max-md:gap-2 shrink-0">
+                  <div className="ml-auto flex items-center gap-1 max-md:gap-2 shrink-0">
                     <DictationButton
                       onText={(t) => setInput((prev) => appendDictation(prev, t))}
                       mobileProminent

--- a/dashboard/src/components/CrosscutIcon.tsx
+++ b/dashboard/src/components/CrosscutIcon.tsx
@@ -1,66 +1,14 @@
-import { useId } from "react";
+import { cn } from "@/lib/utils";
 
+/** Four-leaf mark shared by the sidebar, login, and assistant surfaces. */
 export default function CrosscutIcon({ size = 28, className }: { size?: number; className?: string }) {
-  const uid = useId();
-  const id = (name: string) => `${uid}-${name}`;
-
   return (
-    <svg
-      width={size}
-      height={size}
-      viewBox="0 0 160 160"
-      className={className}
-      style={{ borderRadius: size * 0.15, flexShrink: 0 }}
-    >
-      <defs>
-        <radialGradient id={id("glassDark")} cx="50%" cy="50%" r="50%">
-          <stop offset="0%" stopColor="#2a2a2a"/>
-          <stop offset="80%" stopColor="#0A0A0A"/>
-          <stop offset="100%" stopColor="#000000"/>
-        </radialGradient>
-        <radialGradient id={id("glassLight")} cx="50%" cy="50%" r="50%">
-          <stop offset="0%" stopColor="#2a2a2a" stopOpacity="0.5"/>
-          <stop offset="80%" stopColor="#0A0A0A" stopOpacity="0.35"/>
-          <stop offset="100%" stopColor="#000000" stopOpacity="0.3"/>
-        </radialGradient>
-        <linearGradient id={id("glassReflect")} x1="0" y1="0" x2="0" y2="1">
-          <stop offset="0%" stopColor="#ffffff" stopOpacity="0.55"/>
-          <stop offset="100%" stopColor="#ffffff" stopOpacity="0"/>
-        </linearGradient>
-        <linearGradient id={id("rimLight")} x1="0" y1="0" x2="0" y2="1">
-          <stop offset="0%" stopColor="#ffffff" stopOpacity="0"/>
-          <stop offset="85%" stopColor="#ffffff" stopOpacity="0"/>
-          <stop offset="100%" stopColor="#ffffff" stopOpacity="0.15"/>
-        </linearGradient>
-        <filter id={id("glassShadow")} x="-20%" y="-10%" width="140%" height="140%">
-          <feDropShadow dx="2" dy="3" stdDeviation="2.5" floodColor="#0A0A0A" floodOpacity="0.35"/>
-        </filter>
-        <clipPath id={id("topHalf60")}><rect x="38" y="38" width="44" height="20"/></clipPath>
-        <clipPath id={id("topHalf100")}><rect x="78" y="38" width="44" height="20"/></clipPath>
-        <clipPath id={id("topHalf60b")}><rect x="38" y="78" width="44" height="20"/></clipPath>
-        <clipPath id={id("topHalf100b")}><rect x="78" y="78" width="44" height="20"/></clipPath>
-      </defs>
-      <rect width="160" height="160" fill="#E8FF5A" />
-      <line x1="60" y1="20" x2="60" y2="140" stroke="#0A0A0A" strokeWidth="2" opacity="0.1" />
-      <line x1="100" y1="20" x2="100" y2="140" stroke="#0A0A0A" strokeWidth="2" opacity="0.1" />
-      <line x1="20" y1="60" x2="140" y2="60" stroke="#0A0A0A" strokeWidth="2" opacity="0.1" />
-      <line x1="20" y1="100" x2="140" y2="100" stroke="#0A0A0A" strokeWidth="2" opacity="0.1" />
-      {/* Top-left (dark) */}
-      <circle cx="60" cy="60" r="18" fill={`url(#${id("glassDark")})`} filter={`url(#${id("glassShadow")})`} />
-      <circle cx="60" cy="60" r="17" fill={`url(#${id("rimLight")})`} />
-      <ellipse cx="60" cy="54" rx="13" ry="8" fill={`url(#${id("glassReflect")})`} clipPath={`url(#${id("topHalf60")})`} />
-      {/* Top-right (light) */}
-      <circle cx="100" cy="60" r="18" fill={`url(#${id("glassLight")})`} filter={`url(#${id("glassShadow")})`} />
-      <circle cx="100" cy="60" r="17" fill={`url(#${id("rimLight")})`} opacity="0.5" />
-      <ellipse cx="100" cy="54" rx="13" ry="8" fill={`url(#${id("glassReflect")})`} opacity="0.4" clipPath={`url(#${id("topHalf100")})`} />
-      {/* Bottom-left (light) */}
-      <circle cx="60" cy="100" r="18" fill={`url(#${id("glassLight")})`} filter={`url(#${id("glassShadow")})`} />
-      <circle cx="60" cy="100" r="17" fill={`url(#${id("rimLight")})`} opacity="0.5" />
-      <ellipse cx="60" cy="94" rx="13" ry="8" fill={`url(#${id("glassReflect")})`} opacity="0.4" clipPath={`url(#${id("topHalf60b")})`} />
-      {/* Bottom-right (dark) */}
-      <circle cx="100" cy="100" r="18" fill={`url(#${id("glassDark")})`} filter={`url(#${id("glassShadow")})`} />
-      <circle cx="100" cy="100" r="17" fill={`url(#${id("rimLight")})`} />
-      <ellipse cx="100" cy="94" rx="13" ry="8" fill={`url(#${id("glassReflect")})`} clipPath={`url(#${id("topHalf100b")})`} />
+    <svg width={size} height={size} viewBox="0 0 28 28" aria-hidden="true"
+      className={cn("loma-mark shrink-0", className)} fill="currentColor">
+      <circle cx="8" cy="8" r="6" />
+      <circle cx="20" cy="8" r="6" />
+      <circle cx="8" cy="20" r="6" />
+      <circle cx="20" cy="20" r="6" />
     </svg>
   );
 }

--- a/dashboard/src/components/CrosscutIcon.tsx
+++ b/dashboard/src/components/CrosscutIcon.tsx
@@ -1,14 +1,66 @@
-import { cn } from "@/lib/utils";
+import { useId } from "react";
 
-/** Four-leaf mark shared by the sidebar, login, and assistant surfaces. */
 export default function CrosscutIcon({ size = 28, className }: { size?: number; className?: string }) {
+  const uid = useId();
+  const id = (name: string) => `${uid}-${name}`;
+
   return (
-    <svg width={size} height={size} viewBox="0 0 28 28" aria-hidden="true"
-      className={cn("loma-mark shrink-0", className)} fill="currentColor">
-      <circle cx="8" cy="8" r="6" />
-      <circle cx="20" cy="8" r="6" />
-      <circle cx="8" cy="20" r="6" />
-      <circle cx="20" cy="20" r="6" />
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 160 160"
+      className={className}
+      style={{ borderRadius: size * 0.15, flexShrink: 0 }}
+    >
+      <defs>
+        <radialGradient id={id("glassDark")} cx="50%" cy="50%" r="50%">
+          <stop offset="0%" stopColor="#2a2a2a"/>
+          <stop offset="80%" stopColor="#0A0A0A"/>
+          <stop offset="100%" stopColor="#000000"/>
+        </radialGradient>
+        <radialGradient id={id("glassLight")} cx="50%" cy="50%" r="50%">
+          <stop offset="0%" stopColor="#2a2a2a" stopOpacity="0.5"/>
+          <stop offset="80%" stopColor="#0A0A0A" stopOpacity="0.35"/>
+          <stop offset="100%" stopColor="#000000" stopOpacity="0.3"/>
+        </radialGradient>
+        <linearGradient id={id("glassReflect")} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="#ffffff" stopOpacity="0.55"/>
+          <stop offset="100%" stopColor="#ffffff" stopOpacity="0"/>
+        </linearGradient>
+        <linearGradient id={id("rimLight")} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0%" stopColor="#ffffff" stopOpacity="0"/>
+          <stop offset="85%" stopColor="#ffffff" stopOpacity="0"/>
+          <stop offset="100%" stopColor="#ffffff" stopOpacity="0.15"/>
+        </linearGradient>
+        <filter id={id("glassShadow")} x="-20%" y="-10%" width="140%" height="140%">
+          <feDropShadow dx="2" dy="3" stdDeviation="2.5" floodColor="#0A0A0A" floodOpacity="0.35"/>
+        </filter>
+        <clipPath id={id("topHalf60")}><rect x="38" y="38" width="44" height="20"/></clipPath>
+        <clipPath id={id("topHalf100")}><rect x="78" y="38" width="44" height="20"/></clipPath>
+        <clipPath id={id("topHalf60b")}><rect x="38" y="78" width="44" height="20"/></clipPath>
+        <clipPath id={id("topHalf100b")}><rect x="78" y="78" width="44" height="20"/></clipPath>
+      </defs>
+      <rect width="160" height="160" fill="#E8FF5A" />
+      <line x1="60" y1="20" x2="60" y2="140" stroke="#0A0A0A" strokeWidth="2" opacity="0.1" />
+      <line x1="100" y1="20" x2="100" y2="140" stroke="#0A0A0A" strokeWidth="2" opacity="0.1" />
+      <line x1="20" y1="60" x2="140" y2="60" stroke="#0A0A0A" strokeWidth="2" opacity="0.1" />
+      <line x1="20" y1="100" x2="140" y2="100" stroke="#0A0A0A" strokeWidth="2" opacity="0.1" />
+      {/* Top-left (dark) */}
+      <circle cx="60" cy="60" r="18" fill={`url(#${id("glassDark")})`} filter={`url(#${id("glassShadow")})`} />
+      <circle cx="60" cy="60" r="17" fill={`url(#${id("rimLight")})`} />
+      <ellipse cx="60" cy="54" rx="13" ry="8" fill={`url(#${id("glassReflect")})`} clipPath={`url(#${id("topHalf60")})`} />
+      {/* Top-right (light) */}
+      <circle cx="100" cy="60" r="18" fill={`url(#${id("glassLight")})`} filter={`url(#${id("glassShadow")})`} />
+      <circle cx="100" cy="60" r="17" fill={`url(#${id("rimLight")})`} opacity="0.5" />
+      <ellipse cx="100" cy="54" rx="13" ry="8" fill={`url(#${id("glassReflect")})`} opacity="0.4" clipPath={`url(#${id("topHalf100")})`} />
+      {/* Bottom-left (light) */}
+      <circle cx="60" cy="100" r="18" fill={`url(#${id("glassLight")})`} filter={`url(#${id("glassShadow")})`} />
+      <circle cx="60" cy="100" r="17" fill={`url(#${id("rimLight")})`} opacity="0.5" />
+      <ellipse cx="60" cy="94" rx="13" ry="8" fill={`url(#${id("glassReflect")})`} opacity="0.4" clipPath={`url(#${id("topHalf60b")})`} />
+      {/* Bottom-right (dark) */}
+      <circle cx="100" cy="100" r="18" fill={`url(#${id("glassDark")})`} filter={`url(#${id("glassShadow")})`} />
+      <circle cx="100" cy="100" r="17" fill={`url(#${id("rimLight")})`} />
+      <ellipse cx="100" cy="94" rx="13" ry="8" fill={`url(#${id("glassReflect")})`} clipPath={`url(#${id("topHalf100b")})`} />
     </svg>
   );
 }

--- a/dashboard/src/components/LayoutShell.tsx
+++ b/dashboard/src/components/LayoutShell.tsx
@@ -77,9 +77,8 @@ export default function LayoutShell({ children }: { children: React.ReactNode })
         />
       </Suspense>
 
-      {/* Mobile: no dedicated top bar — a floating menu button keeps every
-          vertical pixel for content. Page headers make room for it via
-          .pwa-header-offset (globals.css). */}
+      {/* Mobile: reserve a short menu row so every route, including pages
+          without a pwa-header-offset, clears the floating menu button. */}
       {standalone && <ViewportHeightSync />}
       <Button
         variant="ghost"
@@ -95,13 +94,13 @@ export default function LayoutShell({ children }: { children: React.ReactNode })
         // dvh (not vh) so the iOS Safari URL bar doesn't cause overflow; in
         // the installed PWA, --app-h tracks the visual viewport so the layout
         // shrinks above the on-screen keyboard (dvh ignores it on iOS).
-        "ml-0 flex flex-col transition-all duration-200 pt-[env(safe-area-inset-top)] md:pt-0 bg-background",
+        "loma-dashboard ml-0 min-w-0 flex flex-col transition-all duration-200 pt-[calc(env(safe-area-inset-top)+2.75rem)] md:pt-0 bg-background",
         standalone ? "h-[var(--app-h,100dvh)]" : "h-dvh",
         sidebarCollapsed ? "md:ml-[56px]" : "md:ml-[220px]"
       )}>
         <div className={cn(
           "flex-1 w-full flex flex-col min-h-0",
-          pathname.startsWith("/skills") ? "overflow-hidden" : "px-3 md:px-3 lg:px-4 py-3"
+          pathname.startsWith("/skills") ? "overflow-hidden" : "px-3 md:px-6 lg:px-8 py-4 md:py-6"
         )}>{children}</div>
         <BottomNav />
       </main>

--- a/dashboard/src/components/Sidebar.tsx
+++ b/dashboard/src/components/Sidebar.tsx
@@ -434,10 +434,10 @@ export default function Sidebar({
       {/* Logo + collapse toggle + close button */}
       <div className={cn("flex items-center justify-between", collapsed ? "flex-col gap-1 px-2 pt-2 pb-1" : "px-5 pt-6 pb-5")}>
         <div className={cn("flex items-center gap-2", collapsed && "justify-center")}>
-          <PetCompanion size={32} onOpen={onClose} fallback={<Link href="/tasks" prefetch onClick={onClose} aria-label="Loma home"><CrosscutIcon size={collapsed ? 22 : 27} /></Link>} />
+          <PetCompanion size={32} onOpen={onClose} fallback={<Link href="/tasks" prefetch onClick={onClose} aria-label="Loma home"><CrosscutIcon size={collapsed ? 22 : 20} /></Link>} />
           {!collapsed && (
-            <Link href="/tasks" prefetch onClick={onClose} className="font-sans text-[29px] font-medium tracking-[-0.04em] text-foreground">
-              loma
+            <Link href="/tasks" prefetch onClick={onClose} className="font-[family-name:var(--font-logo)] text-base font-bold tracking-[0.5px] text-foreground/80">
+              Loma
             </Link>
           )}
         </div>

--- a/dashboard/src/components/Sidebar.tsx
+++ b/dashboard/src/components/Sidebar.tsx
@@ -432,12 +432,12 @@ export default function Sidebar({
   const sidebarContent = (
     <>
       {/* Logo + collapse toggle + close button */}
-      <div className={cn("flex items-center justify-between", collapsed ? "flex-col gap-1 px-2 pt-2 pb-1" : "px-3 pt-3 pb-2")}>
+      <div className={cn("flex items-center justify-between", collapsed ? "flex-col gap-1 px-2 pt-2 pb-1" : "px-5 pt-6 pb-5")}>
         <div className={cn("flex items-center gap-2", collapsed && "justify-center")}>
-          <PetCompanion size={32} onOpen={onClose} fallback={<Link href="/tasks" prefetch onClick={onClose} aria-label="Loma home"><CrosscutIcon size={collapsed ? 22 : 20} /></Link>} />
+          <PetCompanion size={32} onOpen={onClose} fallback={<Link href="/tasks" prefetch onClick={onClose} aria-label="Loma home"><CrosscutIcon size={collapsed ? 22 : 27} /></Link>} />
           {!collapsed && (
-            <Link href="/tasks" prefetch onClick={onClose} className="font-[family-name:var(--font-logo)] text-base font-bold tracking-[0.5px] text-foreground/80">
-              Loma
+            <Link href="/tasks" prefetch onClick={onClose} className="font-sans text-[29px] font-medium tracking-[-0.04em] text-foreground">
+              loma
             </Link>
           )}
         </div>
@@ -481,18 +481,19 @@ export default function Sidebar({
                   onClick={onClose}
                   className={cn(
                     // Roomier on phones (Claude-app scale), compact on desktop
-                    "flex items-center rounded-lg text-xs font-medium transition-all duration-150",
+                    "flex items-center rounded-lg text-[13px] font-medium transition-colors duration-150",
                     "max-md:text-[16px] max-md:[&_svg]:h-5 max-md:[&_svg]:w-5",
                     collapsed
                       ? "justify-center px-0 py-1.5 mx-auto w-10"
-                      : "px-2 py-1 gap-2 max-md:px-3 max-md:py-2.5 max-md:gap-3",
+                      : "px-3 py-2 gap-2.5 max-md:py-2.5 max-md:gap-3",
                     isActive
-                      ? "bg-brand-100/80 text-brand-700"
-                      : "text-muted-foreground hover:bg-accent-200/15 hover:text-foreground hover:translate-x-0.5"
+                      ? "bg-sidebar-primary text-sidebar-primary-foreground"
+                      : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
                   )}
+                  aria-current={isActive ? "page" : undefined}
                   title={collapsed ? item.name : undefined}
                 >
-                  <span className={cn("relative transition-colors flex-shrink-0", isActive ? "text-brand-600" : "text-muted-foreground")}>
+                  <span className={cn("relative transition-colors flex-shrink-0", isActive ? "text-sidebar-primary-foreground" : "text-sidebar-foreground")}>
                     {item.icon}
                     {collapsed && item.badgeKey && badgeCounts[item.badgeKey] > 0 && (
                       <span className="absolute -top-0.5 -right-0.5 h-1.5 w-1.5 rounded-full bg-amber-500" />
@@ -500,11 +501,11 @@ export default function Sidebar({
                   </span>
                   {!collapsed && <span>{item.name}</span>}
                   {!collapsed && item.badgeKey && badgeCounts[item.badgeKey] > 0 ? (
-                    <span className="ml-auto min-w-[18px] h-[18px] px-1 flex items-center justify-center rounded-md bg-brand-50 text-brand-600 text-[10px] font-semibold ring-1 ring-brand-200/60">
+                    <span className="ml-auto min-w-[20px] h-5 px-1 shrink-0 whitespace-nowrap flex items-center justify-center rounded bg-current/10 text-[11px] font-semibold tabular-nums">
                       {badgeCounts[item.badgeKey]}
                     </span>
                   ) : !collapsed && isActive ? (
-                    <span className="ml-auto w-0.5 h-4 bg-brand-500 rounded-full" />
+                    <span className="ml-auto w-0.5 h-4 bg-sidebar-primary-foreground rounded-full" />
                   ) : null}
                 </Link>
               );
@@ -530,7 +531,7 @@ export default function Sidebar({
                       prefetch
                       onClick={onClose}
                       title={p.name}
-                      className="group flex items-center gap-1 px-2 py-1 text-xs max-md:px-3 max-md:py-2 max-md:text-[15px] rounded-lg transition-all duration-150 text-muted-foreground hover:text-foreground hover:bg-muted"
+                      className="group flex items-center gap-1 px-2 py-1 text-[13px] max-md:px-3 max-md:py-2 max-md:text-[15px] rounded-lg transition-all duration-150 text-muted-foreground hover:text-foreground hover:bg-muted"
                     >
                       <span className="w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: p.color || '#94a3b8' }} />
                       <span className="truncate flex-1 min-w-0">{p.name}</span>
@@ -558,7 +559,7 @@ export default function Sidebar({
                       <div
                         key={c.conversation_id}
                         className={cn(
-                          "group flex items-center gap-1 px-2 py-1 text-xs max-md:px-3 max-md:py-2 max-md:text-[15px] rounded-lg transition-all duration-150",
+                          "group flex items-center gap-1 px-2 py-1 text-[13px] max-md:px-3 max-md:py-2 max-md:text-[15px] rounded-lg transition-all duration-150",
                           isConvoActive
                             ? "text-brand-700 bg-brand-100/80 font-medium"
                             : "text-muted-foreground hover:text-foreground hover:bg-muted"
@@ -614,7 +615,7 @@ export default function Sidebar({
                       <div
                         key={c.conversation_id}
                         className={cn(
-                          "group flex items-center gap-1 px-2 py-1 text-xs max-md:px-3 max-md:py-2 max-md:text-[15px] rounded-lg transition-all duration-150",
+                          "group flex items-center gap-1 px-2 py-1 text-[13px] max-md:px-3 max-md:py-2 max-md:text-[15px] rounded-lg transition-all duration-150",
                           isConvoActive
                             ? "text-brand-700 bg-brand-100/80 font-medium"
                             : "text-muted-foreground hover:text-foreground hover:bg-muted"
@@ -787,7 +788,7 @@ export default function Sidebar({
 
       <aside
         className={cn(
-          "fixed top-0 left-0 h-dvh pt-[env(safe-area-inset-top)] flex flex-col z-50 transition-all duration-200 ease-out bg-muted",
+          "loma-sidebar fixed top-0 left-0 h-dvh pt-[env(safe-area-inset-top)] flex flex-col z-50 transition-all duration-200 ease-out bg-sidebar",
           isOpen ? "translate-x-0" : "-translate-x-full",
           "md:translate-x-0",
           collapsed ? "w-[56px]" : "w-[300px] md:w-[220px]"

--- a/dashboard/src/components/tasks/QuickAddTask.tsx
+++ b/dashboard/src/components/tasks/QuickAddTask.tsx
@@ -94,7 +94,7 @@ export function QuickAddTask({ onAdded }: QuickAddTaskProps) {
       <div className="mx-auto w-full max-w-3xl">
       {error && <p className="mb-1 text-xs text-destructive">{error}</p>}
       <PendingFilesStrip files={files} onRemove={(i) => setFiles((prev) => prev.filter((_, idx) => idx !== i))} />
-      <div className="flex flex-col bg-muted border border-border rounded-2xl focus-within:border-gray-300 transition-colors">
+      <div className="flex flex-col bg-card border border-input rounded-xl shadow-sm focus-within:border-ring focus-within:ring-1 focus-within:ring-ring/20 transition-colors">
         <Textarea
           value={value}
           onChange={(e) => setValue(e.target.value)}
@@ -116,8 +116,8 @@ export function QuickAddTask({ onAdded }: QuickAddTaskProps) {
           className="w-full bg-transparent px-3 pt-3 pb-1.5 text-[13px] text-foreground placeholder-muted-foreground focus:outline-none resize-none overflow-hidden border-0 focus-visible:ring-0 focus-visible:border-transparent rounded-none min-h-0"
           style={{ maxHeight: "120px" }}
         />
-        <div className="flex items-center justify-between gap-2 px-2 pb-2">
-          <div className="flex min-w-0 items-center gap-1">
+        <div className="flex items-center justify-between gap-2 px-2 pb-2 max-md:flex-wrap">
+          <div className="flex min-w-0 items-center gap-1 max-md:w-full max-md:flex-wrap">
             <ModelPicker
               models={models}
               selectedModel={selectedModel}
@@ -126,7 +126,7 @@ export function QuickAddTask({ onAdded }: QuickAddTaskProps) {
             />
             <ToolsPicker tools={availableTools} skills={availableSkills} selection={toolsSelection} onToggleTool={toggleTool} onToggleSkill={toggleSkill} onEnableAll={enableAllTools} onOpen={loadToolsCatalog} isAllEnabled={allToolsEnabled} disabledCount={toolsDisabledCount} loadState={toolsLoadState} isAlwaysEnabled={isAlwaysEnabled} />
           </div>
-          <div className="flex items-center gap-1 max-md:gap-2 shrink-0">
+          <div className="ml-auto flex items-center gap-1 max-md:gap-2 shrink-0">
             <DictationButton
               onText={(t) => setValue((prev) => appendDictation(prev, t))}
               mobileProminent

--- a/dashboard/src/components/tasks/TaskCard.tsx
+++ b/dashboard/src/components/tasks/TaskCard.tsx
@@ -64,22 +64,23 @@ export function TaskCard({
         setMenuOpen(true);
       }}
       className={cn(
-        "group rounded-md border bg-card px-3 py-2 cursor-pointer",
-        "hover:bg-muted/50 touch-none select-none",
+        "group relative rounded-lg border bg-card px-3 py-3 shadow-[0_1px_2px_#061b2005] cursor-pointer",
+        "hover:border-input hover:shadow-sm touch-none select-none",
+        task.column === "needs_input" && "border-amber-300",
         isDragging && "opacity-40",
       )}
     >
       <div className="flex items-start gap-2">
         {dot && <span className={cn("mt-1.5 h-2 w-2 shrink-0 rounded-full", dot)} />}
         <div className="min-w-0 flex-1">
-          <div className="line-clamp-2 break-words text-[13px]">
+          <div className="line-clamp-2 break-words text-[15px] leading-5">
             {task.title || task.prompt || "New task"}
           </div>
-          <div className="mt-0.5 flex items-center gap-2 text-xs text-muted-foreground">
+          <div className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] leading-4 text-muted-foreground">
             <ClientTimestamp iso={timestamp} variant="short" placeholder="—" />
             {task.total_turns > 0 && <span>{task.total_turns} turns</span>}
           </div>
-          <div className="mt-1 flex items-center gap-1 overflow-hidden">
+          <div className="mt-1 flex items-center gap-1 overflow-hidden pr-12">
             <TaskPriorityTag task={task} onSetPriority={onSetPriority} />
             <TaskDeadlineBadge task={task} />
             {assignedTags.slice(0, 2).map((tag) => <span key={tag.id} className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">{tag.name}</span>)}
@@ -89,7 +90,7 @@ export function TaskCard({
         <div
           // Hover-revealed on pointer devices; always visible on touch
           // (hover never fires there) and while focused via keyboard.
-          className="flex shrink-0 items-center gap-0.5 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 pointer-coarse:opacity-100"
+          className="absolute bottom-2 right-2 flex shrink-0 items-center gap-0.5 rounded bg-card opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 pointer-coarse:opacity-100"
           onClick={(e) => e.stopPropagation()}
           onPointerDown={(e) => e.stopPropagation()}
         >

--- a/dashboard/src/components/tasks/TaskColumn.tsx
+++ b/dashboard/src/components/tasks/TaskColumn.tsx
@@ -24,12 +24,12 @@ export function TaskColumn({ id, name, tasks, droppable, onAddTask, children }: 
   });
 
   return (
-    <div className="flex w-64 shrink-0 flex-col">
+    <div className="flex min-w-[200px] flex-1 basis-0 flex-col">
       <div className="mb-2 flex items-baseline gap-2 px-1">
-        <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+        <span className="text-[13px] font-medium text-foreground">
           {name}
         </span>
-        <span className="text-xs text-muted-foreground/70">{tasks.length}</span>
+        <span className="rounded bg-muted px-1.5 text-[11px] tabular-nums text-muted-foreground">{tasks.length}</span>
       </div>
       <SortableContext
         items={tasks.map((t) => t.conversation_id)}


### PR DESCRIPTION
## Summary
Apply the approved botanical/editorial Paper concept across the entire Loma dashboard, not only Tasks.

- Shared forest, warm canvas, white card, and leaf-highlight tokens cover navigation, forms, tables, dialogs, agent cards, notifications, integrations, skills, usage, analytics, flows, and admin screens.
- DM Sans body type and Instrument Serif page titles, self-hosted through `next/font`; keep code monospace and user-authored Markdown hierarchy separate.
- Forest sidebar and mobile navigation, original Crosscut logo and Red Hat Display Loma wordmark, readable non-wrapping badges, and explicit current-page semantics. Existing pet companions and preferences remain functional.
- Responsive task columns fit five lanes at 1440px while retaining horizontal scrolling for narrower layouts or more custom lanes. Clearer titles, metadata, and attention borders.
- Card-surface composers and wrapped mobile controls; reserve mobile menu space so headers do not collide with navigation.
- Forest dark mode and reduced-motion support. No backend, task execution, authentication, or permission changes.

## Design reference
[Approved Paper concept](https://app.paper.design/file/01M21A18N4V50EEBBPJRHHM2AK/1-0)

Uses the approved preview substitutes, DM Sans and Instrument Serif, rather than unbundled Feature Deck/Halyard fonts.

## Verification
- `npm run build`: PASS (production compilation and TypeScript).
- `tsc --noEmit`: PASS.
- ESLint: clean for the other modified TSX files. `Sidebar.tsx` and `ChatPanel.tsx` retain exactly the baseline findings: 2 existing React Hooks errors and 11 warnings, with no new findings.
- Real Chromium browser against the actual local backend and dashboard. First-admin setup login against a fresh isolated database, with Slack and scheduler disabled; all displayed records are synthetic fixtures.
- 16 desktop route visits, including all primary navigation screens plus admin/user, conversation, and skill detail routes: no uncaught JavaScript errors or page-level horizontal overflow. Page Index showed its existing missing `page-index.json` empty/error state; no data was available to verify its graph.
- 18 responsive/interaction checks passed: five-column fit, task dialog opening and Escape dismissal, sidebar collapse/expand, mobile menu, five dark-mode screens, and nine mobile screens at 390px.
- Additional check: typed mobile composer keeps the enabled send button inside the viewport. No agent run or external integration was triggered.
- `git diff --check`: PASS.

## Logo and pets follow-up
- Restored the exact original `CrosscutIcon` SVG, sidebar wordmark styling, and Red Hat Display logo font. The dashboard theme remains unchanged.
- Pets were absent from the earlier screenshots because the synthetic local test account had `visible: false`; no pet feature had been removed. No real user preferences were modified.
- Verified default pets on Tasks and Chat, selecting a different pet and persisting it across reload, desktop/mobile settings, dark mode, reduced-motion styling, and original logo fallback when pets are hidden. No uncaught browser errors. No agent runs were triggered; the streaming runway code is unchanged and was not exercised in this follow-up.
- Follow-up `tsc --noEmit`, production build, and `git diff --check`: PASS.
- Added identity/pet preservation guidance to `dashboard/DESIGN.md`.

## Screenshots
Updated screenshots supersede the earlier pet-hidden previews. Synthetic local data only.

<details>
<summary>Tasks with default pet</summary>

![Tasks with default pet](https://cdn.plotline.so/loma-images/3f04d18c66674efbad48468593ced4f9.png)

</details>

<details>
<summary>Chat with selected pet</summary>

![Chat with selected pet](https://cdn.plotline.so/loma-images/c16ae8d62cee4fa4b416c6de32c28639.png)

</details>

<details>
<summary>Chat with pet, dark mode</summary>

![Chat with pet, dark mode](https://cdn.plotline.so/loma-images/17f023718abd4cd9864fe2a80c9f1b7f.png)

</details>

<details>
<summary>Chat with pet, mobile</summary>

![Chat with pet, mobile](https://cdn.plotline.so/loma-images/5bac921c9cce474889fb771e62df185d.png)

</details>

<details>
<summary>Mobile navigation with pet</summary>

![Mobile navigation with pet](https://cdn.plotline.so/loma-images/50cac052acc0482487a540b3e2eb89cf.png)

</details>

<details>
<summary>Pet picker, desktop</summary>

![Pet picker, desktop](https://cdn.plotline.so/loma-images/da91e8d4b46748ce84a845bc0546b85e.png)

</details>

<details>
<summary>Pet picker, mobile</summary>

![Pet picker, mobile](https://cdn.plotline.so/loma-images/23005ac8ad4b4851802344b656711b2c.png)

</details>

<details>
<summary>Original logo fallback with pets hidden</summary>

![Original logo fallback with pets hidden](https://cdn.plotline.so/loma-images/75a8ecee2cc54e43aab872fdd9208647.png)

</details>

<details>
<summary>Original logo and wordmark on login</summary>

![Original logo and wordmark on login](https://cdn.plotline.so/loma-images/6eb54cc36b144de5b856c104d62526cc.png)

</details>

## Review notes
Draft PR generated by Loma for the approved dashboard-wide refresh. Please review before merging.

