### PR TITLE
redesign: UI system rebuild — semantic tokens, refined light/dark themes, quieter chrome

### DIFF
--- a/dashboard/src/app/chat/page.tsx
+++ b/dashboard/src/app/chat/page.tsx
@@ -185,8 +185,8 @@ function ChatPageContent() {
   if (loading) {
     return (
       <div className="flex-1 min-h-0 flex flex-col -mb-3">
-        <div className="px-3 lg:px-4 py-4 border-b border-border bg-card">
-          <h1 className="text-lg md:text-xl font-heading font-semibold text-foreground">{flowId ? "Edit Flow" : taskId ? "Edit Task" : "Continue Chat"}</h1>
+        <div className="flex min-h-14 flex-col justify-center px-3 lg:px-4 py-2 border-b border-border">
+          <h1 className="truncate text-[15px] font-semibold text-foreground">{flowId ? "Edit Flow" : taskId ? "Edit Task" : "Continue Chat"}</h1>
           <p className="text-[13px] text-muted-foreground">{flowId ? "Loading flow..." : taskId ? "Loading task..." : "Loading conversation..."}</p>
         </div>
         <div className="flex-1 flex items-center justify-center bg-muted/30">
@@ -243,8 +243,8 @@ function ChatPageContent() {
       )}
 
       {/* Header with title and action buttons — desktop only; hidden for auto-sent prompts until conversation starts */}
-      {showHeader && <div className="hidden md:block px-3 lg:px-4 py-3 border-b border-border bg-card flex-shrink-0">
-        <div className="flex items-center gap-2">
+      {showHeader && <div className="hidden md:flex min-h-14 items-center px-3 lg:px-4 border-b border-border flex-shrink-0">
+        <div className="flex w-full items-center gap-2">
           {/* Title area */}
           <div className="min-w-0 flex-1">
             {activeConversationId && editingTitle ? (
@@ -275,7 +275,7 @@ function ChatPageContent() {
               <div className="flex items-center gap-2 min-w-0">
                 <h1
                   className={cn(
-                    "text-base font-heading font-semibold text-foreground truncate",
+                    "text-[15px] font-semibold text-foreground truncate",
                     activeConversationId && user?.email === conversationOwner && "cursor-pointer hover:text-brand-600 transition-colors"
                   )}
                   onClick={() => {
@@ -450,8 +450,8 @@ export default function ChatPage() {
     <Suspense
       fallback={
         <div className="flex-1 min-h-0 flex flex-col -mb-3">
-          <div className="px-3 lg:px-4 py-4 border-b border-border bg-card">
-            <h1 className="text-lg md:text-xl font-heading font-semibold text-foreground">Chat</h1>
+          <div className="flex min-h-14 items-center px-3 lg:px-4 border-b border-border">
+            <h1 className="truncate text-[15px] font-semibold text-foreground">Chat</h1>
           </div>
           <div className="flex-1 bg-muted/30 flex items-center justify-center">
             <RiLoader4Line size={32} className="animate-spin text-muted-foreground" />

--- a/dashboard/src/app/chat/page.tsx
+++ b/dashboard/src/app/chat/page.tsx
@@ -276,6 +276,7 @@ function ChatPageContent() {
                 <h1
                   className={cn(
                     "text-[15px] font-semibold text-foreground truncate",
+                    headerTitle === "New Chat" && "editorial-heading text-[19px]",
                     activeConversationId && user?.email === conversationOwner && "cursor-pointer hover:text-brand-600 transition-colors"
                   )}
                   onClick={() => {

--- a/dashboard/src/app/flows/page.tsx
+++ b/dashboard/src/app/flows/page.tsx
@@ -482,7 +482,7 @@ function FlowTabButton({
         marginBottom: "-1px",
         fontFamily: "var(--font-sans), system-ui, sans-serif",
         fontSize: 14,
-        fontWeight: active ? 600 : 500,
+        fontWeight: 500,
       }}
     >
       <span>{label}</span>
@@ -494,7 +494,7 @@ function FlowTabButton({
           fontFamily: "var(--font-jetbrains), ui-monospace, monospace",
           fontSize: 10,
           color: "#5C5650",
-          fontWeight: 600,
+          fontWeight: 500,
         }}
       >
         {count}

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -6,6 +6,13 @@
 @custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
 
 @theme {
+  /* Typography weights — Halyard ships Regular (400) and Medium (500) only.
+     Product default is Regular; emphasis steps up to the real Medium cut
+     (never a synthesized semibold/bold, which breaks kerning). */
+  --font-weight-medium: 400;
+  --font-weight-semibold: 500;
+  --font-weight-bold: 500;
+
   /* Gray: warm neutrals.
      50 secondary surface · 100 canvas · 200 subtle hover · 300 hairline
      400 tertiary text · 500 secondary text · 900 primary ink */
@@ -190,12 +197,19 @@
     font-feature-settings: "rlig" 1, "calt" 1;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    /* Never synthesize missing weights — faux bold wrecks Halyard's kerning.
+       Requests above 500 fall back to the real Medium cut. */
+    font-synthesis-weight: none;
     letter-spacing: -0.01em;
     transition: background-color 0.2s ease-out, color 0.2s ease-out;
     @apply bg-background text-foreground;
   }
   * {
     @apply border-border outline-ring/50;
+  }
+  strong, b {
+    /* Emphasis (e.g. "Stopped by user.") uses the real Medium cut. */
+    font-weight: 500;
   }
   button:not(:disabled), [role="button"]:not(:disabled) {
     cursor: pointer;

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -6,14 +6,16 @@
 @custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
 
 @theme {
-  /* Gray: warm neutrals */
-  --color-gray-50: #FBF9F5;
-  --color-gray-100: #F7F4EF;
-  --color-gray-200: #EEE8E0;
-  --color-gray-300: #D8D2C9;
-  --color-gray-400: #918A81;
-  --color-gray-500: #706B65;
-  --color-gray-600: #565D57;
+  /* Gray: warm neutrals.
+     50 secondary surface · 100 canvas · 200 subtle hover · 300 hairline
+     400 tertiary text · 500 secondary text · 900 primary ink */
+  --color-gray-50: #F9F7F3;
+  --color-gray-100: #F5F1ED;
+  --color-gray-200: #EEEAE4;
+  --color-gray-300: #DDD9D2;
+  --color-gray-400: #8A8F8D;
+  --color-gray-500: #59615F;
+  --color-gray-600: #45514D;
   --color-gray-700: #263D3B;
   --color-gray-800: #12312F;
   --color-gray-900: #061B20;
@@ -30,14 +32,16 @@
   --color-brand-800: #073B35;
   --color-brand-900: #061B20;
 
-  /* Leaf highlight: selected navigation and composer actions */
-  --color-accent-50: #F5F9EF;
-  --color-accent-100: #E7F2D6;
-  --color-accent-200: #C8E98F;
-  --color-accent-300: #B5D77A;
-  --color-accent-400: #9BBF63;
-  --color-accent-500: #567C38;
-  --color-accent-600: #3F612A;
+  /* Lime highlighter: tiny moments of emphasis, never a background system.
+     200 is the brand accent #DDF7A8; 500/600 are restrained functional greens
+     for text/status where lime would be too loud. */
+  --color-accent-50: #F4FAE3;
+  --color-accent-100: #EBF7CC;
+  --color-accent-200: #DDF7A8;
+  --color-accent-300: #D0EE93;
+  --color-accent-400: #B9DB7B;
+  --color-accent-500: #576F20;
+  --color-accent-600: #47591C;
 
   /* Surface: cards, panels, modals (white in light, warm dark in dark) */
   --color-surface: #FFFFFF;
@@ -49,133 +53,136 @@
 /* ── Dark mode palette inversion ─────────────────────────────────────────── */
 
 [data-theme="dark"] {
+  /* Near-black green shell → subtly lighter work surfaces → warm off-white type.
+     50 canvas · 100 elevated surface · 200 secondary surface · 300 hover
+     400 tertiary text · 500 secondary text · 900 primary text */
   --color-gray-50: #061B20;
-  --color-gray-100: #10282B;
-  --color-gray-200: #284143;
-  --color-gray-300: #3C5353;
-  --color-gray-400: #91A49C;
-  --color-gray-500: #A8B9AF;
-  --color-gray-600: #C1CEC3;
-  --color-gray-700: #DDE4D9;
-  --color-gray-800: #EDF0E7;
-  --color-gray-900: #F7F4EF;
+  --color-gray-100: #102A2C;
+  --color-gray-200: #163335;
+  --color-gray-300: #1D3B3C;
+  --color-gray-400: #7F918B;
+  --color-gray-500: #B9C1BD;
+  --color-gray-600: #CBD1CB;
+  --color-gray-700: #E3E4DD;
+  --color-gray-800: #EDEBE4;
+  --color-gray-900: #F5F1ED;
 
-  --color-brand-50: #10282B;
-  --color-brand-100: #193A34;
-  --color-brand-200: #2C5546;
-  --color-brand-300: #45705B;
-  --color-brand-400: #7CA286;
-  --color-brand-500: #91B89A;
-  --color-brand-600: #ACCDAA;
-  --color-brand-700: #C8E0B5;
-  --color-brand-800: #E0EBCF;
+  --color-brand-50: #102A2C;
+  --color-brand-100: #163335;
+  --color-brand-200: #1F4A40;
+  --color-brand-300: #2E5F50;
+  --color-brand-400: #6FA089;
+  --color-brand-500: #8FB89E;
+  --color-brand-600: #A9CCAC;
+  --color-brand-700: #C6DEB9;
+  --color-brand-800: #DFEBD0;
   --color-brand-900: #F0F5EC;
 
-  --color-accent-50: #132A25;
-  --color-accent-100: #253F2F;
-  --color-accent-200: #C8E98F;
-  --color-accent-300: #B5D77A;
-  --color-accent-400: #D7EFAE;
-  --color-accent-500: #A6C97D;
-  --color-accent-600: #C8E98F;
+  --color-accent-50: #14261A;
+  --color-accent-100: #1C3320;
+  --color-accent-200: #DDF7A8;
+  --color-accent-300: #E6FAC0;
+  --color-accent-400: #CFEA8F;
+  --color-accent-500: #A8C46F;
+  --color-accent-600: #DDF7A8;
 
-  --color-surface: #122D30;
+  --color-surface: #102A2C;
 
   /* Semantic color badge overrides: flip light bg/border to dark equivalents.
      -50 (badge bg) → very dark tint | -100 → slightly brighter | -200 (border) → muted dark
      -700 (text) → lighter for readability on dark */
 
   /* Blue */
-  --color-blue-50: color-mix(in srgb, #3b82f6 10%, #0A0A0A);
-  --color-blue-100: color-mix(in srgb, #3b82f6 15%, #0A0A0A);
-  --color-blue-200: color-mix(in srgb, #3b82f6 25%, #0A0A0A);
+  --color-blue-50: color-mix(in srgb, #3b82f6 10%, #0A2226);
+  --color-blue-100: color-mix(in srgb, #3b82f6 15%, #0A2226);
+  --color-blue-200: color-mix(in srgb, #3b82f6 25%, #0A2226);
   --color-blue-700: #60a5fa;
 
   /* Red */
-  --color-red-50: color-mix(in srgb, #ef4444 10%, #0A0A0A);
-  --color-red-100: color-mix(in srgb, #ef4444 15%, #0A0A0A);
-  --color-red-200: color-mix(in srgb, #ef4444 25%, #0A0A0A);
+  --color-red-50: color-mix(in srgb, #ef4444 10%, #0A2226);
+  --color-red-100: color-mix(in srgb, #ef4444 15%, #0A2226);
+  --color-red-200: color-mix(in srgb, #ef4444 25%, #0A2226);
   --color-red-700: #f87171;
 
   /* Green */
-  --color-green-50: color-mix(in srgb, #22c55e 10%, #0A0A0A);
-  --color-green-100: color-mix(in srgb, #22c55e 15%, #0A0A0A);
-  --color-green-200: color-mix(in srgb, #22c55e 25%, #0A0A0A);
+  --color-green-50: color-mix(in srgb, #22c55e 10%, #0A2226);
+  --color-green-100: color-mix(in srgb, #22c55e 15%, #0A2226);
+  --color-green-200: color-mix(in srgb, #22c55e 25%, #0A2226);
   --color-green-700: #4ade80;
 
   /* Amber */
-  --color-amber-50: color-mix(in srgb, #f59e0b 10%, #0A0A0A);
-  --color-amber-100: color-mix(in srgb, #f59e0b 15%, #0A0A0A);
-  --color-amber-200: color-mix(in srgb, #f59e0b 25%, #0A0A0A);
+  --color-amber-50: color-mix(in srgb, #f59e0b 10%, #0A2226);
+  --color-amber-100: color-mix(in srgb, #f59e0b 15%, #0A2226);
+  --color-amber-200: color-mix(in srgb, #f59e0b 25%, #0A2226);
   --color-amber-700: #fbbf24;
 
   /* Emerald */
-  --color-emerald-50: color-mix(in srgb, #10b981 10%, #0A0A0A);
-  --color-emerald-100: color-mix(in srgb, #10b981 15%, #0A0A0A);
-  --color-emerald-200: color-mix(in srgb, #10b981 25%, #0A0A0A);
+  --color-emerald-50: color-mix(in srgb, #10b981 10%, #0A2226);
+  --color-emerald-100: color-mix(in srgb, #10b981 15%, #0A2226);
+  --color-emerald-200: color-mix(in srgb, #10b981 25%, #0A2226);
   --color-emerald-700: #34d399;
 
   /* Purple */
-  --color-purple-50: color-mix(in srgb, #a855f7 10%, #0A0A0A);
-  --color-purple-100: color-mix(in srgb, #a855f7 15%, #0A0A0A);
-  --color-purple-200: color-mix(in srgb, #a855f7 25%, #0A0A0A);
+  --color-purple-50: color-mix(in srgb, #a855f7 10%, #0A2226);
+  --color-purple-100: color-mix(in srgb, #a855f7 15%, #0A2226);
+  --color-purple-200: color-mix(in srgb, #a855f7 25%, #0A2226);
   --color-purple-700: #c084fc;
 
   /* Indigo */
-  --color-indigo-50: color-mix(in srgb, #6366f1 10%, #0A0A0A);
-  --color-indigo-100: color-mix(in srgb, #6366f1 15%, #0A0A0A);
-  --color-indigo-200: color-mix(in srgb, #6366f1 25%, #0A0A0A);
+  --color-indigo-50: color-mix(in srgb, #6366f1 10%, #0A2226);
+  --color-indigo-100: color-mix(in srgb, #6366f1 15%, #0A2226);
+  --color-indigo-200: color-mix(in srgb, #6366f1 25%, #0A2226);
   --color-indigo-700: #818cf8;
 
   /* Orange */
-  --color-orange-50: color-mix(in srgb, #f97316 10%, #0A0A0A);
-  --color-orange-100: color-mix(in srgb, #f97316 15%, #0A0A0A);
-  --color-orange-200: color-mix(in srgb, #f97316 25%, #0A0A0A);
+  --color-orange-50: color-mix(in srgb, #f97316 10%, #0A2226);
+  --color-orange-100: color-mix(in srgb, #f97316 15%, #0A2226);
+  --color-orange-200: color-mix(in srgb, #f97316 25%, #0A2226);
   --color-orange-700: #fb923c;
 
   /* Yellow */
-  --color-yellow-50: color-mix(in srgb, #eab308 10%, #0A0A0A);
-  --color-yellow-100: color-mix(in srgb, #eab308 15%, #0A0A0A);
-  --color-yellow-200: color-mix(in srgb, #eab308 25%, #0A0A0A);
+  --color-yellow-50: color-mix(in srgb, #eab308 10%, #0A2226);
+  --color-yellow-100: color-mix(in srgb, #eab308 15%, #0A2226);
+  --color-yellow-200: color-mix(in srgb, #eab308 25%, #0A2226);
   --color-yellow-700: #facc15;
 
   /* Pink */
-  --color-pink-50: color-mix(in srgb, #ec4899 10%, #0A0A0A);
-  --color-pink-100: color-mix(in srgb, #ec4899 15%, #0A0A0A);
-  --color-pink-200: color-mix(in srgb, #ec4899 25%, #0A0A0A);
+  --color-pink-50: color-mix(in srgb, #ec4899 10%, #0A2226);
+  --color-pink-100: color-mix(in srgb, #ec4899 15%, #0A2226);
+  --color-pink-200: color-mix(in srgb, #ec4899 25%, #0A2226);
   --color-pink-700: #f472b6;
 
   /* Teal */
-  --color-teal-50: color-mix(in srgb, #14b8a6 10%, #0A0A0A);
-  --color-teal-100: color-mix(in srgb, #14b8a6 15%, #0A0A0A);
-  --color-teal-200: color-mix(in srgb, #14b8a6 25%, #0A0A0A);
+  --color-teal-50: color-mix(in srgb, #14b8a6 10%, #0A2226);
+  --color-teal-100: color-mix(in srgb, #14b8a6 15%, #0A2226);
+  --color-teal-200: color-mix(in srgb, #14b8a6 25%, #0A2226);
   --color-teal-700: #2dd4bf;
 
   /* Cyan */
-  --color-cyan-50: color-mix(in srgb, #06b6d4 10%, #0A0A0A);
-  --color-cyan-100: color-mix(in srgb, #06b6d4 15%, #0A0A0A);
-  --color-cyan-200: color-mix(in srgb, #06b6d4 25%, #0A0A0A);
+  --color-cyan-50: color-mix(in srgb, #06b6d4 10%, #0A2226);
+  --color-cyan-100: color-mix(in srgb, #06b6d4 15%, #0A2226);
+  --color-cyan-200: color-mix(in srgb, #06b6d4 25%, #0A2226);
   --color-cyan-700: #22d3ee;
 
   /* Violet */
-  --color-violet-50: color-mix(in srgb, #8b5cf6 10%, #0A0A0A);
-  --color-violet-100: color-mix(in srgb, #8b5cf6 15%, #0A0A0A);
-  --color-violet-200: color-mix(in srgb, #8b5cf6 25%, #0A0A0A);
+  --color-violet-50: color-mix(in srgb, #8b5cf6 10%, #0A2226);
+  --color-violet-100: color-mix(in srgb, #8b5cf6 15%, #0A2226);
+  --color-violet-200: color-mix(in srgb, #8b5cf6 25%, #0A2226);
   --color-violet-700: #a78bfa;
 
   /* Rose */
-  --color-rose-50: color-mix(in srgb, #f43f5e 10%, #0A0A0A);
-  --color-rose-100: color-mix(in srgb, #f43f5e 15%, #0A0A0A);
-  --color-rose-200: color-mix(in srgb, #f43f5e 25%, #0A0A0A);
+  --color-rose-50: color-mix(in srgb, #f43f5e 10%, #0A2226);
+  --color-rose-100: color-mix(in srgb, #f43f5e 15%, #0A2226);
+  --color-rose-200: color-mix(in srgb, #f43f5e 25%, #0A2226);
   --color-rose-700: #fb7185;
 
   /* Lime */
-  --color-lime-50: color-mix(in srgb, #84cc16 10%, #0A0A0A);
-  --color-lime-200: color-mix(in srgb, #84cc16 25%, #0A0A0A);
+  --color-lime-50: color-mix(in srgb, #84cc16 10%, #0A2226);
+  --color-lime-200: color-mix(in srgb, #84cc16 25%, #0A2226);
 
   /* Sky */
-  --color-sky-50: color-mix(in srgb, #0ea5e9 10%, #0A0A0A);
-  --color-sky-200: color-mix(in srgb, #0ea5e9 25%, #0A0A0A);
+  --color-sky-50: color-mix(in srgb, #0ea5e9 10%, #0A2226);
+  --color-sky-200: color-mix(in srgb, #0ea5e9 25%, #0A2226);
 }
 
 @layer base {
@@ -218,11 +225,11 @@
 }
 
 [data-theme="dark"] ::-webkit-scrollbar-thumb {
-  background: #3A3632;
+  background: #1D3B3C;
 }
 
 [data-theme="dark"] ::-webkit-scrollbar-thumb:hover {
-  background: #4A4540;
+  background: #2A4A4B;
 }
 
 /* ── Animation Keyframes ───────────────────────────────────────────────────── */
@@ -241,7 +248,7 @@
 }
 
 [data-theme="dark"] .skeleton {
-  background: linear-gradient(90deg, #1C1A17 25%, #2A2723 50%, #1C1A17 75%);
+  background: linear-gradient(90deg, #102A2C 25%, #163335 50%, #102A2C 75%);
   background-size: 200% 100%;
 }
 
@@ -587,7 +594,9 @@
 }
 
 :root {
-  --background: #F7F4EF;
+  /* Warm canvas → white working surfaces → dark ink → green actions →
+     lime only for moments of emphasis. */
+  --background: #F5F1ED;
   --foreground: #061B20;
   --card: #FFFFFF;
   --card-foreground: #061B20;
@@ -595,30 +604,32 @@
   --popover-foreground: #061B20;
   --primary: #055147;
   --primary-foreground: #FFFFFF;
-  --secondary: #EEE8E0;
+  --secondary: #F9F7F3;
   --secondary-foreground: #263D3B;
-  --muted: #EEE8E0;
-  --muted-foreground: #706B65;
-  --accent: #E7F2D6;
-  --accent-foreground: #073B35;
+  --muted: #EEEAE4;
+  --muted-foreground: #59615F;
+  --accent: #EEEAE4;
+  --accent-foreground: #061B20;
   --destructive: oklch(0.577 0.245 27.325);
-  --border: #E7E1D9;
-  --input: #D8D2C9;
-  --ring: #226750;
+  --border: #DDD9D2;
+  --input: #C8C4BD;
+  --ring: #055147;
   --chart-1: #055147;
   --chart-2: #79A780;
   --chart-3: #567C38;
   --chart-4: #A18A5B;
   --chart-5: #647D8A;
-  --radius: 0.45rem;
+  --radius: 0.5rem;
+  /* The sidebar stays a dark green shell in light mode; active rows use a
+     subtly lighter surface plus a narrow lime indicator — never a lime fill. */
   --sidebar: #061B20;
-  --sidebar-foreground: #BECBC7;
-  --sidebar-primary: #C8E98F;
+  --sidebar-foreground: #B9C1BD;
+  --sidebar-primary: #DDF7A8;
   --sidebar-primary-foreground: #061B20;
-  --sidebar-accent: #193036;
-  --sidebar-accent-foreground: #F7F4EF;
-  --sidebar-border: #284143;
-  --sidebar-ring: #C8E98F;
+  --sidebar-accent: #10302F;
+  --sidebar-accent-foreground: #F5F1ED;
+  --sidebar-border: rgba(245, 241, 237, 0.10);
+  --sidebar-ring: #DDF7A8;
 }
 
 @theme inline {
@@ -668,50 +679,67 @@
 
 [data-theme="dark"] {
   --background: #061B20;
-  --foreground: #F7F4EF;
-  --card: #122D30;
-  --card-foreground: #F7F4EF;
-  --popover: #163237;
-  --popover-foreground: #F7F4EF;
-  --primary: #C8E98F;
+  --foreground: #F5F1ED;
+  --card: #102A2C;
+  --card-foreground: #F5F1ED;
+  --popover: #163335;
+  --popover-foreground: #F5F1ED;
+  --primary: #DDF7A8;
   --primary-foreground: #061B20;
-  --secondary: #213B3C;
-  --secondary-foreground: #DDE4D9;
-  --muted: #1A3437;
-  --muted-foreground: #A8B9AF;
-  --accent: #294638;
-  --accent-foreground: #E7F2D6;
+  --secondary: #163335;
+  --secondary-foreground: #E3E4DD;
+  --muted: #163335;
+  --muted-foreground: #B9C1BD;
+  --accent: #1D3B3C;
+  --accent-foreground: #F5F1ED;
   --destructive: oklch(0.704 0.191 22.216);
-  --border: #284143;
-  --input: #3C5353;
-  --ring: #A6C97D;
-  --chart-1: #C8E98F;
+  --border: rgba(245, 241, 237, 0.10);
+  --input: rgba(245, 241, 237, 0.18);
+  --ring: #A8C46F;
+  --chart-1: #DDF7A8;
   --chart-2: #91B89A;
   --chart-3: #76B5A5;
   --chart-4: #CAB47F;
   --chart-5: #98B7C6;
-  --sidebar: #061B20;
-  --sidebar-foreground: #BECBC7;
-  --sidebar-primary: #C8E98F;
+  --sidebar: #04171B;
+  --sidebar-foreground: #B9C1BD;
+  --sidebar-primary: #DDF7A8;
   --sidebar-primary-foreground: #061B20;
-  --sidebar-accent: #193036;
-  --sidebar-accent-foreground: #F7F4EF;
-  --sidebar-border: #284143;
-  --sidebar-ring: #C8E98F;
+  --sidebar-accent: #0D2528;
+  --sidebar-accent-foreground: #F5F1ED;
+  --sidebar-border: rgba(245, 241, 237, 0.08);
+  --sidebar-ring: #DDF7A8;
 }
 
-/* Shared editorial hierarchy, including routes that predate font-heading.
-   User-authored markdown and compact conversation titles retain their own scale. */
-.loma-dashboard h1:not(:where(.prose h1, .break-words h1, .chat-text h1)) {
+/* Shared editorial hierarchy. Feature Deck is reserved for deliberate
+   moments — page titles and editorial headings. Functional text (long
+   generated conversation titles, markdown, chat) stays in Halyard. */
+.loma-dashboard h1:not(:where(.prose h1, .break-words h1, .chat-text h1, .truncate)) {
   font-family: var(--font-display), Georgia, serif;
-  font-size: clamp(1.75rem, 2.6vw, 2.5rem);
-  line-height: 1.15;
+  font-size: clamp(1.5rem, 2vw, 1.9rem);
+  line-height: 1.2;
   font-weight: 400;
-  letter-spacing: -0.025em;
+  letter-spacing: -0.02em;
 }
-.loma-dashboard h1.truncate { font-size: 1.5rem; }
 .loma-dashboard h2.font-heading {
   font-family: var(--font-body), sans-serif;
+}
+
+/* Editorial serif heading for empty states / special moments. */
+.editorial-heading {
+  font-family: var(--font-display), Georgia, serif;
+  font-weight: 400;
+  line-height: 1.18;
+  letter-spacing: -0.02em;
+}
+
+/* Composer elevation: soft and shadow-led in light, surface-led in dark —
+   no glowing outline. */
+.composer-shadow {
+  box-shadow: 0 1px 2px rgba(6, 27, 32, 0.03), 0 12px 32px -18px rgba(6, 27, 32, 0.12);
+}
+[data-theme="dark"] .composer-shadow {
+  box-shadow: 0 1px 0 rgba(245, 241, 237, 0.02) inset, 0 16px 40px -20px rgba(0, 0, 0, 0.55);
 }
 
 /* Sidebar-scoped tokens also theme nested controls, without affecting portaled
@@ -728,7 +756,7 @@
   color: var(--sidebar-foreground);
 }
 
-::selection { background: #C8E98F; color: #061B20; }
+::selection { background: #DDF7A8; color: #061B20; }
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {
     animation-duration: 0.01ms !important;

--- a/dashboard/src/app/layout.tsx
+++ b/dashboard/src/app/layout.tsx
@@ -62,7 +62,7 @@ export const viewport: Viewport = {
   // opens (ViewportHeightSync's --app-h covers browsers that ignore this).
   interactiveWidget: "resizes-content",
   themeColor: [
-    { media: "(prefers-color-scheme: light)", color: "#F7F4EF" },
+    { media: "(prefers-color-scheme: light)", color: "#F5F1ED" },
     { media: "(prefers-color-scheme: dark)", color: "#061B20" },
   ],
 };

--- a/dashboard/src/app/page-index/page.tsx
+++ b/dashboard/src/app/page-index/page.tsx
@@ -188,7 +188,7 @@ function GraphNode({
       {/* Title text */}
       <foreignObject x={12} y={4} width={NODE_WIDTH - (hasChildren ? 48 : 20)} height={20}>
         <div
-          style={{ color: isSelected ? colors.text : "#1F2937", fontSize: "12px", fontWeight: 600, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+          style={{ color: isSelected ? colors.text : "#1F2937", fontSize: "12px", fontWeight: 500, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
           title={node.title}
         >
           {node.title}
@@ -218,7 +218,7 @@ function GraphNode({
             y={14}
             textAnchor="middle"
             fontSize={14}
-            fontWeight={700}
+            fontWeight={500}
             fill={colors.fill}
           >
             {isExpanded ? "−" : "+"}

--- a/dashboard/src/components/ChatPanel.tsx
+++ b/dashboard/src/components/ChatPanel.tsx
@@ -1398,14 +1398,14 @@ export default function ChatPanel({
       {isEmptyState ? (
         /* Empty state */
         <div className="flex flex-col items-center justify-center h-full px-4 md:px-6 animate-fade-in-up">
-          <div className="mb-8 text-center">
+          <div className="mb-8 flex flex-col items-center gap-4 text-center">
             <PetCompanion size={56} />
-            <h2 className="text-xl md:text-3xl font-heading font-normal text-foreground tracking-tight">
+            <h2 className="editorial-heading text-[26px] md:text-[34px] text-foreground">
               What do you need to get done?
             </h2>
           </div>
 
-          <div className="w-full max-w-full md:max-w-[680px]">
+          <div className="w-full max-w-full md:max-w-[720px]">
             <form
               onSubmit={(e) => {
                 e.preventDefault();
@@ -1414,7 +1414,7 @@ export default function ChatPanel({
             >
               <PendingFilesStrip files={pendingFiles} onRemove={removeFile} onExpandImage={setExpandedImage} />
 
-              <div className="relative flex flex-col bg-card border border-border rounded-2xl shadow-sm focus-within:border-gray-300 transition-colors">
+              <div className="relative flex flex-col bg-card border border-border rounded-2xl composer-shadow focus-within:border-input transition-colors">
                 <Textarea
                   ref={inputRef}
                   value={input}
@@ -1456,7 +1456,7 @@ export default function ChatPanel({
                       type="submit"
                       disabled={!input.trim() && pendingFiles.length === 0}
                       className={cn(
-                        "bg-accent-200 hover:bg-accent-300 disabled:opacity-30 disabled:hover:bg-accent-200 text-accent-on rounded-lg press-scale max-md:size-12 max-md:rounded-xl",
+                        "bg-primary text-primary-foreground hover:bg-accent-200 hover:text-accent-on disabled:opacity-40 disabled:hover:bg-primary disabled:hover:text-primary-foreground rounded-lg press-scale max-md:size-12 max-md:rounded-xl",
                         !input.trim() && pendingFiles.length === 0 && "max-md:hidden",
                       )}
                       size="icon-sm"
@@ -1477,7 +1477,7 @@ export default function ChatPanel({
             <div className="px-3 md:px-6 pt-5">
               <div className="max-w-3xl mx-auto">
                 <div className="inline-flex items-center gap-2 text-[11px] text-muted-foreground/70">
-                  <div className="w-1.5 h-1.5 rounded-full bg-emerald-400" />
+                  <div className="w-1.5 h-1.5 rounded-full bg-brand-400/80" />
                   <span>
                     {accountInfo.runtime === "opencode" ? (
                       <>
@@ -1511,7 +1511,7 @@ export default function ChatPanel({
           )}
           {/* Messages */}
           <div className="flex-1 overflow-y-auto px-3 py-4" onScroll={handleMessagesScroll}>
-            <div className="space-y-3 max-w-3xl mx-auto">
+            <div className="space-y-2 max-w-3xl mx-auto">
               {items.map((item, i) => {
                 if (item.role === "steps") {
                   return <StepsGroup key={i} steps={item.steps || []} />;
@@ -1523,7 +1523,7 @@ export default function ChatPanel({
 
                 if (item.role === "clarify") {
                   return (
-                    <div key={i} className="flex justify-start items-start animate-message-in gap-2">
+                    <div key={i} className="flex justify-start items-start animate-message-in gap-2 mt-5 first:mt-0">
                       <PetCompanion size={24} fallback={<CrosscutIcon size={16} className="shrink-0 mt-px" />} />
                       <div className="chat-text min-w-0 flex-1 text-[13px] leading-relaxed break-words">
                         {item.content && (
@@ -1546,7 +1546,7 @@ export default function ChatPanel({
 
                 if (item.role === "user") {
                   return (
-                    <div key={i} className="flex justify-end animate-message-in group/msg">
+                    <div key={i} className="flex justify-end animate-message-in group/msg mt-6 first:mt-0">
                       {item.queued && editingQueuedIndex !== i && (
                         <div className="flex items-center gap-0.5 mr-1.5 opacity-0 group-hover/msg:opacity-100 transition-opacity">
                           <button
@@ -1568,8 +1568,10 @@ export default function ChatPanel({
                         </div>
                       )}
                       <div className={cn(
-                        "chat-text rounded-xl px-3 py-2 max-w-[75%] text-[13px] leading-relaxed break-words whitespace-pre-wrap",
-                        item.queued ? "bg-muted/60 border border-dashed border-border" : "bg-muted"
+                        "chat-text rounded-xl px-3.5 py-2.5 max-w-[75%] text-[13px] leading-relaxed break-words whitespace-pre-wrap",
+                        item.queued
+                          ? "bg-card/60 border border-dashed border-border"
+                          : "bg-card border border-border shadow-[0_1px_2px_rgba(6,27,32,0.03)]"
                       )}>
                         {editingQueuedIndex === i ? (
                           <div className="flex flex-col gap-1.5">
@@ -1647,7 +1649,7 @@ export default function ChatPanel({
 
                 // Assistant message — editorial style, no bubble
                 return (
-                  <div key={i} className="flex justify-start items-start animate-message-in gap-2">
+                  <div key={i} className="flex justify-start items-start animate-message-in gap-2 mt-5 first:mt-0">
                     <PetCompanion size={24} fallback={<CrosscutIcon size={16} className="shrink-0 mt-px" />} />
                     <div className="chat-text min-w-0 flex-1 text-[13px] leading-relaxed break-words [&>*:first-child]:mt-0">
                       {item.content ? (
@@ -1737,7 +1739,7 @@ export default function ChatPanel({
               {isStreaming && <PetRunway running={!items.some((item) => item.role === "clarify" && !item.submitted)} />}
               <PendingFilesStrip files={pendingFiles} onRemove={removeFile} onExpandImage={setExpandedImage} />
 
-              <div className="flex flex-col bg-card border border-input rounded-xl shadow-sm focus-within:border-ring focus-within:ring-1 focus-within:ring-ring/20 transition-colors">
+              <div className="flex flex-col bg-card border border-border rounded-2xl composer-shadow focus-within:border-input transition-colors">
                 <Textarea
                   ref={inputRef}
                   value={input}
@@ -1792,7 +1794,7 @@ export default function ChatPanel({
                       size="icon-sm"
                       disabled={!input.trim() && pendingFiles.length === 0}
                       className={cn(
-                        "bg-accent-200 hover:bg-accent-300 disabled:opacity-40 disabled:hover:bg-accent-200 text-accent-on rounded-lg press-scale max-md:size-12 max-md:rounded-xl",
+                        "bg-primary text-primary-foreground hover:bg-accent-200 hover:text-accent-on disabled:opacity-40 disabled:hover:bg-primary disabled:hover:text-primary-foreground rounded-lg press-scale max-md:size-12 max-md:rounded-xl",
                         !input.trim() && pendingFiles.length === 0 && "max-md:hidden",
                       )}
                     >
@@ -2075,7 +2077,7 @@ function ClarifyingQuestions({
           type="button"
           disabled={!hasAnySelection}
           onClick={handleSubmit}
-          className="bg-accent-200 hover:bg-accent-300 disabled:opacity-40 disabled:hover:bg-accent-200 text-accent-on text-xs font-medium rounded-lg press-scale"
+          className="bg-primary text-primary-foreground hover:bg-accent-200 hover:text-accent-on disabled:opacity-40 disabled:hover:bg-primary disabled:hover:text-primary-foreground text-xs font-medium rounded-lg press-scale"
           size="sm"
         >
           <RiSendPlaneLine size={14} />
@@ -2107,7 +2109,7 @@ function StatusLine({ message, elapsedSeconds }: { message: string; elapsedSecon
 function StepIcon({ status }: { status: Step["status"] }) {
   if (status === "running") return <RiLoader4Line size={10} className="animate-spin text-brand-500 flex-shrink-0" />;
   if (status === "error") return <RiCloseLine size={10} className="text-red-500 flex-shrink-0" />;
-  return <RiCheckLine size={10} className="text-green-500/70 flex-shrink-0" />;
+  return <RiCheckLine size={10} className="text-muted-foreground/50 flex-shrink-0" />;
 }
 
 function StepsGroup({ steps }: { steps: Step[] }) {

--- a/dashboard/src/components/PetCompanion.tsx
+++ b/dashboard/src/components/PetCompanion.tsx
@@ -185,12 +185,12 @@ function PetPicker({ initial, onSaved }: { initial: typeof DEFAULT_PET; onSaved:
         {PETS.map((pet) => (
           <button type="button" key={pet.id} disabled={saving} aria-pressed={draft.pet_id === pet.id}
             onClick={() => setDraft({ ...draft, pet_id: pet.id })}
-            className="flex flex-col items-center gap-1 rounded-lg border border-border p-2 text-xs hover:bg-muted focus-visible:outline-2 focus-visible:outline-ring aria-pressed:border-primary aria-pressed:bg-accent disabled:opacity-50">
+            className="flex flex-col items-center gap-1 rounded-xl border border-transparent p-2.5 text-xs text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-2 focus-visible:outline-ring aria-pressed:border-brand-700 aria-pressed:bg-accent-200/25 aria-pressed:text-foreground disabled:opacity-50">
             <PetSprite petId={pet.id} size={48} />{pet.name}
           </button>
         ))}
       </div>
-      <div className="flex items-center gap-3 rounded-lg bg-muted p-3">
+      <div className="flex items-center gap-3 rounded-xl bg-muted p-3">
         <PetSprite petId={draft.pet_id} size={48} state="working" animated={draft.animated} />
         <div className="text-sm"><p className="font-medium">Your new sidekick</p><p className="text-xs text-muted-foreground">A quiet companion while you work.</p></div>
       </div>

--- a/dashboard/src/components/Sidebar.tsx
+++ b/dashboard/src/components/Sidebar.tsx
@@ -174,14 +174,14 @@ function PoolStatusWidget({ poolStatus, collapsed }: { poolStatus: PoolStatus; c
     : (codex.queue_depth || 0) > 0
       ? "bg-red-500"
       : (codex.available || 0) > 0
-        ? "bg-emerald-500"
+        ? "bg-brand-400/80"
         : (codex.warming || 0) > 0
           ? "bg-amber-400 animate-pulse"
           : "bg-red-500";
   const opencodeColor = !opencode?.enabled
     ? "bg-gray-300"
     : opencode.total_available > 0
-      ? "bg-emerald-500"
+      ? "bg-brand-400/80"
       : opencode.total_warming > 0
         ? "bg-amber-400 animate-pulse"
         : "bg-red-500";
@@ -189,35 +189,35 @@ function PoolStatusWidget({ poolStatus, collapsed }: { poolStatus: PoolStatus; c
   const statusColor = poolStatus.queue_depth > 0
     ? "bg-red-500"
     : poolStatus.available > 0
-      ? "bg-emerald-500"
+      ? "bg-brand-400/80"
       : poolStatus.warming > 0
         ? "bg-amber-400 animate-pulse"
         : "bg-red-500";
 
   if (collapsed) {
     return (
-      <div className="px-2.5 py-1 flex flex-col items-center gap-1">
-        <span className={cn("w-2 h-2 rounded-full flex-shrink-0", statusColor)} />
+      <div className="px-2.5 py-1 flex flex-col items-center gap-1 opacity-70">
+        <span className={cn("w-1.5 h-1.5 rounded-full flex-shrink-0", statusColor)} />
         {opencode && (
-          <span className={cn("w-2 h-2 rounded-full flex-shrink-0", opencodeColor)} />
+          <span className={cn("w-1.5 h-1.5 rounded-full flex-shrink-0", opencodeColor)} />
         )}
         {codex?.enabled && (
-          <span className={cn("w-2 h-2 rounded-full flex-shrink-0", codexColor)} />
+          <span className={cn("w-1.5 h-1.5 rounded-full flex-shrink-0", codexColor)} />
         )}
       </div>
     );
   }
 
   return (
-    <div className="px-2.5 py-1 overflow-hidden">
+    <div className="px-3 py-1 overflow-hidden opacity-75 transition-opacity hover:opacity-100">
       <Button
         variant="ghost"
         onClick={() => setExpanded(!expanded)}
         className="w-full text-left group flex-col items-stretch gap-1.5 h-auto px-0 rounded-none overflow-hidden"
       >
         <div className="flex items-center gap-2">
-          <span className={cn("w-2 h-2 rounded-full flex-shrink-0", statusColor)} />
-          <span className="text-[11px] text-muted-foreground flex-1 truncate">
+          <span className={cn("w-1.5 h-1.5 rounded-full flex-shrink-0", statusColor)} />
+          <span className="text-[10px] text-sidebar-foreground/70 flex-1 truncate">
             {accountCount === 0
               ? "Claude · no accounts"
               : poolStatus.queue_depth > 0
@@ -234,8 +234,8 @@ function PoolStatusWidget({ poolStatus, collapsed }: { poolStatus: PoolStatus; c
         </div>
         {opencode && (
           <div className="flex items-center gap-2">
-            <span className={cn("w-2 h-2 rounded-full flex-shrink-0", opencodeColor)} />
-            <span className="text-[11px] text-muted-foreground flex-1 truncate">
+            <span className={cn("w-1.5 h-1.5 rounded-full flex-shrink-0", opencodeColor)} />
+            <span className="text-[10px] text-sidebar-foreground/70 flex-1 truncate">
               {opencode.enabled
                 ? `OpenCode · ${opencode.total_available}/${opencode.pool_size} warm${opencode.total_warming ? ` · ${opencode.total_warming} warming` : ""}`
                 : "OpenCode · warm pool off"}
@@ -244,8 +244,8 @@ function PoolStatusWidget({ poolStatus, collapsed }: { poolStatus: PoolStatus; c
         )}
         {codex?.enabled && (
           <div className="flex items-center gap-2">
-            <span className={cn("w-2 h-2 rounded-full flex-shrink-0", codexColor)} />
-            <span className="text-[11px] text-muted-foreground flex-1 truncate">
+            <span className={cn("w-1.5 h-1.5 rounded-full flex-shrink-0", codexColor)} />
+            <span className="text-[10px] text-sidebar-foreground/70 flex-1 truncate">
               {codexAccountCount === 0
                 ? "Codex · no accounts"
                 : (codex.queue_depth || 0) > 0
@@ -468,7 +468,7 @@ export default function Sidebar({
       ) : (
         <>
           {/* Navigation */}
-          <nav className="px-3 space-y-0.5 shrink-0">
+          <nav className="px-3 space-y-0.5 shrink-0 pb-1">
             {visibleNav.map((item) => {
               const isActive = item.href === "/"
                 ? pathname === "/" || pathname === ""
@@ -481,19 +481,22 @@ export default function Sidebar({
                   onClick={onClose}
                   className={cn(
                     // Roomier on phones (Claude-app scale), compact on desktop
-                    "flex items-center rounded-lg text-[13px] font-medium transition-colors duration-150",
+                    "relative flex items-center rounded-lg text-[13px] font-medium transition-colors duration-150",
                     "max-md:text-[16px] max-md:[&_svg]:h-5 max-md:[&_svg]:w-5",
                     collapsed
                       ? "justify-center px-0 py-1.5 mx-auto w-10"
                       : "px-3 py-2 gap-2.5 max-md:py-2.5 max-md:gap-3",
                     isActive
-                      ? "bg-sidebar-primary text-sidebar-primary-foreground"
-                      : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+                      ? "bg-sidebar-accent text-sidebar-accent-foreground"
+                      : "text-sidebar-foreground hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground"
                   )}
                   aria-current={isActive ? "page" : undefined}
                   title={collapsed ? item.name : undefined}
                 >
-                  <span className={cn("relative transition-colors flex-shrink-0", isActive ? "text-sidebar-primary-foreground" : "text-sidebar-foreground")}>
+                  {isActive && (
+                    <span className="absolute left-0 top-1/2 h-4 w-[3px] -translate-y-1/2 rounded-full bg-sidebar-primary" aria-hidden="true" />
+                  )}
+                  <span className="relative flex-shrink-0 transition-colors text-current">
                     {item.icon}
                     {collapsed && item.badgeKey && badgeCounts[item.badgeKey] > 0 && (
                       <span className="absolute -top-0.5 -right-0.5 h-1.5 w-1.5 rounded-full bg-amber-500" />
@@ -504,8 +507,6 @@ export default function Sidebar({
                     <span className="ml-auto min-w-[20px] h-5 px-1 shrink-0 whitespace-nowrap flex items-center justify-center rounded bg-current/10 text-[11px] font-semibold tabular-nums">
                       {badgeCounts[item.badgeKey]}
                     </span>
-                  ) : !collapsed && isActive ? (
-                    <span className="ml-auto w-0.5 h-4 bg-sidebar-primary-foreground rounded-full" />
                   ) : null}
                 </Link>
               );
@@ -517,9 +518,9 @@ export default function Sidebar({
           <ScrollArea className="flex-1 min-h-0">
             {/* Projects */}
             {!collapsed && projects.length > 0 && (
-              <div className="mt-2 flex flex-col">
-                <div className="px-2.5 pb-1">
-                  <span className="text-[11px] max-md:text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+              <div className="mt-6 flex flex-col">
+                <div className="px-3 pb-1.5">
+                  <span className="text-[10px] max-md:text-xs font-medium text-sidebar-foreground/60 uppercase tracking-[0.14em]">
                     Projects
                   </span>
                 </div>
@@ -544,25 +545,25 @@ export default function Sidebar({
 
             {/* Pinned */}
             {!collapsed && pinnedConversations.length > 0 && (
-              <div className="mt-2 flex flex-col">
-                <div className="px-2.5 pb-1">
-                  <span className="text-[11px] max-md:text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+              <div className="mt-6 flex flex-col">
+                <div className="px-3 pb-1.5">
+                  <span className="text-[10px] max-md:text-xs font-medium text-sidebar-foreground/60 uppercase tracking-[0.14em]">
                     Pinned
                   </span>
                 </div>
                 <div className="px-2 space-y-px">
                   {pinnedConversations.map((c) => {
                     const title = c.title || c.prompt?.slice(0, 50) || "Untitled";
-                    const displayTitle = title.length > 32 ? title.slice(0, 32) + "..." : title;
+                    const displayTitle = title;
                     const isConvoActive = activeContinueId === c.conversation_id;
                     return (
                       <div
                         key={c.conversation_id}
                         className={cn(
-                          "group flex items-center gap-1 px-2 py-1 text-[13px] max-md:px-3 max-md:py-2 max-md:text-[15px] rounded-lg transition-all duration-150",
+                          "group flex items-center gap-1 px-2 py-1 text-[12px] max-md:px-3 max-md:py-2 max-md:text-[15px] rounded-lg transition-all duration-150",
                           isConvoActive
-                            ? "text-brand-700 bg-brand-100/80 font-medium"
-                            : "text-muted-foreground hover:text-foreground hover:bg-muted"
+                            ? "bg-sidebar-accent text-sidebar-accent-foreground"
+                            : "text-sidebar-foreground/75 hover:text-sidebar-accent-foreground hover:bg-sidebar-accent/60"
                         )}
                       >
                         <Link
@@ -600,25 +601,25 @@ export default function Sidebar({
 
             {/* Recents (excluding pinned) */}
             {!collapsed && myConversations.filter((c) => !isPinned(c.conversation_id)).length > 0 && (
-              <div className="mt-2 flex flex-col">
-                <div className="px-2.5 pb-1">
-                  <span className="text-[11px] max-md:text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+              <div className="mt-6 flex flex-col">
+                <div className="px-3 pb-1.5">
+                  <span className="text-[10px] max-md:text-xs font-medium text-sidebar-foreground/60 uppercase tracking-[0.14em]">
                     Recents
                   </span>
                 </div>
                 <div className="px-2 space-y-px">
                   {myConversations.filter((c) => !isPinned(c.conversation_id)).map((c) => {
                     const title = c.title || c.prompt?.slice(0, 50) || "Untitled";
-                    const displayTitle = title.length > 36 ? title.slice(0, 36) + "..." : title;
+                    const displayTitle = title;
                     const isConvoActive = activeContinueId === c.conversation_id;
                     return (
                       <div
                         key={c.conversation_id}
                         className={cn(
-                          "group flex items-center gap-1 px-2 py-1 text-[13px] max-md:px-3 max-md:py-2 max-md:text-[15px] rounded-lg transition-all duration-150",
+                          "group flex items-center gap-1 px-2 py-1 text-[12px] max-md:px-3 max-md:py-2 max-md:text-[15px] rounded-lg transition-all duration-150",
                           isConvoActive
-                            ? "text-brand-700 bg-brand-100/80 font-medium"
-                            : "text-muted-foreground hover:text-foreground hover:bg-muted"
+                            ? "bg-sidebar-accent text-sidebar-accent-foreground"
+                            : "text-sidebar-foreground/75 hover:text-sidebar-accent-foreground hover:bg-sidebar-accent/60"
                         )}
                       >
                         <Link
@@ -728,7 +729,7 @@ export default function Sidebar({
                         collapsed ? "justify-center p-1" : "gap-2 px-1 py-1"
                       )}>
                         <Avatar size="sm" className="w-7 h-7 shrink-0">
-                          <AvatarFallback className="bg-brand-100 text-brand-700 text-xs font-medium">
+                          <AvatarFallback className="bg-sidebar-primary/90 text-sidebar-primary-foreground text-xs font-medium">
                             {session.user.email?.charAt(0).toUpperCase() || "U"}
                           </AvatarFallback>
                         </Avatar>

--- a/dashboard/src/components/tasks/MobileTaskCard.tsx
+++ b/dashboard/src/components/tasks/MobileTaskCard.tsx
@@ -63,7 +63,7 @@ export function MobileTaskCard({
   return (
     <div
       onClick={() => onOpen(task)}
-      className="group rounded-md border bg-card px-3 py-2.5 cursor-pointer active:bg-muted/50"
+      className="group rounded-xl border border-border bg-card px-3 py-2.5 cursor-pointer active:bg-muted/50"
     >
       <div className="flex items-start gap-2">
         {dot && <span className={cn("mt-2 h-2 w-2 shrink-0 rounded-full", dot)} />}

--- a/dashboard/src/components/tasks/QuickAddTask.tsx
+++ b/dashboard/src/components/tasks/QuickAddTask.tsx
@@ -94,7 +94,7 @@ export function QuickAddTask({ onAdded }: QuickAddTaskProps) {
       <div className="mx-auto w-full max-w-3xl">
       {error && <p className="mb-1 text-xs text-destructive">{error}</p>}
       <PendingFilesStrip files={files} onRemove={(i) => setFiles((prev) => prev.filter((_, idx) => idx !== i))} />
-      <div className="flex flex-col bg-card border border-input rounded-xl shadow-sm focus-within:border-ring focus-within:ring-1 focus-within:ring-ring/20 transition-colors">
+      <div className="flex flex-col bg-card border border-border rounded-xl focus-within:border-input transition-colors">
         <Textarea
           value={value}
           onChange={(e) => setValue(e.target.value)}
@@ -148,7 +148,7 @@ export function QuickAddTask({ onAdded }: QuickAddTaskProps) {
               disabled={(!value.trim() && files.length === 0) || busy}
               aria-label="Add task"
               className={cn(
-                "bg-accent-200 hover:bg-accent-300 disabled:opacity-30 disabled:hover:bg-accent-200 text-accent-on rounded-lg press-scale max-md:size-12 max-md:rounded-xl",
+                "bg-primary text-primary-foreground hover:bg-accent-200 hover:text-accent-on disabled:opacity-40 disabled:hover:bg-primary disabled:hover:text-primary-foreground rounded-lg press-scale max-md:size-12 max-md:rounded-xl",
                 !value.trim() && files.length === 0 && "max-md:hidden",
               )}
             >

--- a/dashboard/src/components/tasks/TaskCard.tsx
+++ b/dashboard/src/components/tasks/TaskCard.tsx
@@ -64,16 +64,15 @@ export function TaskCard({
         setMenuOpen(true);
       }}
       className={cn(
-        "group relative rounded-lg border bg-card px-3 py-3 shadow-[0_1px_2px_#061b2005] cursor-pointer",
-        "hover:border-input hover:shadow-sm touch-none select-none",
-        task.column === "needs_input" && "border-amber-300",
+        "group relative rounded-xl border border-border bg-card px-3.5 py-3 cursor-pointer",
+        "hover:border-input transition-colors touch-none select-none",
         isDragging && "opacity-40",
       )}
     >
       <div className="flex items-start gap-2">
         {dot && <span className={cn("mt-1.5 h-2 w-2 shrink-0 rounded-full", dot)} />}
         <div className="min-w-0 flex-1">
-          <div className="line-clamp-2 break-words text-[15px] leading-5">
+          <div className="line-clamp-2 break-words text-[14px] font-medium leading-5">
             {task.title || task.prompt || "New task"}
           </div>
           <div className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] leading-4 text-muted-foreground">

--- a/dashboard/src/components/tasks/TaskColumn.tsx
+++ b/dashboard/src/components/tasks/TaskColumn.tsx
@@ -25,11 +25,11 @@ export function TaskColumn({ id, name, tasks, droppable, onAddTask, children }: 
 
   return (
     <div className="flex min-w-[200px] flex-1 basis-0 flex-col">
-      <div className="mb-2 flex items-baseline gap-2 px-1">
-        <span className="text-[13px] font-medium text-foreground">
+      <div className="mb-2.5 flex items-baseline gap-2 px-2">
+        <span className="text-[13px] font-semibold text-foreground">
           {name}
         </span>
-        <span className="rounded bg-muted px-1.5 text-[11px] tabular-nums text-muted-foreground">{tasks.length}</span>
+        <span className="text-[11px] tabular-nums text-muted-foreground/80">{tasks.length}</span>
       </div>
       <SortableContext
         items={tasks.map((t) => t.conversation_id)}
@@ -38,8 +38,8 @@ export function TaskColumn({ id, name, tasks, droppable, onAddTask, children }: 
         <div
           ref={setNodeRef}
           className={cn(
-            "flex min-h-24 flex-1 flex-col gap-1.5 rounded-lg p-1 transition-colors",
-            isOver && droppable !== false && "bg-muted/60",
+            "flex min-h-24 flex-1 flex-col gap-2 rounded-xl p-1.5 bg-foreground/[0.025] transition-colors",
+            isOver && droppable !== false && "bg-foreground/[0.05]",
             droppable === false && "opacity-40",
           )}
         >

--- a/dashboard/src/components/ui/dialog.tsx
+++ b/dashboard/src/components/ui/dialog.tsx
@@ -61,7 +61,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-[13px] text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-2xl bg-card p-4 text-[13px] text-card-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
           // Phones: anchor to the top and scroll internally so the on-screen
           // keyboard never hides fields or footer buttons (--app-h tracks the
           // visual viewport in the installed PWA).
@@ -111,7 +111,7 @@ function DialogFooter({
     <div
       data-slot="dialog-footer"
       className={cn(
-        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-2xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
         className
       )}
       {...props}


### PR DESCRIPTION
Full UI-system redesign of the Loma dashboard across Light and Dark modes. **No functional changes** — navigation, tasks, agents, and the pet companion all behave exactly as before.

## What changed

**Token layer (globals.css) — rebuilt first, components migrated onto it**
- Light: warm canvas `#F5F1ED` → white work surfaces → ink `#061B20` typography → green `#055147` actions → lime `#DDF7A8` only as emphasis
- Dark: layered greens — canvas `#061B20`, sidebar `#04171B`, elevated `#102A2C`, secondary `#163335`, hover `#1D3B3C`; warm off-white text; hairlines at `rgba(245,241,237,0.10)`
- Radius scale: buttons 6–8px · nav rows 8px · cards 10–12px · composer 14–16px · modals 12–16px

**Sidebar** — 224px, compact 36px rows, no filled backgrounds at rest; active nav is a subtle elevated surface + thin lime indicator (giant lime pill removed); recents and system/model statuses demoted to tertiary contrast.

**Composer** — two-row command surface: input on top; agent/model/tools selectors (text-led, unpilled) + mic/attach/send below. Light send `#055147`→white icon; dark send `#DDF7A8`→dark icon.

**Conversation** — three clear levels: subtle human-message surface, assistant output free-flowing on canvas, tool calls compressed into quiet low-contrast rows (`3 tool calls · 1 failed · Bash, Read`) — red only on the failed element.

**Tasks** — lighter column containment, borderless-feeling cards (1px hairline, no shadow), tiny status dots instead of colored card borders ("Needs input" = small orange dot), dark-green New task CTA.

**Header** — 56px with a bottom hairline instead of a boxed banner.

**Typography** — Halyard for all functional UI; Feature Deck reserved for editorial moments (page titles, "What do you need to get done?"); generated conversation titles are Halyard.

**Pet companion** — fully preserved (chooser, "Show my pet throughout Loma", animations, reduced-motion respect); modal restyled onto the new tokens with lime-tinted selection.

## Screenshots (all 8 verified in a real browser)

| | Light | Dark |
|---|---|---|
| **New Chat** | ![](https://cdn.plotline.so/loma-images/loma-redesign/new-chat-light.png) | ![](https://cdn.plotline.so/loma-images/loma-redesign/new-chat-dark.png) |
| **Conversation** | ![](https://cdn.plotline.so/loma-images/loma-redesign/conversation-light.png) | ![](https://cdn.plotline.so/loma-images/loma-redesign/conversation-dark.png) |
| **Tasks** | ![](https://cdn.plotline.so/loma-images/loma-redesign/tasks-light.png) | ![](https://cdn.plotline.so/loma-images/loma-redesign/tasks-dark.png) |
| **Pet selector** | ![](https://cdn.plotline.so/loma-images/loma-redesign/pet-light.png) | ![](https://cdn.plotline.so/loma-images/loma-redesign/pet-dark.png) |

## Testing
- Booted the full stack locally against a throwaway DB, logged in, seeded recents + a rich conversation (tool calls incl. one failure) + a populated task board
- Captured all 8 required screenshots (above)
- Computed-style probe: dark canvas `rgb(6,27,32)` = `#061B20`, sidebar `rgb(4,23,27)` = `#04171B` ✅
- TypeScript check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)