### PR TITLE
fix: restore snake sprite bottom row, remove black cat pet

### DIFF
--- a/api/governance_routes.py
+++ b/api/governance_routes.py
@@ -140,7 +140,7 @@ async def handle_update_my_theme(request: web.Request) -> web.Response:
     return web.json_response({"theme_preference": theme})
 
 
-VALID_PETS = ("tabby", "tuxedo", "black-cat", "calico", "corgi", "golden", "dachshund", "rabbit", "hamster", "parrot",
+VALID_PETS = ("tabby", "tuxedo", "calico", "corgi", "golden", "dachshund", "rabbit", "hamster", "parrot",
               "croc", "lion", "duck", "snake", "dino", "dragon", "llama", "koala")
 
 

--- a/dashboard/src/components/PetCompanion.tsx
+++ b/dashboard/src/components/PetCompanion.tsx
@@ -119,6 +119,7 @@ const spriteArt: Record<string, { colors: Record<string, string>; rows: string[]
       "obaaoooooaabobo",
       "obaaaaaaaaabobo",
       ".obbbbbbbbboobo",
+      "..ooooooooo..o.",
     ],
   },
   dino: {
@@ -311,7 +312,6 @@ const spriteArt: Record<string, { colors: Record<string, string>; rows: string[]
 export const PETS = [
   { id: "tabby", name: "Tabby cat", kind: "cat", coat: "#d98c45", patch: "#98562e" },
   { id: "tuxedo", name: "Tuxedo cat", kind: "cat", coat: "#454754", patch: "#f2ebda" },
-  { id: "black-cat", name: "Black cat", kind: "cat", coat: "#454754", patch: "#626778" },
   { id: "calico", name: "Calico cat", kind: "cat", coat: "#eee4d0", patch: "#c07a42" },
   { id: "corgi", name: "Corgi", kind: "dog", coat: "#c7803d", patch: "#eeb76f" },
   { id: "golden", name: "Golden retriever", kind: "dog", coat: "#c68c40", patch: "#efc36c" },
@@ -351,7 +351,7 @@ export function PetSprite({ petId, size = 40, state = "idle", animated = false }
     pixels[13] = "...oboooooobbo..";
     pixels[14] = "....oo.....oo...";
   }
-  const colors: Record<string, string> = art ? art.colors : { o: "#332f37", a: pet.coat, b: pet.patch, m: pet.id === "black-cat" ? "#626778" : "#f5e9cf", e: "#24232c", n: "#bb7681", p: "#dfa4a0" };
+  const colors: Record<string, string> = art ? art.colors : { o: "#332f37", a: pet.coat, b: pet.patch, m: "#f5e9cf", e: "#24232c", n: "#bb7681", p: "#dfa4a0" };
   return (
     <span aria-hidden="true" data-pet={pet.id} data-state={state} className="pet-sprite inline-flex shrink-0" data-animated={animated} style={{ width: size, height: size }}>
       <svg className="size-full" width={size} height={size} viewBox={`0 0 ${pixels[0].length} ${pixels.length}`} shapeRendering="crispEdges" focusable="false">


### PR DESCRIPTION
Follow-up to #171.

## What

1. **Snake no longer cut off at the bottom.** The Paper "Snake" artboard is a 15×15 pixel grid, but the sprite was extracted as 15×14 — the final bottom outline row was dropped, so the body ended abruptly at the sprite edge. Re-extracted the grid from the Paper export and restored the missing row (`..ooooooooo..o.`).
2. **Removed the Black cat pet.** Dropped from the frontend `PETS` catalog (and its color special-case) and from the backend `VALID_PETS` allowlist. Users who had `black-cat` saved fall back safely to the default Tabby (`PETS.find(...) ?? PETS[0]`), so nothing breaks for existing preferences.

## Sprite fix — before/after

| Before (reported) | After (re-extracted from Paper design) |
|---|---|
| Snake body cut flat at the bottom edge | ![fixed snake](https://cdn.plotline.so/loma-images/bfb1864c793440ab80ea45f5e98ee977.png) |

## Testing

- `tests/test_pet_preferences.py`: **30 passed** (one fewer parametrized case since black-cat was removed; the frontend↔backend sync test keeps both lists aligned)
- `tsc --noEmit` on the dashboard: clean
- Booted the full stack locally against a throwaway DB (`run-loma-local`), logged in, and verified in a real browser:

**Pet picker — 17 pets, Black cat gone:**
![pet picker](https://cdn.plotline.so/loma-images/341f75535be747b79a7ef0bf9a938417.png)

**Snake selected — full body with closed bottom outline:**
![snake selected](https://cdn.plotline.so/loma-images/63e9567e5568411aa6f9be4eefbe54d8.png)

**Saved end-to-end — backend allowlist exercised, snake renders in sidebar + Tasks header:**
![snake saved](https://cdn.plotline.so/loma-images/c2748cc925134ba4965f04f953a27bbb.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)