### PR TITLE
fix: align dark bg and topic tags with new color palette

### DIFF
--- a/dashboard/src/app/conversations/page.tsx
+++ b/dashboard/src/app/conversations/page.tsx
@@ -57,18 +57,8 @@ const statusLabels: Record<string, string> = {
   error: "Error",
 };
 
-const topicStyles: Record<string, string> = {
-  debugging: "bg-red-50 text-red-700",
-  integration: "bg-blue-50 text-blue-700",
-  billing: "bg-green-50 text-green-700",
-  "feature-request": "bg-purple-50 text-purple-700",
-  campaign: "bg-orange-50 text-orange-700",
-  sdk: "bg-cyan-50 text-cyan-700",
-  data: "bg-teal-50 text-teal-700",
-  security: "bg-rose-50 text-rose-700",
-  documentation: "bg-yellow-50 text-yellow-700",
-  other: "bg-gray-50 text-gray-600",
-};
+/* New palette: topic tags share one neutral style (cream fill, warm dark text). */
+const topicTagClass = "bg-[#F5F1ED] text-[#322C26]";
 
 const topicLabels: Record<string, string> = {
   debugging: "Debugging",
@@ -433,7 +423,7 @@ export default function ConversationsPage() {
                     {/* Topic */}
                     <TableCell>
                       {c.topic ? (
-                        <Badge variant="secondary" className={cn("text-xs", topicStyles[c.topic] || "bg-gray-100 text-gray-600")}>
+                        <Badge variant="secondary" className={cn("text-xs", topicTagClass)}>
                           {topicLabels[c.topic] || c.topic}
                         </Badge>
                       ) : <span className="text-xs text-muted-foreground/40">&mdash;</span>}
@@ -557,7 +547,7 @@ export default function ConversationsPage() {
                           <span className="tabular-nums">${c.cost.total_cost_usd.toFixed(2)}</span>
                         )}
                         {c.topic && (
-                          <Badge variant="secondary" className={cn("text-[10px] py-0 px-1.5", topicStyles[c.topic] || "bg-gray-100 text-gray-600")}>
+                          <Badge variant="secondary" className={cn("text-[10px] py-0 px-1.5", topicTagClass)}>
                             {topicLabels[c.topic] || c.topic}
                           </Badge>
                         )}

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -49,7 +49,7 @@
 /* ── Dark mode palette inversion ─────────────────────────────────────────── */
 
 [data-theme="dark"] {
-  --color-gray-50: #091D21;
+  --color-gray-50: #061B20;
   --color-gray-100: #10282B;
   --color-gray-200: #284143;
   --color-gray-300: #3C5353;
@@ -665,7 +665,7 @@
 }
 
 [data-theme="dark"] {
-  --background: #091D21;
+  --background: #061B20;
   --foreground: #F7F4EF;
   --card: #122D30;
   --card-foreground: #F7F4EF;


### PR DESCRIPTION
## Summary
- Dark mode background is now always `#061B20` (was `#091D21`) — updated `--background` and the dark `--color-gray-50` token
- Topic tags on the Conversations page now use the new neutral tag style: `#F5F1ED` fill with `#322C26` text (replacing the per-topic blue/red/green color map), matching the "Everyone" tag reference

## Context
Design feedback from Nandita: Loma is on the new color palette — dark bg should always be `#061B20`, and tags at this level should use `#F5F1ED` fill and `#322C26` text.

## Changes
- `dashboard/src/app/globals.css` — dark theme `--background` and `--color-gray-50` changed `#091D21` → `#061B20`
- `dashboard/src/app/conversations/page.tsx` — replaced the `topicStyles` per-topic color map with a single `topicTagClass` (`bg-[#F5F1ED] text-[#322C26]`), applied to both desktop table and mobile list badges

## Testing
Booted the full stack locally (backend + dashboard, isolated throwaway DB), logged in, seeded sample conversations, and verified in a real browser:
- Dark mode body background computed as `rgb(6, 27, 32)` = `#061B20` ✅
- Topic tag computed styles: `rgb(245, 241, 237)` fill / `rgb(50, 44, 38)` text = `#F5F1ED` / `#322C26` ✅

**Dark mode:**
![dark](https://cdn.plotline.so/loma-images/loma-pr/palette-conversations-dark.png)

**Light mode:**
![light](https://cdn.plotline.so/loma-images/loma-pr/palette-conversations-light.png)

## Notes
- This PR was generated by the Plotline IE Bot based on the request above
- Please review carefully before merging
