### PR TITLE
fix: retired pet ids silently rendered as Tabby - migrate to successor pets

### DIFF
--- a/api/governance_routes.py
+++ b/api/governance_routes.py
@@ -103,6 +103,17 @@ async def handle_get_me(request: web.Request) -> web.Response:
             email, user["system_role"], user["status"],
         )
 
+    # Migrate retired pet ids to their successor so the saved companion still renders
+    # as the pet the user actually chose (e.g. "calico" was replaced by "cat").
+    pet_pref = user.get("pet_preference")
+    if isinstance(pet_pref, dict) and pet_pref.get("pet_id") in LEGACY_PET_MAP:
+        pet_pref = {**pet_pref, "pet_id": LEGACY_PET_MAP[pet_pref["pet_id"]]}
+        user["pet_preference"] = pet_pref
+        await db.users.update_one(
+            {"email": email},
+            {"$set": {"pet_preference": pet_pref, "updated_at": datetime.now(timezone.utc)}},
+        )
+
     serialized_user = _serialize(user)
     # Legacy users created before the approval flow are treated as active.
     serialized_user.setdefault("status", "active")
@@ -142,6 +153,10 @@ async def handle_update_my_theme(request: web.Request) -> web.Response:
 
 VALID_PETS = ("tabby", "tuxedo", "cat", "doggo", "corgi", "golden", "dachshund", "rabbit", "hamster", "parrot",
               "croc", "lion", "duck", "snake", "dino", "dragon", "llama", "koala")
+
+# Pets removed from the catalog map to their closest successor so a user who picked
+# one keeps seeing their actual pet instead of silently reverting to the default.
+LEGACY_PET_MAP = {"black-cat": "tuxedo", "calico": "cat"}
 
 
 async def handle_update_my_pet(request: web.Request) -> web.Response:

--- a/dashboard/src/components/PetCompanion.tsx
+++ b/dashboard/src/components/PetCompanion.tsx
@@ -438,12 +438,15 @@ export const PETS = [
 ] as const;
 
 const DEFAULT_PET = { pet_id: "tabby", visible: true, animated: true };
