### PR TITLE
feat: on-demand task capture with save or start

### DIFF
--- a/api/task_routes.py
+++ b/api/task_routes.py
@@ -123,8 +123,14 @@ async def _run_task_headless(db, conversation_id: str, prompt: str,
         logger.warning("Headless task run failed for %s: %s", conversation_id, e)
 
 
+def _task_prompt_title(prompt: str) -> str | None:
+    """Immediate, bounded fallback while automatic naming runs."""
+    text = " ".join(prompt.split())
+    return (text[:77].rstrip() + "..." if len(text) > 80 else text) or None
+
+
 async def _auto_title_task(db, conversation_id: str, prompt: str):
-    """Generate a short LLM title for a quick-added draft (fire-and-forget).
+    """Generate a short LLM title for an immediately started task.
 
     Leaves title_edited unset so finish-time enrichment can still improve the
     title once the agent has actually run. Skips the write if the user has
@@ -135,7 +141,8 @@ async def _auto_title_task(db, conversation_id: str, prompt: str):
         title = await _generate_title_llm(prompt)
         if title and title != "Untitled conversation":
             await db.conversations.update_one(
-                {"conversation_id": conversation_id, "title": None},
+                {"conversation_id": conversation_id, "title_edited": {"$ne": True},
+                 "title": {"$in": [None, _task_prompt_title(prompt)]}},
                 {"$set": {"title": title}},
             )
     except Exception as e:
@@ -369,7 +376,7 @@ async def handle_create_task(request: web.Request) -> web.Response:
         "claude_account": None,
         "error": None,
         "deleted": False,
-        "title": title,
+        "title": title or _task_prompt_title(prompt),
         # Guard user-provided titles against finish-time LLM enrichment.
         "title_edited": bool(title),
         "task_status": "active" if start else "todo",
@@ -391,9 +398,9 @@ async def handle_create_task(request: web.Request) -> web.Response:
     }
     await db.conversations.insert_one(doc)
 
-    # Quick-added tasks (no explicit title) get an LLM title from the prompt.
-    # Empty drafts skip this — enrichment titles them after the first run.
-    if not title and prompt:
+    # Started tasks get an improved title asynchronously; scratch tasks keep
+    # the input-based name until they run, without paying for an LLM call.
+    if start and not title and prompt:
         asyncio.create_task(_auto_title_task(db, doc["conversation_id"], prompt))
 
     if start:

--- a/dashboard/src/app/tasks/page.tsx
+++ b/dashboard/src/app/tasks/page.tsx
@@ -67,6 +67,14 @@ export default function TasksPage() {
   const [taskDialogOpen, setTaskDialogOpen] = useState(false);
   const [editingTask, setEditingTask] = useState<Task | null>(null);
   const [newTaskLane, setNewTaskLane] = useState<string | undefined>(undefined);
+  const [composerOpen, setComposerOpen] = useState(false);
+  const [composerAnchor, setComposerAnchor] = useState<HTMLElement | null>(null);
+  const [creationNotice, setCreationNotice] = useState("");
+  useEffect(() => {
+    if (!creationNotice) return;
+    const timer = setTimeout(() => setCreationNotice(""), 5000);
+    return () => clearTimeout(timer);
+  }, [creationNotice]);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [addChatOpen, setAddChatOpen] = useState(false);
   // Desktop: clicking a non-draft card opens its chat in a side drawer so the
@@ -173,28 +181,11 @@ export default function TasksPage() {
     }
   };
 
-  const openNewTaskDrawer = async () => {
-    if (!board || busyRef.current) return;
-    busyRef.current = true;
-    setError(null);
-    try {
-      const todoLane = board.lanes.find(
-        (lane) => lane.id === "todo" || lane.name.trim().toLowerCase() === "todo",
-      ) || board.lanes[0];
-      // No title: the backend leaves title_edited false so the first run's
-      // enrichment can name the task. "New task" is a display-only fallback.
-      const { task } = await createTask({
-        prompt: "",
-        lane: todoLane?.id || "todo",
-      });
-      setBoard({ ...board, tasks: [task, ...board.tasks] });
-      setChatTask(task);
-      setChatDrawerOpen(true);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Could not create task");
-    } finally {
-      busyRef.current = false;
-    }
+  const openNewTaskComposer = (laneId?: string, anchor?: HTMLElement) => {
+    if (!board) return;
+    setNewTaskLane((current) => laneId || (board.lanes.some((lane) => lane.id === current) ? current : board.lanes[0]?.id));
+    setComposerAnchor(anchor ?? (document.activeElement as HTMLElement));
+    setComposerOpen(true);
   };
 
   const laneCounts: Record<string, number> = {};
@@ -253,7 +244,7 @@ export default function TasksPage() {
               </DropdownMenuContent>
             </DropdownMenu>
           )}
-          <Button size="sm" onClick={() => void openNewTaskDrawer()}>
+          <Button size="sm" onClick={(event) => openNewTaskComposer(undefined, event.currentTarget)} disabled={!board}>
             <RiAddLine className="h-4 w-4" />
             New task
           </Button>
