### PR TITLE
feat: add Doggo and new Cat pets, replace Corgi with Paper design

### DIFF
--- a/api/governance_routes.py
+++ b/api/governance_routes.py
@@ -140,7 +140,7 @@ async def handle_update_my_theme(request: web.Request) -> web.Response:
     return web.json_response({"theme_preference": theme})
 
 
-VALID_PETS = ("tabby", "tuxedo", "calico", "corgi", "golden", "dachshund", "rabbit", "hamster", "parrot",
+VALID_PETS = ("tabby", "tuxedo", "cat", "doggo", "corgi", "golden", "dachshund", "rabbit", "hamster", "parrot",
               "croc", "lion", "duck", "snake", "dino", "dragon", "llama", "koala")
 
 

--- a/dashboard/src/components/PetCompanion.tsx
+++ b/dashboard/src/components/PetCompanion.tsx
@@ -306,14 +306,122 @@ const spriteArt: Record<string, { colors: Record<string, string>; rows: string[]
       ".........bbbccccccbbbbbbbbb.....................",
     ],
   },
+  doggo: {
+    colors: { a: "#dc9b40", b: "#c67c36", c: "#f5ca7c", d: "#fffefb", o: "#2e2e2a" },
+    rows: [
+      "..........oooooooooooo..........",
+      "...oooooooaaaaaaaaaaaaooooooo...",
+      "...oooooooaaaaaaaaaaaaooooooo...",
+      "..obbbbbbaaaaaaaaaaaaaaabbbbboo.",
+      "oobbbbbooaaaaaaaaaaaaaaaobbbbbbo",
+      "oobbbbbooaaaaaaaaaaaaaaaobbbbbbo",
+      "oobbbbbooaaaaaaaaaaaaaaaobbbbbbo",
+      "oobbbboaaaaaaaaaaaaaaaaaaoobbbbo",
+      "oobbbboaaaaaaaaaaaaaaaaaaoobbbbo",
+      "oooooooaaaooaaaaaaaaooaaaooooooo",
+      "oooooooaaaooaaaaaaaaooaaaooooooo",
+      "......oaaaooaaccccaaooaaaoo.....",
+      "......oaaaaaccooooccaaaaaoo.....",
+      "...oooooaaaaccooooccaaaaaoooo...",
+      "...oooooaacccccoocccccaaaoooo...",
+      "...oodddoacccccoocccccaoodddo...",
+      "...oodddoaccccooooccccadddddo...",
+      "...ooddddoooooooooooooodddddo...",
+      ".....oddddddddddddddddddddoo....",
+      "...oooddddddddddddddddddddooo...",
+      "...ooddddoooooooooooooodddddo...",
+      "...oodddoaaaccccccccaaaoodddo...",
+      "...oodddoaaaccccccccaaaoodddo...",
+      "...oooooaaaaccccccccaaaaaooooooo",
+      "......ooaaaaaacccccaaaaaaoobbbbo",
+      "......ooaaaaaacccccaaaaaaoobbbbo",
+      "......ooaaaaaaoccooaaaaaaoobbbbo",
+      "......ooaooaaaoccooaaaoaaoobbooo",
+      "......ooaooaaaoccooaaaoaaoobbooo",
+      ".....obbaoocccoaaoocccoaabbooo..",
+      ".....obbaoocccoaaoocccoaabboo...",
+      ".....obbaoocccoaaoocccoaabbo....",
+      ".....oooboocccooooocccobbooo....",
+      ".....oooboocccooooocccobbooo....",
+      "......ooooooooooooooooooooo.....",
+      "......ooooooooooooooooooooo.....",
+    ],
+  },
+  corgi: {
+    colors: { a: "#fb7508", b: "#fd9002", c: "#f3dbab", d: "#000000", e: "#49110c", o: "#2e2e2a" },
+    rows: [
+      "....................oooo......oooo......",
+      "....................oooo......oooo......",
+      "....................ooaaoo....ooaaoo....",
+      "....................ooaaoo....ooaaoo....",
+      "..................ooaaaaooooooaaaaoo....",
+      "..................ooaaaaooooooaaaaoo....",
+      "..................ooaaaaooooooaaaaoo....",
+      "..................ooaaaabbbbbbbbaaoo....",
+      "..................ooaaaabbbbbbbbaaoo....",
+      "................ooaabbbbbbbbbbbbbbbbcc..",
+      "................ooaabbbbbbbbbbbbbbbbcc..",
+      "..oooo..........ooaabbbbddbbbbbbddbbcc..",
+      "..oooo..........ooaabbbbddbbbbbbddbbcc..",
+      "ooccccoo......ooaabbbbbbbbbbccccccccbboo",
+      "ooccccoo......ooaabbbbbbbbbbccccccccbboo",
+      "oocccccc......ooaabbbbbbeecccccceeccbboo",
+      "ooccccccoo....ooaabbbbbbeecccccceeccbboo",
+      "ooccccccoo....ooaabbbbbbeecccccceeccbboo",
+      "ooccccaaaaooooooaabbbbcccceeeeeeccccbboo",
+      "ooccccaaaaooooooaabbbbcccceeeeeeccccbboo",
+      "..ooaaaabbbbbbbbbbaabbccccccccccccccoo..",
+      "..ooaaaabbbbbbbbbbaabbccccccccccccccoo..",
+      "....ooaabbbbbbbbbbbbbbbbccccccccccoo....",
+      "....ooaabbbbbbbbbbbbbbbbccccccccccoo....",
+      "....ooaabbbbbbbbbbbbbbbbccccccccccoo....",
+      "....ooaabbbbbbbbbbbbbbbbccccccccccoo....",
+      "....ooaabbbbbbbbbbbbbbbbccccccccccoo....",
+      "....ooaabbbbbbbbbbbbbbbbbbccccccbboo....",
+      "....ooaabbbbbbbbbbbbbbbbbbccccccbboo....",
+      "....ooaabbbbaaaaaaaabbbbbbbbccaabboo....",
+      "....ooaabbbbaaaaaaaabbbbbbbbccaabboo....",
+      "....oobbbbbbooaaooooaabbbboooobbbboo....",
+      "....oobbbbbbooaaooooaabbbboooobbbboo....",
+      "....oobbbbooaaaaoo..ooaabb..ooaabboo....",
+      "....oobbbbooaaaaoo..ooaabb..ooaabboo....",
+      "....oobboo..ooaaoo....oobb..ooaaoo......",
+      "....oobboo..ooaaoo....oobb..ooaaoo......",
+      "....oobboo..ooaaoo....oobb..ooaaoo......",
+      "....oooooo..oooo......oooo....oooo......",
+      "....oooooo..oooo......oooo....oooo......",
+    ],
+  },
+  cat: {
+    colors: { a: "#f7a4bd", b: "#d56518", c: "#fbb738", d: "#f9f1c8", o: "#2e2e2a" },
+    rows: [
+      "..oo.......oo....",
+      "..oao.....oao....",
+      "..oabooooobao....",
+      "..obccbcbccbo....",
+      "oooccdbcbdccooo..",
+      ".obcoocdcoocbo...",
+      "ooccccdodccccoo..",
+      ".obcccccccccbo...",
+      "obbbcdcccdcbbbo..",
+      "obccbcdddcbccbo..",
+      "obbcccbdbcccbboo.",
+      "obcbcccbcccbcbobo",
+      "obbcbccbccbcbobbo",
+      ".obbcccbcccbobcco",
+      "..oobddoddbobcco.",
+      "....ooo.ooo.ooo..",
+    ],
+  },
 };
 
 
 export const PETS = [
   { id: "tabby", name: "Tabby cat", kind: "cat", coat: "#d98c45", patch: "#98562e" },
   { id: "tuxedo", name: "Tuxedo cat", kind: "cat", coat: "#454754", patch: "#f2ebda" },
-  { id: "calico", name: "Calico cat", kind: "cat", coat: "#eee4d0", patch: "#c07a42" },
-  { id: "corgi", name: "Corgi", kind: "dog", coat: "#c7803d", patch: "#eeb76f" },
+  { id: "cat", name: "Cat", kind: "cat", coat: "#fbb738", patch: "#d56518" },
+  { id: "doggo", name: "Doggo", kind: "doggo", coat: "#dc9b40", patch: "#c67c36" },
+  { id: "corgi", name: "Corgi", kind: "corgi", coat: "#fd9002", patch: "#f3dbab" },
   { id: "golden", name: "Golden retriever", kind: "dog", coat: "#c68c40", patch: "#efc36c" },
   { id: "dachshund", name: "Dachshund", kind: "dog", coat: "#654331", patch: "#a66738" },
   { id: "rabbit", name: "Rabbit", kind: "rabbit", coat: "#d8cbbf", patch: "#b4a59c" },
@@ -338,11 +446,6 @@ export function PetSprite({ petId, size = 40, state = "idle", animated = false }
   const pet = PETS.find((p) => p.id === petId) ?? PETS[0];
   const art = spriteArt[pet.id];
   const pixels: string[] = art ? art.rows : [...silhouettes[pet.kind as keyof typeof silhouettes]];
-  if (pet.id === "corgi") {
-    pixels[1] = "...oo......oo...";
-    pixels[2] = "...oao....oao...";
-    pixels[3] = "...oaaooooaao...";
-  }
   if (pet.id === "dachshund") {
     pixels[9] = "....obbbbbbbooo.";
     pixels[10] = "....obbbbbbbbbo.";
@@ -373,8 +476,7 @@ export function PetSprite({ petId, size = 40, state = "idle", animated = false }
           if (pixel === ".") return null;
           // Coat markings distinguish the cats without recoloring their eyes.
           const marking = pet.id === "tabby" && pixel === "a" && y < 6 && x % 3 === 0;
-          const calico = pet.id === "calico" && pixel === "a" && ((x < 7 && y < 7) || (x > 9 && y > 10));
-          return <rect key={`${x}-${y}`} x={x} y={y} width="1" height="1" fill={marking || calico ? pet.patch : colors[pixel]} />;
+          return <rect key={`${x}-${y}`} x={x} y={y} width="1" height="1" fill={marking ? pet.patch : colors[pixel]} />;
         }))}
       </svg>
       <style jsx>{`


### PR DESCRIPTION
## What

Follow-up to #171/#172 — brings in the remaining pets from the [Paper pets file](https://app.paper.design/file/01M23WNF975B06YH0VVEB0XWK9):

- **Doggo added** (dog holding a bone) — extracted pixel-for-pixel from the Paper artboard into the code-native sprite format
- **Corgi replaced** — the old silhouette-based corgi (and its pixel-override special case) is removed; the new side-view orange Corgi from Paper is used instead, keeping the same `corgi` id so saved preferences carry over
- **Calico cat removed, new Cat added** — the fluffy orange Cat from Paper replaces the Calico entry; the calico marking special case is removed. Users who had `calico` saved fall back safely to the default Tabby
- Backend `VALID_PETS` allowlist kept in sync (add `doggo` + `cat`, remove `calico`)

## Testing

- `tests/test_pet_preferences.py`: **31 passed** (parametrized over the updated allowlist, frontend/backend catalog sync check included)
- `tsc --noEmit` on the dashboard: clean
- Booted the stack locally against a throwaway DB and verified in a real browser (Playwright):
  - Picker shows **18 pets** — Doggo, new Corgi, and new Cat present; Calico gone
  - Saved **Doggo** end-to-end: PATCH accepted by the backend allowlist, sprite renders in the sidebar and Tasks header after save

| Pet picker (new Cat / Doggo / Corgi, no Calico) | Doggo saved (sidebar + header) |
|---|---|
| ![picker](https://cdn.plotline.so/loma-images/loma-pr-pets2/ss1-pet-picker.png) | ![saved](https://cdn.plotline.so/loma-images/loma-pr-pets2/ss5-doggo-saved.png) |

| Doggo selected | Corgi selected | Cat selected |
|---|---|---|
| ![doggo](https://cdn.plotline.so/loma-images/loma-pr-pets2/ss2-doggo.png) | ![corgi](https://cdn.plotline.so/loma-images/loma-pr-pets2/ss3-corgi.png) | ![cat](https://cdn.plotline.so/loma-images/loma-pr-pets2/ss4-cat.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)