### PR TITLE
design: containment & visual-hierarchy cleanup across the dashboard

### DIFF
--- a/dashboard/src/app/chat/page.tsx
+++ b/dashboard/src/app/chat/page.tsx
@@ -315,7 +315,7 @@ function ChatPageContent() {
           {activeConversationId && (
             <div className="flex items-center gap-1 flex-shrink-0">
               {/* Live chat cost */}
-              <CostChip conversationId={activeConversationId} className="h-8 mr-1" />
+              <CostChip conversationId={activeConversationId} className="h-8 mr-1 px-1.5 rounded-md border-0 bg-transparent backdrop-blur-none hover:text-foreground" />
               {/* Pin / Unpin */}
               <Tooltip>
                 <TooltipTrigger asChild>

--- a/dashboard/src/app/conversations/page.tsx
+++ b/dashboard/src/app/conversations/page.tsx
@@ -15,8 +15,6 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
-import { Badge } from "@/components/ui/badge";
-import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import {
@@ -56,9 +54,6 @@ const statusLabels: Record<string, string> = {
   completed: "Completed",
   error: "Error",
 };
-
-/* New palette: topic tags share one neutral style (cream fill, warm dark text). */
-const topicTagClass = "bg-[#F5F1ED] text-[#322C26]";
 
 const topicLabels: Record<string, string> = {
   debugging: "Debugging",
@@ -105,8 +100,8 @@ function SkeletonRow() {
 
 function MobileSkeletonCard() {
   return (
-    <Card className="p-3">
-      <CardContent className="p-0">
+    <div className="px-1 py-2">
+      <div>
         <div className="flex items-start gap-2">
           <Skeleton className="h-2 w-2 rounded-full mt-1.5" />
           <div className="flex-1">
@@ -117,8 +112,8 @@ function MobileSkeletonCard() {
             </div>
           </div>
         </div>
-      </CardContent>
-    </Card>
+      </div>
+    </div>
   );
 }
 
@@ -338,8 +333,8 @@ export default function ConversationsPage() {
           </div>
         </div>
 
-        {/* Desktop table */}
-        <div className="desktop-table bg-card rounded-xl overflow-hidden">
+        {/* Desktop table — sits directly on the page canvas, no wrapper card */}
+        <div className="desktop-table">
           <Table>
             <TableHeader>
               <TableRow className="text-left">
@@ -423,9 +418,9 @@ export default function ConversationsPage() {
                     {/* Topic */}
                     <TableCell>
                       {c.topic ? (
-                        <Badge variant="secondary" className={cn("text-xs", topicTagClass)}>
+                        <span className="text-xs text-muted-foreground">
                           {topicLabels[c.topic] || c.topic}
-                        </Badge>
+                        </span>
                       ) : <span className="text-xs text-muted-foreground/40">&mdash;</span>}
                     </TableCell>
 
@@ -518,9 +513,9 @@ export default function ConversationsPage() {
             )
           ) : (
             conversations.map((c, idx) => (
-              <Card
+              <div
                 key={c.conversation_id}
-                className="p-3 active:bg-muted/50 transition-colors animate-fade-in-up cursor-pointer"
+                className="px-1 py-2 rounded-lg active:bg-muted/50 transition-colors animate-fade-in-up cursor-pointer"
                 style={{ animationDelay: `${Math.min(idx * 30, 300)}ms` }}
                 onClick={(e) => {
                   const url = `/conversations/${c.conversation_id}`;
@@ -531,7 +526,7 @@ export default function ConversationsPage() {
                   }
                 }}
               >
-                <CardContent className="p-0">
+                <div>
                   <div className="flex items-start gap-2.5">
                     <div className={cn("h-2 w-2 rounded-full mt-1.5 shrink-0", statusDotStyles[c.status] || "bg-gray-400")} />
                     <div className="flex-1 min-w-0">
@@ -547,9 +542,9 @@ export default function ConversationsPage() {
                           <span className="tabular-nums">${c.cost.total_cost_usd.toFixed(2)}</span>
                         )}
                         {c.topic && (
-                          <Badge variant="secondary" className={cn("text-[10px] py-0 px-1.5", topicTagClass)}>
+                          <span className="text-[10px] text-muted-foreground">
                             {topicLabels[c.topic] || c.topic}
-                          </Badge>
+                          </span>
                         )}
                       </div>
                     </div>
@@ -570,8 +565,8 @@ export default function ConversationsPage() {
                       />
                     </div>
                   </div>
-                </CardContent>
-              </Card>
+                </div>
+              </div>
             ))
           )}
         </div>

--- a/dashboard/src/app/integrations/manage/page.tsx
+++ b/dashboard/src/app/integrations/manage/page.tsx
@@ -110,28 +110,33 @@ function formatScope(scope: string): string {
 /* -- Components ------------------------------------------------------------- */
 
 function StatusBadge({ status }: { status: string }) {
+  const base = "inline-flex items-center gap-1.5 text-xs text-muted-foreground";
   if (status === "connected")
     return (
-      <Badge className="bg-emerald-50 text-emerald-600 border-transparent">
+      <span className={base}>
+        <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
         Connected
-      </Badge>
+      </span>
     );
   if (status === "system_managed")
     return (
-      <Badge variant="secondary">
+      <span className={base}>
+        <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/40" />
         System-managed
-      </Badge>
+      </span>
     );
   if (status === "expired")
     return (
-      <Badge className="bg-amber-50 text-amber-600 border-transparent">
+      <span className="inline-flex items-center gap-1.5 text-xs text-amber-600">
+        <span className="h-1.5 w-1.5 rounded-full bg-amber-500" />
         Expired
-      </Badge>
+      </span>
     );
   return (
-    <Badge variant="secondary">
+    <span className={base}>
+      <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/25" />
       Not connected
-    </Badge>
+    </span>
   );
 }
 
@@ -1303,7 +1308,7 @@ export default function IntegrationsPage() {
                                   Webhook URL
                                 </p>
                                 <div className="flex items-center gap-2">
-                                  <code className="text-xs bg-muted text-muted-foreground px-3 py-1.5 rounded-lg border border-border flex-1 truncate">
+                                  <code className="text-xs bg-muted text-muted-foreground px-3 py-1.5 rounded-md flex-1 truncate">
                                     {webhookUrls[integ.provider]}
                                   </code>
                                   <Button
@@ -1328,16 +1333,9 @@ export default function IntegrationsPage() {
                             Connect your {integ.display_name} account to enable MCP tools
                             {integ.has_webhook ? ", webhook event ingestion, and agent capabilities" : " and agent capabilities"}.
                           </p>
-                          <div className="mt-2 flex flex-wrap gap-2">
-                            {["MCP tools", integ.has_webhook ? "Event ingestion" : null, "Agent skills"].filter(Boolean).map((cap) => (
-                              <Badge
-                                key={cap}
-                                variant="secondary"
-                              >
-                                {cap}
-                              </Badge>
-                            ))}
-                          </div>
+                          <p className="mt-2 text-xs text-muted-foreground">
+                            {["MCP tools", integ.has_webhook ? "Event ingestion" : null, "Agent skills"].filter(Boolean).join(" · ")}
+                          </p>
                         </>
                       )}
                     </CardContent>
@@ -1346,13 +1344,9 @@ export default function IntegrationsPage() {
               })}
               </div>
             ) : (
-              <Card className="border-dashed">
-                <CardContent className="p-3 text-center">
-                  <p className="text-[13px] text-muted-foreground">
-                    No org integrations available.
-                  </p>
-                </CardContent>
-              </Card>
+              <p className="text-[13px] text-muted-foreground text-center py-8">
+                No org integrations available.
+              </p>
             )}
           </TabsContent>
 
@@ -1382,27 +1376,18 @@ export default function IntegrationsPage() {
                           </p>
                         </div>
                       </div>
-                      <div className="flex items-center gap-1.5 mt-2">
-                        <Badge variant="outline" className="text-[10px]">
-                          MCP tools
-                        </Badge>
-                        <Badge variant="outline" className="text-[10px]">
-                          Server configured
-                        </Badge>
-                      </div>
+                      <p className="mt-2 text-xs text-muted-foreground">
+                        MCP tools · Server configured
+                      </p>
                     </CardContent>
                   </Card>
                 );
               })}
               </div>
             ) : (
-              <Card className="border-dashed">
-                <CardContent className="p-3 text-center">
-                  <p className="text-[13px] text-muted-foreground">
-                    No system-managed integrations configured.
-                  </p>
-                </CardContent>
-              </Card>
+              <p className="text-[13px] text-muted-foreground text-center py-8">
+                No system-managed integrations configured.
+              </p>
             )}
           </TabsContent>
 