@@ -340,7 +331,7 @@ export default function TasksPage() {
             onBoardChange={setBoard}
             onRefresh={refresh}
             onEditDraft={(task) => { setEditingTask(task); setTaskDialogOpen(true); }}
-            onAddTask={(laneId) => { setEditingTask(null); setNewTaskLane(laneId); setTaskDialogOpen(true); }}
+            onAddTask={openNewTaskComposer}
             onError={setError}
             includedTagIds={includedTagIds}
             excludedTagIds={excludedTagIds}
@@ -352,16 +343,12 @@ export default function TasksPage() {
               onBoardChange={setBoard}
               onRefresh={refresh}
               onEditDraft={(task) => { setChatTask(task); setChatDrawerOpen(true); }}
-              onAddTask={() => void openNewTaskDrawer()}
+              onAddTask={openNewTaskComposer}
               onOpenChat={(task) => { setChatTask(task); setChatDrawerOpen(true); }}
               onError={setError}
               includedTagIds={includedTagIds}
               excludedTagIds={excludedTagIds}
             />
-            {/* Desktop capture box — mirrors the PWA. Mobile renders its own
-                inside MobileTaskBoard, so only add it here. Fires the task
-                immediately (start: true); it lands in Working on refresh. */}
-            <QuickAddTask onAdded={refresh} />
           </>
         )
       ) : (
@@ -376,6 +363,19 @@ export default function TasksPage() {
         </div>
       )}
 
+      {creationNotice && <p role="status" className="text-xs text-muted-foreground">{creationNotice}</p>}
+      <QuickAddTask
+        open={composerOpen}
+        onOpenChange={setComposerOpen}
+        lanes={board?.lanes ?? []}
+        lane={newTaskLane ?? ""}
+        onLaneChange={setNewTaskLane}
+        anchor={composerAnchor}
+        onAdded={(started) => {
+          setCreationNotice(started ? "Task added and started" : "Task saved. Start it whenever you are ready.");
+          void refresh();
+        }}
+      />
       <TaskDialog
         open={taskDialogOpen}
         onOpenChange={setTaskDialogOpen}

--- a/dashboard/src/components/tasks/MobileTaskBoard.tsx
+++ b/dashboard/src/components/tasks/MobileTaskBoard.tsx
@@ -6,7 +6,6 @@ import { cn } from "@/lib/utils";
 import type { Task, TasksBoardResponse } from "@/lib/api";
 import { useTaskBoardActions } from "./useTaskBoardActions";
 import { MobileTaskCard } from "./MobileTaskCard";
