### PR TITLE
feat: add Axolotl pet companion

### DIFF
--- a/api/governance_routes.py
+++ b/api/governance_routes.py
@@ -141,7 +141,7 @@ async def handle_update_my_theme(request: web.Request) -> web.Response:
 
 
 VALID_PETS = ("tabby", "tuxedo", "cat", "doggo", "corgi", "golden", "dachshund", "rabbit", "hamster", "parrot",
-              "croc", "lion", "duck", "snake", "dino", "dragon", "llama", "koala")
+              "croc", "lion", "duck", "snake", "dino", "dragon", "llama", "koala", "axolotl")
 
 
 async def handle_update_my_pet(request: web.Request) -> web.Response:

--- a/dashboard/src/components/PetCompanion.tsx
+++ b/dashboard/src/components/PetCompanion.tsx
@@ -15,8 +15,35 @@ const silhouettes = {
   parrot: ["................", "......ooo.......", ".....oaaao......", "....oaaaaao.....", "....oaaeeao.....", "....oaammmmo....", "....oaammo......", "...oaaaaao......", "..oabbaaaao.....", "..oabbbaaao.....", "..oabbbaaao.....", "...obbaaao......", "....oaaaao......", "....omoomoo.....", "...oooooooooo...", "................"],
 };
 
-// Pixel art imported from the Paper pet designs (one palette per pet).
+// Pixel art with one palette per pet; includes imported Paper designs and original sprites.
 const spriteArt: Record<string, { colors: Record<string, string>; rows: string[] }> = {
+  axolotl: {
+    colors: { o: "#513541", a: "#f6b6cc", b: "#ffdae5", p: "#dd6a99", e: "#302c39" },
+    rows: [
+      "........................",
+      "..p...p..........p...p..",
+      "..pp..p..........p..pp..",
+      "...pp.pp........pp.pp...",
+      ".pp.pppooooooooooppp.pp.",
+      "..ppppoaabbaaaabbaopppp.",
+      "...ppoaabbaaaaabbaopp...",
+      ".ppppoaabbaaaaabbaopppp.",
+      "..pppoaaeaaaaaaeaaoppp..",
+      "...ppoaapaaaaaapaaopp...",
+      ".....oaaaaaooaaaaao.....",
+      "......oaaaaaaaaaao......",
+      ".......ooaaaaaaoo.......",
+      "........oabbbaao........",
+      ".....oo.oabbbaao.oo.....",
+      "....oaaaoabbbaaoaaao....",
+      ".....oooaaaaaaaaooo.....",
+      ".......oaaaaaaaao..oo...",
+      ".......oaaaaaaaaoooapo..",
+      "......oaaooooaaaappo....",
+      "......ooo....oooooo.....",
+      "........................",
+    ],
+  },
   croc: {
     colors: { o: "#181818", a: "#70bd41", b: "#3ba471", c: "#f9f1c8", d: "#ffffff", e: "#b5222a", f: "#b8af8d" },
     rows: [
@@ -435,6 +462,7 @@ export const PETS = [
   { id: "dragon", name: "Dragon", kind: "dragon", coat: "#3ba471", patch: "#d0511f" },
   { id: "llama", name: "Llama", kind: "llama", coat: "#c18048", patch: "#895128" },
   { id: "koala", name: "Koala", kind: "koala", coat: "#8f8e8e", patch: "#6f462b" },
+  { id: "axolotl", name: "Axolotl", kind: "axolotl", coat: "#f6b6cc", patch: "#dd6a99" },
 ] as const;
 
 const DEFAULT_PET = { pet_id: "tabby", visible: true, animated: true };

--- a/tests/test_pet_preferences.py
+++ b/tests/test_pet_preferences.py
@@ -79,3 +79,17 @@ def test_frontend_pet_catalog_matches_api():
 
     source = (Path(__file__).parents[1] / "dashboard/src/components/PetCompanion.tsx").read_text()
     assert set(re.findall(r'\{ id: "([a-z-]+)", name:', source)) == set(VALID_PETS)
+
+
+def test_axolotl_sprite_has_complete_palette_and_rectangular_grid():
+    from pathlib import Path
+    import re
+
+    source = (Path(__file__).parents[1] / "dashboard/src/components/PetCompanion.tsx").read_text()
+    assert "axolotl" in VALID_PETS
+    art = re.search(r'axolotl: \{\s+colors: \{(.*?)\},\s+rows: \[(.*?)\]', source, re.S)
+    assert art is not None
+    colors = set(re.findall(r'(\w): "#[0-9a-fA-F]{6}"', art[1]))
+    rows = re.findall(r'"([.a-z]+)"', art[2])
+    assert rows and len({len(row) for row in rows}) == 1
+    assert set("".join(rows)) - {"."} <= colors


### PR DESCRIPTION
## Summary
- Add a pink Axolotl with feathery gills as the 19th pet in the existing picker.
- Reuse the shared pixel-sprite renderer and reactions throughout Loma, including the task drawer runway.
- Allow `axolotl` in the authenticated user's saved preference API. Existing defaults and pets are unchanged.
- Add sprite palette/grid validation; existing parameterized persistence tests cover the new pet.

## Verification
- `python -m pytest tests/test_pet_preferences.py -q`: 33 passed.
- Dashboard `tsc --noEmit`: passed.
- ESLint on `src/components/PetCompanion.tsx`: passed.
- Browser: isolated local backend and dashboard, real first-admin login, real pet PATCH/GET and persistence after reload.
- Browser: task drawer running state used intercepted task/conversation fixtures, not a live agent run. Verified Axolotl runway animation, click-to-open picker, closing via X preserves draft, reduced motion, animation toggle, hidden pets, desktop/mobile and dark mode. No browser errors.
- Test processes stopped and throwaway database deleted; production health stayed 200.

## Existing issue noticed (not changed here)
Pressing Escape inside pet settings during a running chat also reaches ChatPanel's global stop shortcut. Closing with X works and preserves the draft. This handler predates this change; fixing keyboard shortcut scoping is outside this pet-catalog addition.

## Screenshots

### Picker with Axolotl selected
![Picker with Axolotl selected](https://cdn.plotline.so/loma-images/loma-axolotl/picker-desktop.png)

### Saved companion on taskboard
![Saved companion on taskboard](https://cdn.plotline.so/loma-images/loma-axolotl/board-desktop.png)

### Running task drawer (fixture)
![Running task drawer (fixture)](https://cdn.plotline.so/loma-images/loma-axolotl/task-desktop.png)

### Dark task drawer
![Dark task drawer](https://cdn.plotline.so/loma-images/loma-axolotl/task-dark.png)

### Mobile task drawer
![Mobile task drawer](https://cdn.plotline.so/loma-images/loma-axolotl/task-mobile.png)

### Mobile picker, scrolled to Axolotl
![Mobile picker, scrolled to Axolotl](https://cdn.plotline.so/loma-images/loma-axolotl/picker-mobile.png)

### Hidden companion control
![Hidden companion control](https://cdn.plotline.so/loma-images/loma-axolotl/hidden-mobile.png)

## Notes
Generated by Loma at the user's request. Draft for human review; not merged.