@@ -1415,13 +1400,9 @@ export default function IntegrationsPage() {
             </div>
 
             {customConnectors.length === 0 ? (
-              <Card className="border-dashed">
-                <CardContent className="p-3 text-center">
-                  <p className="text-[13px] text-muted-foreground">
-                    No custom connectors yet. Add a remote MCP server to extend the agent.
-                  </p>
-                </CardContent>
-              </Card>
+              <p className="text-[13px] text-muted-foreground text-center py-8">
+                No custom connectors yet. Add a remote MCP server to extend the agent.
+              </p>
             ) : (
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-2">
                 {customConnectors.map((integ) => (
@@ -1464,24 +1445,17 @@ export default function IntegrationsPage() {
                         </div>
                       </div>
                       <Separator className="my-5" />
-                      <div className="flex flex-wrap items-center gap-1.5">
-                        <Badge variant="outline" className="text-[10px]">
-                          MCP tools
-                        </Badge>
+                      <div className="flex flex-wrap items-center gap-x-2 text-xs text-muted-foreground">
+                        <span>MCP tools</span>
+                        <span aria-hidden>·</span>
                         {integ.auth_mode === "oauth" ? (
                           integ.user_oauth_status === "connected" ? (
-                            <Badge variant="outline" className="text-[10px] bg-emerald-50 text-emerald-600 border-emerald-100">
-                              Authenticated
-                            </Badge>
+                            <span className="text-emerald-600">Authenticated</span>
                           ) : (
-                            <Badge variant="outline" className="text-[10px] bg-amber-50 text-amber-600 border-amber-100">
-                              Login required
-                            </Badge>
+                            <span className="text-amber-600">Login required</span>
                           )
                         ) : (
-                          <Badge variant="outline" className="text-[10px]">
-                            {integ.has_token ? "Token auth" : "No auth"}
-                          </Badge>
+                          <span>{integ.has_token ? "Token auth" : "No auth"}</span>
                         )}
                       </div>
                     </CardContent>
@@ -1811,9 +1785,8 @@ export default function IntegrationsPage() {
         </Tabs>
       )}
 
-      {/* Info section */}
-      <Card className="bg-muted/50">
-        <CardContent>
+      {/* Info section — divider + text, not a tinted rectangle */}
+      <div className="mt-6 border-t border-border/60 pt-4">
           <h3 className="text-[13px] font-medium text-foreground mb-2">How it works</h3>
           <ul className="text-[13px] text-muted-foreground space-y-1.5">
             <li>Org integrations are shared across the team — connect with an API key</li>
@@ -1823,8 +1796,7 @@ export default function IntegrationsPage() {
             <li>All tokens and keys are encrypted at rest</li>
             <li>You can disconnect at any time to revoke access</li>
           </ul>
-        </CardContent>
-      </Card>
+      </div>
     </div>
   );
 }

--- a/dashboard/src/app/my-usage/page.tsx
+++ b/dashboard/src/app/my-usage/page.tsx
@@ -8,10 +8,8 @@ import {
 import {
   RiChat1Line,
   RiDownloadLine,
-  RiMoneyDollarCircleLine,
   RiUploadLine,
 } from "@remixicon/react";
-import { Card } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import ClientTimestamp from "@/components/ClientTimestamp";
@@ -22,26 +20,6 @@ function formatTokens(n: number): string {
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
   return String(n);
-}
-
-function StatCard({ icon, label, value, sub }: {
-  icon: React.ReactNode;
-  label: string;
-  value: string;
-  sub?: string;
-}) {
-  return (
-    <Card className="p-3">
-      <div className="flex items-center gap-2 text-xs text-muted-foreground">
-        {icon}
-        {label}
-      </div>
-      <div className="mt-1 text-lg font-heading font-semibold tabular-nums">
-        {value}
-        {sub && <span className="ml-1.5 text-xs font-normal text-muted-foreground">{sub}</span>}
-      </div>
-    </Card>
-  );
 }
 
 type Range = "today" | "7" | "30" | "90";
@@ -93,47 +71,46 @@ export default function MyUsagePage() {
       {error && <p className="mt-4 text-[13px] text-destructive">{error}</p>}
 
       {!data && !error && (
-        <div className="mt-4 grid grid-cols-2 gap-2 md:grid-cols-4">
-          {Array.from({ length: 4 }).map((_, i) => <Skeleton key={i} className="h-[74px] rounded-xl" />)}
+        <div className="mt-6">
+          <Skeleton className="h-3 w-14" />
+          <Skeleton className="mt-2 h-11 w-44" />
+          <Skeleton className="mt-4 h-3 w-72" />
         </div>
       )}
 
       {data && (
         <>
-          <div className="mt-4 grid grid-cols-2 gap-2 md:grid-cols-4">
-            <StatCard
-              icon={<RiMoneyDollarCircleLine size={14} />}
-              label="Spent"
-              value={formatUsd(data.totals.total_cost_usd)}
-            />
-            <StatCard
-              icon={<RiChat1Line size={14} />}
-              label="Chats"
-              value={String(data.totals.conversations)}
-            />
-            <StatCard
-              icon={<RiUploadLine size={14} />}
-              label="Tokens in"
-              value={formatTokens(data.totals.input_tokens)}
-              // Cache reads/writes are billed too — the $ figure doesn't add
-              // up from fresh tokens alone on long agentic runs.
-              sub={
-                data.totals.cache_read_tokens + data.totals.cache_creation_tokens > 0
-                  ? `+${formatTokens(data.totals.cache_read_tokens + data.totals.cache_creation_tokens)} cached`
-                  : undefined
-              }
-            />
-            <StatCard
-              icon={<RiDownloadLine size={14} />}
-              label="Tokens out"
-              value={formatTokens(data.totals.output_tokens)}
-            />
+          {/* Impact comes from scale + whitespace, not a surfaced card */}
+          <div className="mt-6">
+            <div className="text-xs uppercase tracking-wider text-muted-foreground">Spent</div>
+            <div className="mt-1 font-heading font-semibold tabular-nums leading-none text-foreground text-[40px] md:text-[46px]">
+              {formatUsd(data.totals.total_cost_usd)}
+            </div>
+            <div className="mt-3 flex flex-wrap items-center gap-x-6 gap-y-1.5 text-[13px] text-muted-foreground">
+              <span className="inline-flex items-center gap-1.5">
+                <RiChat1Line size={14} />
+                {data.totals.conversations} chats
+              </span>
+              <span className="inline-flex items-center gap-1.5">
+                <RiUploadLine size={14} />
+                {formatTokens(data.totals.input_tokens)} in
+                {data.totals.cache_read_tokens + data.totals.cache_creation_tokens > 0 && (
+                  <span className="text-muted-foreground/70">
+                    {" "}+{formatTokens(data.totals.cache_read_tokens + data.totals.cache_creation_tokens)} cached
+                  </span>
+                )}
+              </span>
+              <span className="inline-flex items-center gap-1.5">
+                <RiDownloadLine size={14} />
+                {formatTokens(data.totals.output_tokens)} out
+              </span>
+            </div>
           </div>
 
           {/* A one-bar chart says nothing — Today skips it */}
           {data.daily.length > 1 && (
-            <Card className="mt-3 p-3">
-              <div className="mb-2 text-xs text-muted-foreground">Daily spend</div>
+            <div className="mt-6 border-t border-border/60 pt-4">
+              <div className="mb-2 text-xs uppercase tracking-wider text-muted-foreground">Daily spend</div>
               <div className="h-40">
                 <ResponsiveContainer width="100%" height="100%">
                   <BarChart data={data.daily} margin={{ top: 4, right: 4, bottom: 0, left: -18 }}>
@@ -157,20 +134,20 @@ export default function MyUsagePage() {
                   </BarChart>
                 </ResponsiveContainer>
               </div>
-            </Card>
+            </div>
           )}
 
-          <Card className="mt-3 mb-4 p-0 overflow-hidden">
-            <div className="px-3 pt-3 pb-2 text-xs text-muted-foreground">Costliest chats</div>
+          <div className="mt-6 mb-4 border-t border-border/60 pt-4">
+            <div className="mb-1 text-xs uppercase tracking-wider text-muted-foreground">Costliest chats</div>
             {data.top_chats.length === 0 ? (
-              <p className="px-3 pb-3 text-[13px] text-muted-foreground">Nothing yet in this window.</p>
+              <p className="text-[13px] text-muted-foreground">Nothing yet in this window.</p>
             ) : (
-              <ul className="divide-y divide-border">
+              <ul className="divide-y divide-border/60">
                 {data.top_chats.map((chat) => (
                   <li key={chat.conversation_id}>
                     <Link
                       href={`/chat?continue=${chat.conversation_id}`}
-                      className="flex items-center gap-3 px-3 py-2.5 hover:bg-muted/50"
+                      className="flex items-center gap-3 rounded-lg px-1 py-2.5 hover:bg-muted/50"
                     >
                       <div className="min-w-0 flex-1">
                         <div className="truncate text-[13px]">{chat.title || chat.prompt || "Untitled"}</div>
@@ -187,7 +164,7 @@ export default function MyUsagePage() {
                 ))}
               </ul>
             )}
-          </Card>
+          </div>
         </>
       )}
     </div>

--- a/dashboard/src/app/notifications/page.tsx
+++ b/dashboard/src/app/notifications/page.tsx
@@ -11,7 +11,6 @@ import {
   RiNotification3Line,
   RiRefreshLine,
 } from "@remixicon/react";
-import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -176,8 +175,8 @@ export default function NotificationsPage() {
         </div>
       </div>
 
-      {/* List */}
-      <div className="space-y-2">
+      {/* List — rows sit on the page canvas, separated by thin dividers */}
+      <div className="divide-y divide-border/60">
         {loading ? (
           <>
             <Skeleton className="h-16 w-full" />
@@ -195,17 +194,13 @@ export default function NotificationsPage() {
             const expanded = expandedId === n.notification_id;
             const hasActions = Boolean(n.conversation_id || n.link);
             return (
-              <Card
+              <div
                 key={n.notification_id}
-                className={cn(
-                  "p-3 active:bg-muted/50 transition-colors animate-fade-in-up cursor-pointer",
-                  !n.read && "bg-brand-50/40",
-                )}
+                className="px-1 py-3 active:bg-muted/40 transition-colors animate-fade-in-up cursor-pointer"
                 style={{ animationDelay: `${Math.min(idx * 30, 300)}ms` }}
                 onClick={() => handleToggle(n)}
                 aria-expanded={expanded}
               >
-                <CardContent className="p-0">
                   <div className="flex items-start gap-2.5">
                     <div
                       className={cn(
@@ -291,8 +286,7 @@ export default function NotificationsPage() {
                       </Tooltip>
                     </div>
                   </div>
-                </CardContent>
-              </Card>
+              </div>
             );
           })
         )}

--- a/dashboard/src/components/ApiKeysPanel.tsx
+++ b/dashboard/src/components/ApiKeysPanel.tsx
@@ -147,7 +147,7 @@ export default function ApiKeysPanel() {
         </CardContent>
       </Card>
 
-      <div className="space-y-2">
+      <div className="divide-y divide-border/60">
         {keys === null ? (
           <>
             <Skeleton className="h-14 w-full" />
@@ -161,8 +161,7 @@ export default function ApiKeysPanel() {
           />
         ) : (
           keys.map((k) => (
-            <Card key={k.key_id}>
-              <CardContent className="flex items-center gap-3">
+            <div key={k.key_id} className="flex items-center gap-3 py-3">
                 <RiKey2Line size={16} className="text-muted-foreground shrink-0" />
                 <div className="min-w-0 flex-1">
                   <div className="text-[13px] font-semibold text-foreground truncate">{k.name}</div>
@@ -183,8 +182,7 @@ export default function ApiKeysPanel() {
                 >
                   <RiDeleteBinLine size={15} />
                 </Button>
-              </CardContent>
-            </Card>
+            </div>
           ))
         )}
       </div>

--- a/dashboard/src/components/ChatPanel.tsx
+++ b/dashboard/src/components/ChatPanel.tsx
@@ -513,9 +513,9 @@ function FileAttachmentCard({ file }: { file: FileAttachment }) {
       download={file.name}
       target="_blank"
       rel="noopener noreferrer"
-      className={`flex items-center gap-2 px-3 py-2.5 rounded-xl border border-gray-200 hover:border-gray-300 hover:shadow-sm transition-all group ${bg}`}
+      className={`flex items-center gap-2 px-3 py-2.5 rounded-lg border border-border hover:border-input transition-colors group ${bg}`}
     >
-      <div className={`w-10 h-10 rounded-lg flex items-center justify-center text-lg flex-shrink-0 ${bg}`}>
+      <div className="w-10 h-10 rounded-lg flex items-center justify-center text-lg flex-shrink-0">
         {isImage && file.size < 5 * 1024 * 1024 ? (
           <img
             src={downloadUrl}
@@ -1571,7 +1571,7 @@ export default function ChatPanel({
                         "chat-text rounded-xl px-3.5 py-2.5 max-w-[75%] text-[13px] leading-relaxed break-words whitespace-pre-wrap",
                         item.queued
                           ? "bg-card/60 border border-dashed border-border"
-                          : "bg-card border border-border shadow-[0_1px_2px_rgba(6,27,32,0.03)]"
+                          : "bg-card border border-border"
                       )}>
                         {editingQueuedIndex === i ? (
                           <div className="flex flex-col gap-1.5">

--- a/dashboard/src/components/Nav.tsx
+++ b/dashboard/src/components/Nav.tsx
@@ -14,7 +14,7 @@ export default function Nav() {
             <span className="text-lg font-semibold text-foreground">
               Loma
             </span>
-            <span className="text-xs bg-blue-600 text-white px-2 py-0.5 rounded-full">
+            <span className="text-xs text-muted-foreground">
               Dashboard
             </span>
           </a>

--- a/dashboard/src/components/Sidebar.tsx
+++ b/dashboard/src/components/Sidebar.tsx
@@ -481,20 +481,20 @@ export default function Sidebar({
                   onClick={onClose}
                   className={cn(
                     // Roomier on phones (Claude-app scale), compact on desktop
-                    "relative flex items-center rounded-lg text-[13px] font-medium transition-colors duration-150",
+                    "relative flex items-center text-[13px] font-medium transition-colors duration-150",
                     "max-md:text-[16px] max-md:[&_svg]:h-5 max-md:[&_svg]:w-5",
                     collapsed
-                      ? "justify-center px-0 py-1.5 mx-auto w-10"
+                      ? "justify-center px-0 py-1.5 mx-auto w-10 rounded-lg"
                       : "px-3 py-2 gap-2.5 max-md:py-2.5 max-md:gap-3",
                     isActive
-                      ? "bg-sidebar-accent text-sidebar-accent-foreground"
-                      : "text-sidebar-foreground hover:bg-sidebar-accent/60 hover:text-sidebar-accent-foreground"
+                      ? "bg-sidebar-accent/25 text-sidebar-accent-foreground"
+                      : "text-sidebar-foreground hover:bg-sidebar-accent/20 hover:text-sidebar-accent-foreground"
                   )}
                   aria-current={isActive ? "page" : undefined}
                   title={collapsed ? item.name : undefined}
                 >
                   {isActive && (
-                    <span className="absolute left-0 top-1/2 h-4 w-[3px] -translate-y-1/2 rounded-full bg-sidebar-primary" aria-hidden="true" />
+                    <span className="absolute left-0 top-1/2 h-4 w-[4px] -translate-y-1/2 rounded-full bg-sidebar-primary" aria-hidden="true" />
                   )}
                   <span className="relative flex-shrink-0 transition-colors text-current">
                     {item.icon}
@@ -504,7 +504,7 @@ export default function Sidebar({
                   </span>
                   {!collapsed && <span>{item.name}</span>}
                   {!collapsed && item.badgeKey && badgeCounts[item.badgeKey] > 0 ? (
-                    <span className="ml-auto min-w-[20px] h-5 px-1 shrink-0 whitespace-nowrap flex items-center justify-center rounded bg-current/10 text-[11px] font-semibold tabular-nums">
+                    <span className="ml-auto shrink-0 whitespace-nowrap text-[11px] font-medium tabular-nums text-current/60">
                       {badgeCounts[item.badgeKey]}
                     </span>
                   ) : null}
@@ -562,8 +562,8 @@ export default function Sidebar({
                         className={cn(
                           "group flex items-center gap-1 px-2 py-1 text-[12px] max-md:px-3 max-md:py-2 max-md:text-[15px] rounded-lg transition-all duration-150",
                           isConvoActive
-                            ? "bg-sidebar-accent text-sidebar-accent-foreground"
-                            : "text-sidebar-foreground/75 hover:text-sidebar-accent-foreground hover:bg-sidebar-accent/60"
+                            ? "bg-sidebar-accent/25 text-sidebar-accent-foreground"
+                            : "text-sidebar-foreground/75 hover:text-sidebar-accent-foreground hover:bg-sidebar-accent/20"
                         )}
                       >
                         <Link
@@ -618,8 +618,8 @@ export default function Sidebar({
                         className={cn(
                           "group flex items-center gap-1 px-2 py-1 text-[12px] max-md:px-3 max-md:py-2 max-md:text-[15px] rounded-lg transition-all duration-150",
                           isConvoActive
-                            ? "bg-sidebar-accent text-sidebar-accent-foreground"
-                            : "text-sidebar-foreground/75 hover:text-sidebar-accent-foreground hover:bg-sidebar-accent/60"
+                            ? "bg-sidebar-accent/25 text-sidebar-accent-foreground"
+                            : "text-sidebar-foreground/75 hover:text-sidebar-accent-foreground hover:bg-sidebar-accent/20"
                         )}
                       >
                         <Link
@@ -686,13 +686,13 @@ export default function Sidebar({
                   onValueChange={(value) => {
                     if (value) setTheme(value as "light" | "system" | "dark");
                   }}
-                  className="w-full bg-muted/50 rounded-lg p-0.5"
+                  className="w-full p-0.5"
                   size="sm"
                 >
                   <ToggleGroupItem
                     value="light"
                     aria-label="Light mode"
-                    className="flex-1 flex items-center justify-center gap-1 text-[11px] font-medium data-[state=on]:bg-background data-[state=on]:text-foreground data-[state=on]:shadow-sm"
+                    className="flex-1 flex items-center justify-center gap-1 rounded-md text-[11px] font-medium data-[state=on]:bg-sidebar-accent/50 data-[state=on]:text-sidebar-accent-foreground"
                   >
                     <RiSunLine size={14} />
                     <span className="hidden sm:inline">Light</span>
@@ -700,7 +700,7 @@ export default function Sidebar({
                   <ToggleGroupItem
                     value="system"
                     aria-label="System mode"
-                    className="flex-1 flex items-center justify-center gap-1 text-[11px] font-medium data-[state=on]:bg-background data-[state=on]:text-foreground data-[state=on]:shadow-sm"
+                    className="flex-1 flex items-center justify-center gap-1 rounded-md text-[11px] font-medium data-[state=on]:bg-sidebar-accent/50 data-[state=on]:text-sidebar-accent-foreground"
                   >
                     <RiComputerLine size={14} />
                     <span className="hidden sm:inline">System</span>
@@ -708,7 +708,7 @@ export default function Sidebar({
                   <ToggleGroupItem
                     value="dark"
                     aria-label="Dark mode"
-                    className="flex-1 flex items-center justify-center gap-1 text-[11px] font-medium data-[state=on]:bg-background data-[state=on]:text-foreground data-[state=on]:shadow-sm"
+                    className="flex-1 flex items-center justify-center gap-1 rounded-md text-[11px] font-medium data-[state=on]:bg-sidebar-accent/50 data-[state=on]:text-sidebar-accent-foreground"
                   >
                     <RiMoonLine size={14} />
                     <span className="hidden sm:inline">Dark</span>

--- a/dashboard/src/components/tasks/TaskBoard.tsx
+++ b/dashboard/src/components/tasks/TaskBoard.tsx
@@ -153,7 +153,7 @@ export function TaskBoard({ board, onBoardChange, onRefresh, onEditDraft, onAddT
       </div>
       <DragOverlay>
         {activeTask && (
-          <div className="rounded-md border bg-card px-3 py-2 text-[13px] shadow-md">
+          <div className="rounded-lg border bg-card px-3 py-2 text-[13px] shadow-md">
             <div className="line-clamp-2 break-words">{activeTask.title || activeTask.prompt || "New task"}</div>
           </div>
         )}

--- a/dashboard/src/components/tasks/TaskCard.tsx
+++ b/dashboard/src/components/tasks/TaskCard.tsx
@@ -64,7 +64,7 @@ export function TaskCard({
         setMenuOpen(true);
       }}
       className={cn(
-        "group relative rounded-xl border border-border bg-card px-3.5 py-3 cursor-pointer",
+        "group relative rounded-lg border border-border bg-card px-3.5 py-3 cursor-pointer",
         "hover:border-input transition-colors touch-none select-none",
         isDragging && "opacity-40",
       )}
@@ -82,7 +82,7 @@ export function TaskCard({
           <div className="mt-1 flex items-center gap-1 overflow-hidden pr-12">
             <TaskPriorityTag task={task} onSetPriority={onSetPriority} />
             <TaskDeadlineBadge task={task} />
-            {assignedTags.slice(0, 2).map((tag) => <span key={tag.id} className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">{tag.name}</span>)}
+            {assignedTags.slice(0, 2).map((tag) => <span key={tag.id} className="text-[10px] text-muted-foreground">{tag.name}</span>)}
             {assignedTags.length > 2 && <span className="text-[10px] text-muted-foreground">+{assignedTags.length - 2}</span>}
           </div>
         </div>

--- a/dashboard/src/components/tasks/TaskColumn.tsx
+++ b/dashboard/src/components/tasks/TaskColumn.tsx
@@ -38,8 +38,8 @@ export function TaskColumn({ id, name, tasks, droppable, onAddTask, children }: 
         <div
           ref={setNodeRef}
           className={cn(
-            "flex min-h-24 flex-1 flex-col gap-2 rounded-xl p-1.5 bg-foreground/[0.025] transition-colors",
-            isOver && droppable !== false && "bg-foreground/[0.05]",
+            "flex min-h-24 flex-1 flex-col gap-2 rounded-lg p-1.5 transition-colors",
+            isOver && droppable !== false && "bg-foreground/[0.04]",
             droppable === false && "opacity-40",
           )}
         >

--- a/dashboard/src/components/tasks/TaskDeadline.tsx
+++ b/dashboard/src/components/tasks/TaskDeadline.tsx
@@ -49,8 +49,8 @@ export function TaskDeadlineBadge({ task, className }: { task: Task; className?:
     <span
       title={`Deadline: ${display.fullDate}`}
       className={cn(
-        "flex shrink-0 items-center gap-1 rounded bg-muted px-1.5 py-0.5 text-[10px] leading-4 text-muted-foreground",
-        display.urgent && "bg-destructive/10 text-destructive",
+        "flex shrink-0 items-center gap-1 text-[10px] leading-4 text-muted-foreground",
+        display.urgent && "text-destructive",
         className,
       )}
     >

--- a/dashboard/src/components/ui/card.tsx
+++ b/dashboard/src/components/ui/card.tsx
@@ -12,7 +12,7 @@ function Card({
       data-slot="card"
       data-size={size}
       className={cn(
-        "group/card flex flex-col gap-(--card-spacing) overflow-hidden rounded-xl bg-card py-(--card-spacing) text-[13px] text-card-foreground ring-1 ring-foreground/10 [--card-spacing:--spacing(4)] has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:[--card-spacing:--spacing(3)] data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+        "group/card flex flex-col gap-(--card-spacing) overflow-hidden rounded-lg bg-card py-(--card-spacing) text-[13px] text-card-foreground ring-1 ring-foreground/10 [--card-spacing:--spacing(4)] has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:[--card-spacing:--spacing(3)] data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-lg *:[img:last-child]:rounded-b-lg",
         className
       )}
       {...props}
@@ -25,7 +25,7 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-header"
       className={cn(
-        "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-(--card-spacing) has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-(--card-spacing)",
+        "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-lg px-(--card-spacing) has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-(--card-spacing)",
         className
       )}
       {...props}
@@ -84,7 +84,7 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card-footer"
       className={cn(
-        "flex items-center rounded-b-xl border-t bg-muted/50 p-(--card-spacing)",
+        "flex items-center rounded-b-lg border-t bg-muted/50 p-(--card-spacing)",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
Flatten the UI so hierarchy comes from **whitespace, alignment, typography and thin dividers** instead of nested boxes, borders and pills. Max containment depth 1; containers only where interaction genuinely needs one. **No changes** to functionality, content, navigation, typography, the pixel pet, or the color tokens.

## What changed
- **Activity / Conversations** — removed the card wrapping the table (the list now sits directly on the page canvas); topics render as plain secondary text instead of white pills; mobile rows de-carded. Compact 8px filters float above the list.
- **My Usage** — removed the giant *Spent* card, the chart card and the *Costliest chats* card. *Spent* is now a Feature Deck hero number with a small Halyard label; secondary stats are a quiet inline row; lists sit on the canvas with thin dividers.
- **Sidebar** — active item is now the lime 4px indicator + a faint tint (no visible rounded box); notification/task counts are quiet numerals; the appearance selector track/active chip are simplified.
- **Tasks** — flattened the Kanban columns (no tinted/rounded surface); cards kept as cards at ~8px; deadline de-pilled. Priority stays a pill (interactive control).
- **Notifications** — rows sit on the canvas separated by thin dividers; no per-row cards, no unread tint band (the dot already signals unread).
- **Integrations** — connection status is a dot + text; capability/auth chips are plain text; dashed empty-states and the "How it works" tint become divider sections; webhook code block loses its redundant inner border. Integration cards kept (legitimate independent objects) at 8px.
- **Chat** — file-attachment card loses its redundant inner tint; user message bubble drops its shadow; the desktop cost chip is de-pilled; Nav "Dashboard" pill to text. **Composer surface left intact.**
- **Card primitive** radius 12px to 8px to match the corner-radius scale.

## Screenshots (Light / Dark)

**My Usage**

| Light | Dark |
|---|---|
| ![](https://cdn.plotline.so/loma-images/loma-design/containment-my-usage-light.png) | ![](https://cdn.plotline.so/loma-images/loma-design/containment-my-usage-dark.png) |

**Activity / Conversations**

| Light | Dark |
|---|---|
| ![](https://cdn.plotline.so/loma-images/loma-design/containment-conversations-light.png) | ![](https://cdn.plotline.so/loma-images/loma-design/containment-conversations-dark.png) |

**Tasks**

| Light | Dark |
|---|---|
| ![](https://cdn.plotline.so/loma-images/loma-design/containment-tasks-light.png) | ![](https://cdn.plotline.so/loma-images/loma-design/containment-tasks-dark.png) |

**Notifications**

| Light | Dark |
|---|---|
| ![](https://cdn.plotline.so/loma-images/loma-design/containment-notifications-light.png) | ![](https://cdn.plotline.so/loma-images/loma-design/containment-notifications-dark.png) |

**Integrations**

| Light | Dark |
|---|---|
| ![](https://cdn.plotline.so/loma-images/loma-design/containment-integrations-light.png) | ![](https://cdn.plotline.so/loma-images/loma-design/containment-integrations-dark.png) |

**Chat**

| Light | Dark |
|---|---|
| ![](https://cdn.plotline.so/loma-images/loma-design/containment-chat-light.png) | ![](https://cdn.plotline.so/loma-images/loma-design/containment-chat-dark.png) |

## Notes
- Verified in-browser against a local Loma stack (isolated throwaway DB) with seeded data; every screen was captured logged-in in both themes.
- **Draft — do not merge.** Opened for review of the preview.
- Generated by the Plotline IE Bot.
