### PR TITLE
typography: zero kerning, clamp residual bold to Medium

### DIFF
--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -382,7 +382,7 @@
     /* Never synthesize missing weights — faux bold wrecks Halyard's kerning.
        Requests above 500 fall back to the real Medium cut. */
     font-synthesis-weight: none;
-    letter-spacing: -0.01em;
+    letter-spacing: 0;
     transition: background-color 0.2s ease-out, color 0.2s ease-out;
     @apply bg-background text-foreground;
   }
@@ -391,6 +391,12 @@
   }
   strong, b {
     /* Emphasis (e.g. "Stopped by user.") uses the real Medium cut. */
+    font-weight: 500;
+  }
+  /* Clamp any residual 600/700 (e.g. typography-plugin defaults) to the real
+     Medium cut, so fallback fonts never flash a genuine bold while Halyard
+     loads. Zero-specificity :where() — any explicit weight still wins. */
+  :where(h1, h2, h3, h4, h5, h6, th, dt) {
     font-weight: 500;
   }
   button:not(:disabled), [role="button"]:not(:disabled) {
@@ -917,7 +923,7 @@
   font-size: clamp(1.5rem, 2vw, 1.9rem);
   line-height: 1.2;
   font-weight: 400;
-  letter-spacing: -0.02em;
+  letter-spacing: 0;
 }
 .loma-dashboard h2.font-heading {
   font-family: var(--font-body), sans-serif;
@@ -928,7 +934,7 @@
   font-family: var(--font-display), Georgia, serif;
   font-weight: 400;
   line-height: 1.18;
-  letter-spacing: -0.02em;
+  letter-spacing: 0;
 }
 
 /* Composer elevation: soft and shadow-led in light, surface-led in dark —


### PR DESCRIPTION
## What

Follow-up to #165 typography feedback: "halyard in places is still semibold. use medium. make kerning 0."

- **Kerning → 0 everywhere**: body letter-spacing `-0.01em` → `0`; page `h1` and `.editorial-heading` `-0.02em` → `0`. No negative tracking remains anywhere in the app.
- **Bold clamp**: zero-specificity `:where(h1–h6, th, dt)` base rule pins weight to `500`, so any residual hardcoded 600/700 (e.g. typography-plugin defaults) computes at the real Halyard Medium cut — and fallback fonts can never flash a genuine bold while Halyard loads.

Note: the reported "still semibold" render was on a build that predates #165 (inspector showed the pre-redesign `#F7F4EF` foreground). On current `main`, `font-semibold`/`font-bold` already resolve to Medium via the token remap + `font-synthesis-weight: none`; this PR adds the kerning-0 change and the belt-and-braces clamp.

## Tested

Booted the full stack locally against a throwaway DB, logged in, and probed the exact element from the report (`h2.font-semibold` integration card title):

- computed `font-weight: 500` (real Medium cut), `letter-spacing: normal` — light and dark ✅
- body `letter-spacing: normal`, `font-synthesis-weight: none` ✅
- page h1 = Feature Deck 400, letter-spacing normal ✅

### Integrations — Light
![integrations light](https://cdn.plotline.so/loma-images/loma-kerning/integrations-light.png)

### Integrations — Dark
![integrations dark](https://cdn.plotline.so/loma-images/loma-kerning/integrations-dark.png)

### New Chat — Light
![new chat light](https://cdn.plotline.so/loma-images/loma-kerning/new-chat-light.png)

### New Chat — Dark
![new chat dark](https://cdn.plotline.so/loma-images/loma-kerning/new-chat-dark.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)