+// Retired pets map to their closest successor so a saved preference never silently reverts to the default.
+const LEGACY_PETS: Record<string, string> = { "black-cat": "tuxedo", calico: "cat" };
+const resolvePetId = (petId: string) => LEGACY_PETS[petId] ?? petId;
 type PetState = "idle" | "working" | "listening" | "completed" | "attention";
 
 export function PetSprite({ petId, size = 40, state = "idle", animated = false }: {
   petId: string; size?: number; state?: PetState; animated?: boolean;
 }) {
-  const pet = PETS.find((p) => p.id === petId) ?? PETS[0];
+  const pet = PETS.find((p) => p.id === resolvePetId(petId)) ?? PETS[0];
   const art = spriteArt[pet.id];
   const pixels: string[] = art ? art.rows : [...silhouettes[pet.kind as keyof typeof silhouettes]];
   if (pet.id === "dachshund") {
@@ -579,7 +582,7 @@ export function PetSettingsProvider({ children }: { children: React.ReactNode })
 }
 
 function PetPicker({ initial, onSaved }: { initial: typeof DEFAULT_PET; onSaved: () => void }) {
-  const [draft, setDraft] = useState(initial);
+  const [draft, setDraft] = useState({ ...initial, pet_id: resolvePetId(initial.pet_id) });
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState("");
   // Ignore a response if the dialog closed or the authenticated account changed.

--- a/tests/test_pet_preferences.py
+++ b/tests/test_pet_preferences.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from api.governance_routes import VALID_PETS, handle_update_my_pet
+from api.governance_routes import LEGACY_PET_MAP, VALID_PETS, handle_get_me, handle_update_my_pet
 
 
 class Request(dict):
@@ -79,3 +79,42 @@ def test_frontend_pet_catalog_matches_api():
 
     source = (Path(__file__).parents[1] / "dashboard/src/components/PetCompanion.tsx").read_text()
     assert set(re.findall(r'\{ id: "([a-z-]+)", name:', source)) == set(VALID_PETS)
+
+
+def test_legacy_pet_map_targets_current_catalog():
+    assert set(LEGACY_PET_MAP.values()) <= set(VALID_PETS)
+    assert not set(LEGACY_PET_MAP) & set(VALID_PETS)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("legacy,successor", sorted(LEGACY_PET_MAP.items()))
+async def test_me_migrates_retired_pet_to_successor(legacy, successor):
+    db = MagicMock()
+    db.users.find_one = AsyncMock(return_value={
+        "email": "alice@example.com",
+        "pet_preference": {"pet_id": legacy, "visible": True, "animated": False},
+    })
+    db.users.update_one = AsyncMock(return_value=MagicMock(matched_count=1))
+    with patch("api.governance_routes.get_db", return_value=db):
+        response = await handle_get_me(Request(None))
+    assert response.status == 200
+    body = json.loads(response.body)
+    assert body["pet_preference"] == {"pet_id": successor, "visible": True, "animated": False}
+    args = db.users.update_one.call_args.args
+    assert args[0] == {"email": "alice@example.com"}
+    assert args[1]["$set"]["pet_preference"]["pet_id"] == successor
+
+
+@pytest.mark.asyncio
+async def test_me_leaves_current_pet_untouched():
+    db = MagicMock()
+    db.users.find_one = AsyncMock(return_value={
+        "email": "alice@example.com",
+        "pet_preference": {"pet_id": "duck", "visible": True, "animated": True},
+    })
+    db.users.update_one = AsyncMock()
+    with patch("api.governance_routes.get_db", return_value=db):
+        response = await handle_get_me(Request(None))
+    assert response.status == 200
+    assert json.loads(response.body)["pet_preference"]["pet_id"] == "duck"
+    db.users.update_one.assert_not_called()


### PR DESCRIPTION
## Summary
- Users who picked a pet that was later removed from the catalog (`calico` in #173, `black-cat` in #172) were silently shown the default **Tabby** everywhere in Loma instead of their actual pet. `rajat@plotline.so` currently has `calico` saved in the prod DB and sees a Tabby today.
- Retired pet ids now map to their designed successor (`calico` -> `cat`, `black-cat` -> `tuxedo`) on both the backend and the frontend, and the stored preference self-heals.

## Context
Reported on the taskboard: "when a new pet is selected, it is not showing as the actual pet." Root cause: PRs #172/#173 removed pets from the catalog without migrating saved `pet_preference` values; `PetSprite` falls back to `PETS[0]` (Tabby) for unknown ids, and the picker highlights nothing.

## Changes
- `api/governance_routes.py` - add `LEGACY_PET_MAP`; `GET /api/governance/me` migrates a retired `pet_id` to its successor and persists it back (self-healing, no separate migration script needed).
- `dashboard/src/components/PetCompanion.tsx` - `resolvePetId()` applies the same map in `PetSprite` (sprite rendering) and in the picker draft (correct highlight + valid id on save).
- `tests/test_pet_preferences.py` - tests for the `/me` migration, no-op for current pets, and that the map targets only the live catalog.

## Testing
- `python -m pytest tests/test_pet_preferences.py -q`: **35 passed**.
- Dashboard `tsc --noEmit`: passed.
- Browser (isolated local stack, throwaway DB, real login): seeded the user with `pet_preference.pet_id = "calico"`.
  - **Before fix**: companion rendered `data-pet="tabby"`, picker highlighted nothing.
  - **After fix**: `/me` returns `cat`, companion renders the orange Cat, DB is healed to `cat`, picker highlights **Cat**. Selecting and saving **Koala** afterwards still works end-to-end.

| Before (calico renders as Tabby) | After (renders as Cat) | Picker highlight | Normal flow still works |
|---|---|---|---|
| ![before](https://cdn.plotline.so/loma-images/legacy-pet-fix-pet8-calico-renders-as.png) | ![after](https://cdn.plotline.so/loma-images/legacy-pet-fix-fix2-sprite-zoom.png) | ![picker](https://cdn.plotline.so/loma-images/legacy-pet-fix-fix3-picker-highlight.png) | ![koala](https://cdn.plotline.so/loma-images/legacy-pet-fix-fix4-koala-saved.png) |

## Notes
- This PR was generated by the Plotline IE Bot based on the request above
- Please review carefully before merging
- Note for future pet-catalog PRs (incl. #174): when removing a pet, add its id to `LEGACY_PET_MAP`.