-import { QuickAddTask } from "./QuickAddTask";
 
 interface MobileTaskBoardProps {
   board: TasksBoardResponse;
@@ -67,12 +66,6 @@ export function MobileTaskBoard({
   const tasks = tasksByColumn[selectedId] ?? [];
   const isLane = laneIds.includes(selectedId);
 
-  // Quick-added tasks fire immediately — show them where they land.
-  const handleQuickAdded = () => {
-    setSelected("working");
-    onRefresh();
-  };
-
   return (
     <div className="flex flex-1 flex-col gap-3 min-h-0">
       {/* Column chips */}
@@ -105,6 +98,20 @@ export function MobileTaskBoard({
         })}
       </div>
 
+      <div className="flex shrink-0 items-center justify-between px-1">
+        <h2 className="text-sm font-medium">{columns.find((column) => column.id === selectedId)?.name}</h2>
+        {isLane && (
+          <button
+            onClick={() => onAddTask(selectedId)}
+            aria-label={`Add task to ${columns.find((column) => column.id === selectedId)?.name}`}
+            className="flex items-center gap-1 rounded-md px-2 py-2 text-xs text-muted-foreground/70 active:bg-muted"
+          >
+            <RiAddLine className="h-3.5 w-3.5" />
+            Add task
+          </button>
+        )}
+      </div>
+
       {/* Selected column */}
       <div className="flex flex-1 flex-col gap-1.5 overflow-y-auto pb-4">
         {tasks.map((task) => (
@@ -127,18 +134,7 @@ export function MobileTaskBoard({
         {tasks.length === 0 && (
           <p className="py-6 text-center text-xs text-muted-foreground">Nothing here</p>
         )}
-        {isLane && (
-          <button
-            onClick={() => onAddTask(selectedId)}
-            className="flex items-center gap-1 rounded-md px-2 py-2 text-xs text-muted-foreground/70 active:bg-muted"
-          >
-            <RiAddLine className="h-3.5 w-3.5" />
-            Task
-          </button>
-        )}
       </div>
-
-      <QuickAddTask onAdded={handleQuickAdded} />
     </div>
   );
 }

--- a/dashboard/src/components/tasks/QuickAddTask.tsx
+++ b/dashboard/src/components/tasks/QuickAddTask.tsx
@@ -1,165 +1,192 @@
 "use client";
 
-import { useRef, useState } from "react";
-import { RiSendPlaneLine, RiLoader4Line, RiAttachmentLine } from "@remixicon/react";
+import { useId, useRef, useState } from "react";
+import { RiCloseLine, RiLoader4Line, RiAttachmentLine } from "@remixicon/react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
-import { createTask, type ChatFile } from "@/lib/api";
+import { Dialog, DialogContent, DialogTitle, DialogDescription } from "@/components/ui/dialog";
+import { Popover, PopoverAnchor, PopoverContent } from "@/components/ui/popover";
+import { createTask, type BoardLane, type ChatFile } from "@/lib/api";
 import { filesToChatFiles } from "@/lib/chatFiles";
 import { useAgentModels } from "@/hooks/useAgentModels";
 import { useToolsPicker } from "@/hooks/useToolsPicker";
+import { useIsMobile } from "@/hooks/useIsMobile";
 import { ModelPicker } from "@/components/composer/ModelPicker";
 import { ToolsPicker } from "@/components/composer/ToolsPicker";
 import { PendingFilesStrip } from "@/components/composer/PendingFilesStrip";
 import { DictationButton, appendDictation } from "@/components/composer/DictationButton";
-import { cn } from "@/lib/utils";
 
 interface QuickAddTaskProps {
-  onAdded: () => void;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  lanes: BoardLane[];
+  lane: string;
+  onLaneChange: (lane: string) => void;
+  anchor: HTMLElement | null;
+  onAdded: (started: boolean) => void;
 }
 
-/** Bottom-pinned capture box on the tasks board (mobile and desktop) — the
- * same composer controls as chat (model picker, attachments). Typing here
- * fires the task immediately: the agent starts running in the background
- * (survives closing the app) and the backend titles the task from the prompt
- * with an LLM. */
-export function QuickAddTask({ onAdded }: QuickAddTaskProps) {
+/** One on-demand capture flow for list buttons and the board header.
+ * Keep this component mounted: dismissing preserves text and attachments,
+ * but never creates a conversation until the user explicitly submits. */
+export function QuickAddTask({ open, onOpenChange, lanes, lane, onLaneChange, anchor, onAdded }: QuickAddTaskProps) {
+  const isMobile = useIsMobile();
+  const id = useId();
   const [value, setValue] = useState("");
   const [files, setFiles] = useState<ChatFile[]>([]);
   const [busy, setBusy] = useState(false);
+  const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const swipeStartRef = useRef<{ x: number; y: number } | null>(null);
+  const submittingRef = useRef(false);
+  const uploadsRef = useRef(0);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
   const { models, selectedModel, selectModel, loadState } = useAgentModels();
   const {
-    tools: availableTools,
-    skills: availableSkills,
-    selection: toolsSelection,
-    loadState: toolsLoadState,
-    loadCatalog: loadToolsCatalog,
-    toggleTool,
-    toggleSkill,
-    enableAll: enableAllTools,
-    isAllEnabled: allToolsEnabled,
-    disabledCount: toolsDisabledCount,
-    toolConfig,
-    isAlwaysEnabled,
+    tools: availableTools, skills: availableSkills, selection: toolsSelection,
+    loadState: toolsLoadState, loadCatalog: loadToolsCatalog, toggleTool, toggleSkill,
+    enableAll: enableAllTools, isAllEnabled: allToolsEnabled,
+    disabledCount: toolsDisabledCount, toolConfig, isAlwaysEnabled,
   } = useToolsPicker();
+  const selectedLane = lanes.some((item) => item.id === lane) ? lane : lanes[0]?.id ?? "";
+  const disabled = busy || uploading || !selectedLane || (!value.trim() && !files.length);
 
+  const changeOpen = (next: boolean) => {
+    if (!submittingRef.current) onOpenChange(next);
+  };
   const addFiles = async (fileList: FileList | File[]) => {
-    const { files: chatFiles, rejected } = await filesToChatFiles(fileList);
-    if (chatFiles.length) setFiles((prev) => [...prev, ...chatFiles]);
-    if (rejected.length) console.warn("Unsupported files skipped:", rejected);
+    if (submittingRef.current) return;
+    uploadsRef.current += 1;
+    setUploading(true);
+    try {
+      const { files: chatFiles, rejected } = await filesToChatFiles(fileList);
+      if (chatFiles.length) setFiles((prev) => [...prev, ...chatFiles]);
+      if (rejected.length) setError("Some files could not be attached. Please check the attachments before submitting.");
+    } catch {
+      setError("Could not read the attachment. Please try again.");
+    } finally {
+      uploadsRef.current -= 1;
+      setUploading(uploadsRef.current > 0);
+    }
   };
 
-  const submit = async () => {
-    const prompt = value.trim();
-    if ((!prompt && files.length === 0) || busy) return;
+  const submit = async (start: boolean) => {
+    if (submittingRef.current || uploadsRef.current || disabled) return;
+    submittingRef.current = true;
     setBusy(true);
     setError(null);
     try {
       await createTask({
-        prompt: prompt || files.map((f) => f.name).join(", "),
+        prompt: value.trim() || files.map((file) => file.name).join(", "),
+        lane: selectedLane,
         model: selectedModel || undefined,
-        files: files.length > 0 ? files : undefined,
-        start: true,
+        files: files.length ? files : undefined,
+        start,
         tool_config: toolConfig,
       });
       setValue("");
       setFiles([]);
-      onAdded();
+      onOpenChange(false);
+      onAdded(start);
     } catch (e) {
-      // Keep the text so nothing is lost; the user can retry.
       setError(e instanceof Error ? e.message : "Failed to add task");
     } finally {
+      submittingRef.current = false;
       setBusy(false);
     }
   };
 
-  return (
-    <div className="shrink-0 border-t border-border bg-background px-3 pt-2 pb-2">
-      <input
-        ref={fileInputRef}
-        type="file"
-        multiple
-        className="hidden"
-        onChange={(e) => {
-          if (e.target.files?.length) {
-            void addFiles(e.target.files);
-            e.target.value = "";
-          }
+  const content = (
+    <div className="flex min-h-0 flex-col gap-3">
+      <div
+        className="pr-8"
+        onTouchStart={(event) => {
+          const touch = event.touches[0];
+          if (isMobile && touch) swipeStartRef.current = { x: touch.clientX, y: touch.clientY };
         }}
-      />
-      {/* Centered + width-capped so the composer stays readable on the wide
-          desktop board; on a phone max-w-3xl is simply full width. */}
-      <div className="mx-auto w-full max-w-3xl">
-      {error && <p className="mb-1 text-xs text-destructive">{error}</p>}
-      <PendingFilesStrip files={files} onRemove={(i) => setFiles((prev) => prev.filter((_, idx) => idx !== i))} />
-      <div className="flex flex-col bg-card border border-border rounded-xl focus-within:border-input transition-colors">
+        onTouchCancel={() => { swipeStartRef.current = null; }}
+        onTouchEnd={(event) => {
+          const touch = event.changedTouches[0];
+          const start = swipeStartRef.current;
+          swipeStartRef.current = null;
+          if (isMobile && touch && start && touch.clientY - start.y > 60 && Math.abs(touch.clientX - start.x) < 40) changeOpen(false);
+        }}
+      >
+        {isMobile ? <DialogTitle>New task</DialogTitle> : <h2 id={`${id}-title`} className="font-medium">New task</h2>}
+        {isMobile
+          ? <DialogDescription className="mt-1">Save an idea or start working with Loma.</DialogDescription>
+          : <p className="mt-1 text-xs text-muted-foreground">Save an idea or start working with Loma.</p>}
+      </div>
+      <Button type="button" variant="ghost" size="icon-sm" className="absolute right-2 top-2" aria-label="Close task composer" disabled={busy} onClick={() => changeOpen(false)}>
+        <RiCloseLine size={18} />
+      </Button>
+      {error && <p role="alert" className="text-xs text-destructive">{error}</p>}
+      <fieldset disabled={busy} className="flex min-h-0 flex-col gap-3 disabled:opacity-70">
+        <input ref={fileInputRef} type="file" multiple className="hidden" onChange={(e) => {
+          if (e.target.files?.length) { void addFiles(e.target.files); e.target.value = ""; }
+        }} />
         <Textarea
+          ref={inputRef}
+          aria-label="Task details"
           value={value}
           onChange={(e) => setValue(e.target.value)}
           onKeyDown={(e) => {
-            if (e.key === "Enter" && !e.shiftKey) {
+            if (e.key === "Enter" && !e.nativeEvent.isComposing && (e.metaKey || e.ctrlKey)) {
               e.preventDefault();
-              void submit();
+              void submit(e.shiftKey);
             }
           }}
           onPaste={(e) => {
             const pasted = Array.from(e.clipboardData?.files ?? []);
-            if (pasted.length) {
-              e.preventDefault();
-              void addFiles(pasted);
-            }
+            if (pasted.length) { e.preventDefault(); void addFiles(pasted); }
           }}
           placeholder="What do you need done?"
-          rows={1}
-          className="w-full bg-transparent px-3 pt-3 pb-1.5 text-[13px] text-foreground placeholder-muted-foreground focus:outline-none resize-none overflow-hidden border-0 focus-visible:ring-0 focus-visible:border-transparent rounded-none min-h-0"
-          style={{ maxHeight: "120px" }}
+          rows={4}
+          className="max-h-48 min-h-24 resize-none overflow-y-auto max-md:text-base"
         />
-        <div className="flex items-center justify-between gap-2 px-2 pb-2 max-md:flex-wrap">
-          <div className="flex min-w-0 items-center gap-1 max-md:w-full max-md:flex-wrap">
-            <ModelPicker
-              models={models}
-              selectedModel={selectedModel}
-              onSelect={selectModel}
-              loadState={loadState}
-            />
+        <PendingFilesStrip files={files} onRemove={(i) => setFiles((prev) => prev.filter((_, idx) => idx !== i))} />
+        <div className="flex items-center gap-2">
+          <label htmlFor={`${id}-lane`} className="text-xs text-muted-foreground">List</label>
+          <select id={`${id}-lane`} value={selectedLane} onChange={(e) => onLaneChange(e.target.value)} className="h-9 min-w-0 flex-1 rounded-md border border-input bg-background px-2 text-sm">
+            {lanes.map((item) => <option key={item.id} value={item.id}>{item.name}</option>)}
+          </select>
+          <DictationButton disabled={busy} onText={(text) => setValue((prev) => appendDictation(prev, text))} />
+          <Button type="button" variant="ghost" size="icon-sm" onClick={() => fileInputRef.current?.click()} aria-label="Attach files">
+            <RiAttachmentLine size={16} />
+          </Button>
+        </div>
+        <details className="text-xs text-muted-foreground">
+          <summary className="w-fit cursor-pointer py-1">Model & tools</summary>
+          <div className="mt-2 flex flex-wrap items-center gap-1">
+            <ModelPicker models={models} selectedModel={selectedModel} onSelect={selectModel} loadState={loadState} />
             <ToolsPicker tools={availableTools} skills={availableSkills} selection={toolsSelection} onToggleTool={toggleTool} onToggleSkill={toggleSkill} onEnableAll={enableAllTools} onOpen={loadToolsCatalog} isAllEnabled={allToolsEnabled} disabledCount={toolsDisabledCount} loadState={toolsLoadState} isAlwaysEnabled={isAlwaysEnabled} />
           </div>
-          <div className="ml-auto flex items-center gap-1 max-md:gap-2 shrink-0">
-            <DictationButton
-              onText={(t) => setValue((prev) => appendDictation(prev, t))}
-              mobileProminent
-            />
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              onClick={() => fileInputRef.current?.click()}
-              title="Attach files"
-              className="text-muted-foreground hover:text-foreground max-md:size-11 max-md:rounded-xl"
-            >
-              <RiAttachmentLine size={16} />
-            </Button>
-            <Button
-              type="button"
-              size="icon-sm"
-              onClick={() => void submit()}
-              disabled={(!value.trim() && files.length === 0) || busy}
-              aria-label="Add task"
-              className={cn(
-                "bg-primary text-primary-foreground hover:bg-accent-200 hover:text-accent-on disabled:opacity-40 disabled:hover:bg-primary disabled:hover:text-primary-foreground rounded-lg press-scale max-md:size-12 max-md:rounded-xl",
-                !value.trim() && files.length === 0 && "max-md:hidden",
-              )}
-            >
-              {busy
-                ? <RiLoader4Line size={16} className="animate-spin" />
-                : <RiSendPlaneLine size={16} />}
-            </Button>
-          </div>
-        </div>
+        </details>
+      </fieldset>
+      <div className="sticky bottom-0 flex gap-2 border-t border-border bg-card pt-3">
+        <Button variant="outline" className="flex-1 max-md:h-11" disabled={disabled} onClick={() => void submit(false)}>Add task</Button>
+        <Button className="flex-1 max-md:h-11" disabled={disabled} onClick={() => void submit(true)}>
+          {busy && <RiLoader4Line size={16} className="animate-spin" />} Add & start
+        </Button>
       </div>
-      </div>
+      <p className="text-xs text-muted-foreground">{uploading ? "Reading attachments..." : "Add task saves without running Loma."}</p>
     </div>
+  );
+
+  if (isMobile) return (
+    <Dialog open={open} onOpenChange={changeOpen}>
+      <DialogContent showCloseButton={false} className="max-md:top-auto max-md:bottom-[calc(100dvh-var(--app-h,100dvh))] max-md:max-w-full max-md:rounded-b-none max-md:pb-[max(1rem,env(safe-area-inset-bottom))]" onOpenAutoFocus={(e) => { e.preventDefault(); inputRef.current?.focus(); }}>
+        {content}
+      </DialogContent>
+    </Dialog>
+  );
+  return (
+    <Popover open={open} onOpenChange={changeOpen} modal>
+      <PopoverAnchor virtualRef={{ current: { getBoundingClientRect: () => anchor?.getBoundingClientRect() ?? new DOMRect(100, 100, 0, 0) } }} />
+      <PopoverContent align="start" side="bottom" collisionPadding={16} aria-labelledby={`${id}-title`} className="relative w-[420px] max-w-[calc(100vw-2rem)] max-h-[var(--radix-popover-content-available-height)] overflow-y-auto bg-card p-4" onOpenAutoFocus={(e) => { e.preventDefault(); inputRef.current?.focus(); }} onCloseAutoFocus={(e) => { e.preventDefault(); anchor?.focus(); }}>
+        {content}
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/dashboard/src/components/tasks/TaskBoard.tsx
+++ b/dashboard/src/components/tasks/TaskBoard.tsx
@@ -26,8 +26,8 @@ interface TaskBoardProps {
   onBoardChange: (board: TasksBoardResponse) => void;
   onRefresh: () => void;
   onEditDraft: (task: Task) => void;
-  /** Create a new task and open it in the side drawer. */
-  onAddTask: (laneId: string) => void;
+  /** Open capture in the selected list without creating a blank task. */
+  onAddTask: (laneId: string, anchor?: HTMLElement) => void;
   /** Open a non-draft task's chat in the side drawer instead of a new tab. */
   onOpenChat?: (task: Task) => void;
   onError: (message: string | null) => void;
@@ -124,7 +124,7 @@ export function TaskBoard({ board, onBoardChange, onRefresh, onEditDraft, onAddT
                 ? canMove(activeTask, activeTask.column, column.id, laneIds)
                 : undefined
             }
-            onAddTask={laneIds.includes(column.id) ? () => onAddTask(column.id) : undefined}
+            onAddTask={laneIds.includes(column.id) ? (anchor) => onAddTask(column.id, anchor) : undefined}
           >
             {(tasksByColumn[column.id] ?? []).map((task) => (
               <TaskCard

--- a/dashboard/src/components/tasks/TaskColumn.tsx
+++ b/dashboard/src/components/tasks/TaskColumn.tsx
@@ -13,7 +13,7 @@ interface TaskColumnProps {
   /** Whether the current drag can drop here (undefined = no drag active). */
   droppable?: boolean;
   /** Staging lanes only: create a task directly in this lane. */
-  onAddTask?: () => void;
+  onAddTask?: (anchor: HTMLElement) => void;
   children: React.ReactNode;
 }
 
@@ -30,6 +30,18 @@ export function TaskColumn({ id, name, tasks, droppable, onAddTask, children }: 
           {name}
         </span>
         <span className="text-[11px] tabular-nums text-muted-foreground/80">{tasks.length}</span>
+        {onAddTask && (
+          <button
+            onClick={(event) => onAddTask(event.currentTarget)}
+            aria-label={`Add task to ${name}`}
+            className={cn(
+              "ml-auto flex items-center gap-1 rounded-md px-2 py-1.5 text-xs",
+              "text-muted-foreground/70 hover:bg-muted hover:text-foreground",
+            )}
+          >
+            <RiAddLine className="h-3.5 w-3.5" />
+          </button>
+        )}
       </div>
       <SortableContext
         items={tasks.map((t) => t.conversation_id)}
@@ -44,18 +56,6 @@ export function TaskColumn({ id, name, tasks, droppable, onAddTask, children }: 
           )}
         >
           {children}
-          {onAddTask && (
-            <button
-              onClick={onAddTask}
-              className={cn(
-                "flex items-center gap-1 rounded-md px-2 py-1.5 text-xs",
-                "text-muted-foreground/70 hover:bg-muted hover:text-foreground",
-              )}
-            >
-              <RiAddLine className="h-3.5 w-3.5" />
-              Task
-            </button>
-          )}
         </div>
       </SortableContext>
     </div>

--- a/tests/browser/task-capture.cjs
+++ b/tests/browser/task-capture.cjs
@@ -1,0 +1,153 @@
+/** Run against an isolated local stack after setup-token login.
+ * NODE_PATH=<playwright install>/node_modules LOMA_TEST_STORAGE=<storage-state.json>
+ *   node tests/browser/task-capture.cjs
+ * This creates test tasks and starts two harmless, tool-free agent prompts.
+ */
+const { chromium } = require('playwright');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const baseURL = process.env.LOMA_TEST_URL || 'http://localhost:13001';
+assert.equal(new URL(baseURL).hostname, 'localhost', 'Use only the isolated local test stack');
+const output = process.env.LOMA_TEST_OUTPUT || '/tmp/loma-task-capture-screenshots';
+fs.mkdirSync(output, { recursive: true });
+(async () => {
+  const browser = await chromium.launch();
+  try {
+    for (const mobile of (process.env.LOMA_MOBILE_ONLY ? [true] : [false, true])) {
+      const label = mobile ? 'mobile' : 'desktop';
+      const context = await browser.newContext({
+        baseURL, storageState: process.env.LOMA_TEST_STORAGE,
+        viewport: mobile ? { width: 390, height: 844 } : { width: 1440, height: 1000 },
+        isMobile: mobile, hasTouch: mobile,
+      });
+      await context.addInitScript(() => localStorage.setItem('dashboard-chat-selected-model', 'codex/gpt-5.6-sol'));
+      const page = await context.newPage();
+      page.setDefaultTimeout(20000);
+      const errors = [];
+      page.on('pageerror', e => errors.push(e.message));
+      const settings = await context.request.put('/api/tasks/board-settings', { data: {
+        lanes: [{ id: 'todo', name: 'Todo' }, { id: 'ideas', name: 'Ideas' }], prompt: '',
+      }});
+      assert.equal(settings.status(), 200);
+      await page.goto('/tasks');
+      const open = page.getByRole('button', { name: 'New task', exact: true });
+      await open.waitFor();
+      await page.waitForTimeout(1500);
+      const board = async () => (await (await context.request.get('/api/tasks')).json());
+      const initial = (await board()).tasks.length;
+      assert.equal(await page.getByRole('textbox', {name:'Task details'}).count(), 0);
+      await open.click();
+      await page.getByRole('button', {name:'Close task composer'}).click();
+      assert.equal((await board()).tasks.length, initial, 'Opening/closing must not create a blank card');
+
+      if (mobile) await page.getByRole('button', {name:/^Ideas/}).click();
+      await page.getByRole('button', {name:'Add task to Ideas'}).click();
+      const details = page.getByRole('textbox', {name:'Task details'});
+      await details.waitFor();
+      assert.equal(await page.getByLabel('List', {exact:true}).inputValue(), 'ideas');
+      const prompt = `Investigate dashboard loading times (${label} ${Date.now().toString(36).slice(-4)})`;
+      await details.fill('Detailed task notes '.repeat(400));
+      await details.press('Enter');
+      assert.equal((await board()).tasks.length, initial, 'Enter inserts a newline rather than starting a task');
+      const actionBounds = await page.getByRole('button', {name:'Add & start',exact:true}).boundingBox();
+      assert.ok(actionBounds && actionBounds.y + actionBounds.height <= (mobile ? 844 : 1000), 'Large text must not hide actions');
+      await details.fill(prompt);
+      await page.getByRole('button', {name:'Close task composer'}).click();
+      assert.equal((await board()).tasks.length, initial);
+      await page.getByRole('button', {name:'Add task to Ideas'}).click();
+      assert.equal(await details.inputValue(), prompt, 'Dismissal preserves unsaved text');
+      if (mobile) {
+        const header = page.getByRole('heading', {name:'New task', exact:true}).locator('..');
+        await header.evaluate(element => {
+          const start = new Touch({identifier:0,target:element,clientX:100,clientY:200});
+          const end = new Touch({identifier:0,target:element,clientX:100,clientY:300});
+          element.dispatchEvent(new TouchEvent('touchstart', {bubbles:true,touches:[start],targetTouches:[start],changedTouches:[start]}));
+          element.dispatchEvent(new TouchEvent('touchend', {bubbles:true,changedTouches:[end]}));
+        });
+        await details.waitFor({state:'hidden'});
+        await open.click();
+        assert.equal(await details.inputValue(), prompt, 'Swipe dismissal preserves text');
+        assert.equal(await page.getByLabel('List', {exact:true}).inputValue(), 'ideas', 'Header reopening preserves draft list');
+      }
+
+      await page.locator('input[type=file]').setInputFiles({ name: 'task-notes.txt', mimeType: 'text/plain', buffer: Buffer.from('Check performance without changing production.') });
+      await page.getByText('task-notes.txt', {exact:true}).waitFor();
+      const add = page.getByRole('button', {name:'Add task', exact:true});
+      await page.waitForFunction(() => ![...document.querySelectorAll('button')].find(b=>b.textContent==='Add task')?.disabled);
+      await page.screenshot({path:`${output}/${label}-composer.png`});
+      // Simulated transient failure must retain text and files for retry.
+      await page.route('**/api/tasks', async route => {
+        if (route.request().method() !== 'POST') return route.continue();
+        await route.fulfill({status:503, contentType:'application/json', body:JSON.stringify({error:'Temporary test outage'})});
+      });
+      await add.click();
+      await page.getByRole('alert').waitFor();
+      assert.equal(await details.inputValue(), prompt);
+      assert.equal((await board()).tasks.length, initial);
+      await page.unroute('**/api/tasks');
+      let postCount = 0;
+      await page.route('**/api/tasks', async route => {
+        if (route.request().method() !== 'POST') return route.continue();
+        postCount++;
+        const response = await route.fetch();
+        await new Promise(resolve => setTimeout(resolve, 300));
+        await route.fulfill({response});
+      });
+      const savedResponse = page.waitForResponse(r=>r.url().endsWith('/api/tasks') && r.request().method()==='POST');
+      await add.evaluate(button => { button.click(); button.click(); });
+      const saved = await (await savedResponse).json();
+      assert.equal(saved.task.title, prompt);
+      assert.equal(postCount, 1, 'Repeated clicks must create only one task');
+      await page.unroute('**/api/tasks');
+      assert.equal(saved.task.task_lane, 'ideas');
+      assert.equal(saved.task.task_status, 'todo');
+      assert.equal(saved.task.started_at, null);
+      await details.waitFor({state:'hidden'});
+      assert.equal(new URL(page.url()).pathname, '/tasks');
+      await page.getByText(prompt, {exact:true}).waitFor();
+      await page.screenshot({path:`${output}/${label}-board.png`});
+      // Inspect the persisted conversation: full prompt and staged attachment.
+      const conversationResponse = await context.request.get(`/api/conversations/${saved.task.conversation_id}`);
+      assert.equal(conversationResponse.status(), 200);
+      const conversation = await conversationResponse.json();
+      const doc = conversation.conversation || conversation;
+      assert.equal(doc.prompt, prompt);
+      assert.equal(doc.draft_files[0].name, 'task-notes.txt');
+
+      // Existing task mode must have no new-task composer underneath it.
+      await page.getByText(prompt, {exact:true}).click();
+      assert.equal(await page.getByRole('textbox', {name:'Task details'}).count(), 0);
+      await page.goto('/tasks');
+      await open.waitFor();
+      await page.waitForTimeout(500);
+      await open.click();
+      await details.fill('Reply exactly READY. Do not use tools. This is a local task creation smoke test.');
+      await page.locator('summary').filter({hasText:'Model & tools'}).click();
+      // Explicitly ensure runs use the current user's Codex connection.
+      await page.getByTitle('Choose model', {exact:true}).waitFor();
+      assert.match(await page.getByTitle('Choose model', {exact:true}).innerText(), /gpt-5.6-sol/i);
+      await page.screenshot({path:`${output}/${label}-start.png`});
+      if (mobile) {
+        // Emulate a reduced visual viewport while the keyboard is open.
+        await page.evaluate(()=>document.documentElement.style.setProperty('--app-h','510px'));
+        await page.waitForTimeout(250);
+        await page.screenshot({path:`${output}/mobile-keyboard.png`});
+        const box = await page.getByRole('button',{name:'Add & start',exact:true}).boundingBox();
+        assert.ok(box && box.y >= 0 && box.y + box.height <= 510, 'Actions stay above the keyboard');
+        await page.screenshot({path:`${output}/mobile-keyboard.png`});
+        await page.evaluate(()=>document.documentElement.style.removeProperty('--app-h'));
+      }
+      const startedResponse = page.waitForResponse(r=>r.url().endsWith('/api/tasks') && r.request().method()==='POST');
+      await page.getByRole('button',{name:'Add & start',exact:true}).click();
+      const started = await (await startedResponse).json();
+      assert.equal(started.task.task_status, 'active');
+      assert.ok(started.task.title && started.task.title !== 'New task');
+      assert.ok(started.task.started_at);
+      await details.waitFor({state:'hidden'});
+      assert.equal(new URL(page.url()).pathname, '/tasks');
+      assert.deepEqual(errors, []);
+      console.log(`${label}: capture, lane, dismiss, attachments, failure/retry, save, clean board, existing task, start and naming passed`);
+      await context.close();
+    }
+  } finally { await browser.close(); }
+})().catch(error=>{console.error(error);process.exit(1)});

--- a/tests/test_task_create.py
+++ b/tests/test_task_create.py
@@ -15,10 +15,11 @@ class FakeRequest:
 
 
 def _setup(monkeypatch):
-    conversations = SimpleNamespace(insert_one=AsyncMock())
+    conversations = SimpleNamespace(insert_one=AsyncMock(), update_one=AsyncMock())
     users = SimpleNamespace(find_one=AsyncMock(return_value={
         "task_board": {
-            "lanes": [{"id": "todo", "name": "Todo", "order": 0}],
+            "lanes": [{"id": "todo", "name": "Todo", "order": 0},
+                      {"id": "ideas", "name": "Ideas", "order": 1}],
             "tags": [],
         },
     }))
@@ -48,7 +49,7 @@ async def test_create_empty_draft_leaves_title_open_for_auto_naming(monkeypatch)
 
 
 @pytest.mark.asyncio
-async def test_quick_add_with_prompt_schedules_auto_title(monkeypatch):
+async def test_scratch_task_keeps_input_name_without_running(monkeypatch):
     conversations, scheduled = _setup(monkeypatch)
 
     response = await task_routes.handle_create_task(
@@ -56,11 +57,11 @@ async def test_quick_add_with_prompt_schedules_auto_title(monkeypatch):
     inserted = conversations.insert_one.await_args.args[0]
 
     assert response.status == 201
-    assert inserted["title"] is None
+    assert inserted["title"] == "Investigate the flaky deploy"
     assert inserted["title_edited"] is False
-    assert scheduled.called
-    for call in scheduled.call_args_list:
-        call.args[0].close()  # discard un-run coroutines from the mock
+    assert inserted["started_at"] is None
+    assert inserted["messages"] == []
+    scheduled.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -139,3 +140,75 @@ async def test_build_board_context_uses_default_setting_and_owner_doc(monkeypatc
     )
     users.find_one.assert_awaited_once_with(
         {"email": "owner@example.com"}, {"task_board": 1, "name": 1, "email": 1})
+
+
+@pytest.mark.asyncio
+async def test_scratch_respects_lane_and_preserves_details_and_files(monkeypatch):
+    conversations, scheduled = _setup(monkeypatch)
+    prompt = "Check loading times " * 20
+    files = [{"name": "notes.txt", "data": "dGVzdA==", "type": "text/plain"}]
+    response = await task_routes.handle_create_task(FakeRequest({
+        "prompt": prompt, "lane": "ideas", "start": False, "files": files,
+        "tool_config": {"enabled_tools": []},
+    }))
+    doc = conversations.insert_one.await_args.args[0]
+    assert response.status == 201
+    assert doc["task_lane"] == "ideas"
+    assert doc["task_status"] == "todo"
+    assert doc["prompt"] == prompt.strip()
+    assert len(doc["title"]) <= 80
+    assert doc["draft_files"] == files
+    assert doc["tool_config"] == {"enabled_tools": []}
+    scheduled.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_add_and_start_has_immediate_name_and_schedules_both_jobs(monkeypatch):
+    conversations, scheduled = _setup(monkeypatch)
+    response = await task_routes.handle_create_task(FakeRequest({
+        "prompt": "Investigate\n  slow dashboard", "lane": "ideas", "start": True,
+    }))
+    doc = conversations.insert_one.await_args.args[0]
+    assert response.status == 201
+    assert doc["title"] == "Investigate slow dashboard"
+    assert doc["title_edited"] is False
+    assert doc["started_at"] is not None
+    assert doc["task_status"] == "active"
+    assert doc["task_lane"] == "ideas"
+    assert scheduled.call_count == 2
+    jobs = [call.args[0] for call in scheduled.call_args_list]
+    assert {job.cr_code.co_name for job in jobs} == {"_auto_title_task", "_run_task_headless"}
+    for job in jobs:
+        job.close()
+
+
+@pytest.mark.asyncio
+async def test_unknown_lane_does_not_create_task(monkeypatch):
+    conversations, scheduled = _setup(monkeypatch)
+    response = await task_routes.handle_create_task(FakeRequest({"prompt": "Test", "lane": "missing"}))
+    assert response.status == 400
+    conversations.insert_one.assert_not_called()
+    scheduled.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_auto_naming_is_atomic_and_protects_manual_and_enriched_titles(monkeypatch):
+    from api import routes
+    generate = AsyncMock(return_value="Investigate slowness")
+    monkeypatch.setattr(routes, "_generate_title_llm", generate)
+    conversations = SimpleNamespace(update_one=AsyncMock())
+    await task_routes._auto_title_task(SimpleNamespace(conversations=conversations), "test-id", "Check slow dashboard")
+    conversations.update_one.assert_awaited_once_with(
+        {"conversation_id": "test-id", "title_edited": {"$ne": True},
+         "title": {"$in": [None, "Check slow dashboard"]}},
+        {"$set": {"title": "Investigate slowness"}},
+    )
+
+
+@pytest.mark.asyncio
+async def test_failed_naming_leaves_fallback_untouched(monkeypatch):
+    from api import routes
+    monkeypatch.setattr(routes, "_generate_title_llm", AsyncMock(side_effect=RuntimeError("offline")))
+    conversations = SimpleNamespace(update_one=AsyncMock())
+    await task_routes._auto_title_task(SimpleNamespace(conversations=conversations), "test-id", "Keep this name")
+    conversations.update_one.assert_not_called()


### PR DESCRIPTION
## Summary
Replaces the always-visible task input with one on-demand composer on desktop and mobile.

- List-header **+** opens capture with that list selected; **New task** opens the same composer.
- **Add task** saves an unstarted scratch task. **Add & start** delegates immediately in the background without navigating away.
- Desktop uses an anchored popover; mobile uses a dismissible bottom sheet with keyboard-aware positioning.
- Closing, swiping down on the mobile header, or pressing Escape creates no blank task. Text and attachments survive dismissal while the board remains mounted.
- Retains attachments, dictation, model and tools selection. Model/tools are tucked under options.
- Tasks receive an immediate input-based name. Started tasks improve it asynchronously, with atomic protection against overwriting manual renames or newer generated titles.
- Removes both permanent bottom input bars. Existing task reply/edit flows remain intact.

## Validation
- `python -m pytest tests/test_task*.py -q`: **16 passed**.
- `tsc --noEmit`: passed.
- ESLint on all changed TypeScript/TSX files: passed.
- `git diff --check`: passed.
- Booted the actual backend and dashboard on isolated local ports and a throwaway Mongo database; signed in through the first-admin setup flow.
- Playwright checks at **1440 x 1000** and **390 x 844**: list preselection, no blank cards, retained drafts, attachment persistence, failure/retry, repeated-click protection, long text, plain Enter not submitting, scratch save without execution, unobstructed board/existing task, and live background starts with immediate names.
- Mobile also covers swipe dismissal, preserved list on reopening, and a simulated **510px visual viewport** for keyboard clearance. Physical iOS/Android keyboard and microphone behavior were not hardware-tested.
- Live smoke tasks completed through the current user's Codex connection; generated titles were observed after execution.
- Reproducible browser checks: `tests/browser/task-capture.cjs` (requires Playwright and local authenticated storage state; usage in file header).

## Screenshots
Synthetic test tasks only.

### Desktop composer
![Desktop composer](https://cdn.plotline.so/loma-images/ed09b4db650c4f3d8f61961da45a39dc.png)

### Clean desktop board
![Desktop board without permanent input](https://cdn.plotline.so/loma-images/5f92061693484c24b227e6240afc6952.png)

### Mobile composer
<img src="https://cdn.plotline.so/loma-images/200d4ebcc608405886d533dff417772a.png" width="390" alt="Mobile task composer" />

### Mobile keyboard-height simulation
<img src="https://cdn.plotline.so/loma-images/b4d5328e4d3d4008baf0c0cad88a5b2b.png" width="390" alt="Actions remain above the simulated keyboard" />

## Review notes
No new runtime dependencies or schema migration. Existing empty-draft API compatibility is retained; the board no longer calls it on open. Draft persistence across page reloads is not added.

Created by Loma at Adarsh's request. Please review before merging.
