### PR TITLE
feat: attach any file extension across all composers (drag-drop + paste)

### DIFF
--- a/dashboard/src/components/ChatPanel.tsx
+++ b/dashboard/src/components/ChatPanel.tsx
@@ -7,10 +7,11 @@ import { useAgentModels } from "@/hooks/useAgentModels";
 import { useAgentIdentities } from "@/hooks/useAgentIdentities";
 import { AgentPicker } from "@/components/composer/AgentPicker";
 import { useToolsPicker } from "@/hooks/useToolsPicker";
-import { filesToChatFiles } from "@/lib/chatFiles";
+import { filesToChatFiles, filesFromClipboard } from "@/lib/chatFiles";
 import { ModelPicker } from "./composer/ModelPicker";
 import { ToolsPicker } from "./composer/ToolsPicker";
 import { PendingFilesStrip } from "./composer/PendingFilesStrip";
+import { useFileDrop } from "./composer/useFileDrop";
 import { DictationButton, appendDictation } from "./composer/DictationButton";
 import { streamChat, fetchConversation, injectMessage, interruptAgent, basePath } from "../lib/api";
 import type { ChatEvent, ChatFile, ChatMessage, ClarifyQuestion, Turn, PersistedArtifact } from "../lib/api";
@@ -601,7 +602,6 @@ export default function ChatPanel({
   const [streamElapsedSeconds, setStreamElapsedSeconds] = useState(0);
   const [isRecovering, setIsRecovering] = useState(false);
   const [pendingFiles, setPendingFiles] = useState<ChatFile[]>(initialFiles || []);
-  const [isDragOver, setIsDragOver] = useState(false);
   const [expandedImage, setExpandedImage] = useState<string | null>(null);
   const [accountInfo, setAccountInfo] = useState<{
     account_type?: "round_robin";
@@ -1312,59 +1312,23 @@ export default function ChatPanel({
 
   const handlePaste = useCallback(
     (e: React.ClipboardEvent) => {
-      const items = e.clipboardData?.items;
-      if (!items) return;
-
-      const imageFiles: File[] = [];
-      for (let i = 0; i < items.length; i++) {
-        const item = items[i];
-        if (item.kind === "file" && item.type.startsWith("image/")) {
-          const file = item.getAsFile();
-          if (file) {
-            const ext = file.type.split("/")[1] || "png";
-            const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-            const named = new File([file], `clipboard-${timestamp}.${ext}`, {
-              type: file.type,
-            });
-            imageFiles.push(named);
-          }
-        }
-      }
-
-      if (imageFiles.length > 0) {
+      const pasted = filesFromClipboard(e.clipboardData);
+      if (pasted.length > 0) {
         e.preventDefault();
-        addFiles(imageFiles);
+        addFiles(pasted);
       }
     },
     [addFiles],
   );
 
-  const handleDragOver = (e: React.DragEvent) => {
-    e.preventDefault();
-    setIsDragOver(true);
-  };
-
-  const handleDragLeave = (e: React.DragEvent) => {
-    e.preventDefault();
-    setIsDragOver(false);
-  };
-
-  const handleDrop = (e: React.DragEvent) => {
-    e.preventDefault();
-    setIsDragOver(false);
-    if (e.dataTransfer.files.length > 0) {
-      addFiles(e.dataTransfer.files);
-    }
-  };
+  const { isDragOver, dropHandlers } = useFileDrop(addFiles);
 
   const isEmptyState = items.length === 0 && !isStreaming;
 
   return (
     <div
       className="flex flex-col h-full"
-      onDragOver={handleDragOver}
-      onDragLeave={handleDragLeave}
-      onDrop={handleDrop}
+      {...dropHandlers}
     >
       {/* Lightbox overlay */}
       {expandedImage && (

--- a/dashboard/src/components/composer/useFileDrop.ts
+++ b/dashboard/src/components/composer/useFileDrop.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { useCallback, useState, type DragEvent } from "react";
+
+export interface FileDropHandlers {
+  onDragOver: (e: DragEvent) => void;
+  onDragLeave: (e: DragEvent) => void;
+  onDrop: (e: DragEvent) => void;
+}
+
+/**
+ * Shared drag-and-drop wiring for composer surfaces (chat + tasks quick-add).
+ *
+ * Returns `isDragOver` (for rendering a drop overlay) and the drag handlers to
+ * spread onto the drop target. Files of any type are forwarded to `onFiles`;
+ * the composer's own handler decides how to convert/attach them. Centralising
+ * this keeps drop behaviour identical everywhere a composer is used.
+ */
+export function useFileDrop(onFiles: (files: FileList | File[]) => void): {
+  isDragOver: boolean;
+  dropHandlers: FileDropHandlers;
+} {
+  const [isDragOver, setIsDragOver] = useState(false);
+
+  const isFileDrag = (e: DragEvent) => {
+    const types = e.dataTransfer?.types;
+    // Some browsers report an empty list mid-drag — treat that as "maybe files".
+    return !types || types.length === 0 || Array.from(types).includes("Files");
+  };
+
+  const onDragOver = useCallback((e: DragEvent) => {
+    if (!isFileDrag(e)) return;
+    e.preventDefault();
+    setIsDragOver(true);
+  }, []);
+
+  const onDragLeave = useCallback((e: DragEvent) => {
+    e.preventDefault();
+    setIsDragOver(false);
+  }, []);
+
+  const onDrop = useCallback(
+    (e: DragEvent) => {
+      e.preventDefault();
+      setIsDragOver(false);
+      if (e.dataTransfer?.files?.length) onFiles(e.dataTransfer.files);
+    },
+    [onFiles],
+  );
+
+  return { isDragOver, dropHandlers: { onDragOver, onDragLeave, onDrop } };
+}

--- a/dashboard/src/components/tasks/QuickAddTask.tsx
+++ b/dashboard/src/components/tasks/QuickAddTask.tsx
@@ -1,17 +1,18 @@
 "use client";
 
 import { useRef, useState } from "react";
-import { RiSendPlaneLine, RiLoader4Line, RiAttachmentLine } from "@remixicon/react";
+import { RiSendPlaneLine, RiLoader4Line, RiAttachmentLine, RiUploadLine } from "@remixicon/react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { createTask, type ChatFile } from "@/lib/api";
-import { filesToChatFiles } from "@/lib/chatFiles";
+import { filesToChatFiles, filesFromClipboard } from "@/lib/chatFiles";
 import { useAgentModels } from "@/hooks/useAgentModels";
 import { useToolsPicker } from "@/hooks/useToolsPicker";
 import { ModelPicker } from "@/components/composer/ModelPicker";
 import { ToolsPicker } from "@/components/composer/ToolsPicker";
 import { PendingFilesStrip } from "@/components/composer/PendingFilesStrip";
 import { DictationButton, appendDictation } from "@/components/composer/DictationButton";
+import { useFileDrop } from "@/components/composer/useFileDrop";
 import { cn } from "@/lib/utils";
 
 interface QuickAddTaskProps {
@@ -51,6 +52,8 @@ export function QuickAddTask({ onAdded }: QuickAddTaskProps) {
     if (rejected.length) console.warn("Unsupported files skipped:", rejected);
   };
 
+  const { isDragOver, dropHandlers } = useFileDrop((f) => void addFiles(f));
+
   const submit = async () => {
     const prompt = value.trim();
     if ((!prompt && files.length === 0) || busy) return;
@@ -76,7 +79,18 @@ export function QuickAddTask({ onAdded }: QuickAddTaskProps) {
   };
 
   return (
-    <div className="shrink-0 border-t border-border bg-background px-3 pt-2 pb-2">
+    <div
+      className="relative shrink-0 border-t border-border bg-background px-3 pt-2 pb-2"
+      {...dropHandlers}
+    >
+      {isDragOver && (
+        <div className="absolute inset-0 z-50 flex items-center justify-center rounded-xl border-2 border-dashed border-brand-400 bg-brand-50/80">
+          <div className="flex items-center gap-2 text-[13px] font-medium text-brand-600">
+            <RiUploadLine size={20} />
+            Drop files here
+          </div>
+        </div>
+      )}
       <input
         ref={fileInputRef}
         type="file"
@@ -105,7 +119,7 @@ export function QuickAddTask({ onAdded }: QuickAddTaskProps) {
             }
           }}
           onPaste={(e) => {
-            const pasted = Array.from(e.clipboardData?.files ?? []);
+            const pasted = filesFromClipboard(e.clipboardData);
             if (pasted.length) {
               e.preventDefault();
               void addFiles(pasted);

--- a/dashboard/src/lib/chatFiles.ts
+++ b/dashboard/src/lib/chatFiles.ts
@@ -11,47 +11,50 @@ const TEXT_EXTENSIONS = new Set([
   "txt", "csv", "json", "py", "md", "js", "ts", "tsx", "jsx", "yml", "yaml",
   "xml", "html", "css", "log", "sh", "sql", "env", "cfg", "ini", "toml",
 ]);
-const BINARY_EXTENSIONS = new Set([
-  "xlsx", "xlsm", "xls", "pdf", "docx", "pptx",
-  "zip", "tar", "gz", "7z", "rar", "tgz",       // archives
-]);
 
-/** Read a File into a ChatFile object */
+/** Base64-encode a File's raw bytes. */
+async function fileToBase64(file: File): Promise<string> {
+  const buffer = await file.arrayBuffer();
+  return btoa(
+    new Uint8Array(buffer).reduce((data, byte) => data + String.fromCharCode(byte), "")
+  );
+}
+
+/**
+ * Read a File into a ChatFile object.
+ *
+ * Any file extension is accepted — images and known text formats get their
+ * dedicated handling, and everything else (documents, archives, or any
+ * unrecognized extension) is attached as a binary blob. The backend writes
+ * binary attachments to a temp file with their original extension, so the
+ * agent can work with arbitrary file types.
+ */
 export async function readFileAsChatFile(file: File): Promise<ChatFile | null> {
   if (file.size > MAX_FILE_SIZE) return null;
 
   const ext = file.name.split(".").pop()?.toLowerCase() || "";
   const isImage = IMAGE_TYPES.has(file.type);
   const isText = TEXT_EXTENSIONS.has(ext) || file.type.startsWith("text/");
-  const isBinary = BINARY_EXTENSIONS.has(ext);
-
-  if (!isImage && !isText && !isBinary) {
-    console.warn(`Unsupported file type: ${file.name} (${file.type})`);
-    return null;
-  }
 
   if (isImage) {
-    const buffer = await file.arrayBuffer();
-    const base64 = btoa(
-      new Uint8Array(buffer).reduce((data, byte) => data + String.fromCharCode(byte), "")
-    );
-    return { name: file.name, mimetype: file.type, type: "image", data: base64 };
+    return { name: file.name, mimetype: file.type, type: "image", data: await fileToBase64(file) };
   }
 
-  if (isBinary) {
-    const buffer = await file.arrayBuffer();
-    const base64 = btoa(
-      new Uint8Array(buffer).reduce((data, byte) => data + String.fromCharCode(byte), "")
-    );
-    return { name: file.name, mimetype: file.type || "application/octet-stream", type: "binary", data: base64 };
+  if (isText) {
+    let text = await file.text();
+    if (text.length > MAX_TEXT_SIZE) {
+      text = text.slice(0, MAX_TEXT_SIZE) + `\n\n... [truncated, file was ${(file.size / 1024).toFixed(0)} KB]`;
+    }
+    return { name: file.name, mimetype: file.type || "text/plain", type: "text", data: text };
   }
 
-  // Text file
-  let text = await file.text();
-  if (text.length > MAX_TEXT_SIZE) {
-    text = text.slice(0, MAX_TEXT_SIZE) + `\n\n... [truncated, file was ${(file.size / 1024).toFixed(0)} KB]`;
-  }
-  return { name: file.name, mimetype: file.type || "text/plain", type: "text", data: text };
+  // Any other file type — attach as a binary blob (no allow-list gate).
+  return {
+    name: file.name,
+    mimetype: file.type || "application/octet-stream",
+    type: "binary",
+    data: await fileToBase64(file),
+  };
 }
 
 /** Convert a FileList/array into ChatFiles, reporting rejects by name. */
@@ -70,4 +73,29 @@ export async function filesToChatFiles(
     else rejected.push(f.name);
   }
   return { files, rejected };
+}
+
+/**
+ * Extract every file from a clipboard paste (any type, not just images).
+ * Clipboard files that arrive without a usable name (e.g. screenshots) are
+ * given a timestamped name so they are distinguishable. Non-file clipboard
+ * items (plain text, html) are ignored, so normal text paste is untouched.
+ */
+export function filesFromClipboard(clipboardData: DataTransfer | null): File[] {
+  const items = clipboardData?.items;
+  if (!items) return [];
+  const out: File[] = [];
+  for (const item of Array.from(items)) {
+    if (item.kind !== "file") continue;
+    const file = item.getAsFile();
+    if (!file) continue;
+    if (!file.name || file.name.toLowerCase() === "image.png" || file.name.toLowerCase() === "blob") {
+      const ext = (file.type.split("/")[1] || "bin").split("+")[0];
+      const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+      out.push(new File([file], `clipboard-${timestamp}.${ext}`, { type: file.type }));
+    } else {
+      out.push(file);
+    }
+  }
+  return out;
 }


### PR DESCRIPTION
## Summary
- **Any file extension can now be attached anywhere.** The composer previously rejected any file whose extension was not in a hard-coded allow-list, so dragging (for example) a `.xyz`, `.heic`, `.dmg`, or `.mp4` file did nothing. Unknown types now attach as a binary blob. The backend already materialises binary attachments to a temp file with their original extension, so no server change was needed.
- **Standardised the chat/text-input file handling across all pages.** Added a shared `useFileDrop()` hook and a `filesFromClipboard()` helper, reused by both composer surfaces.

## Context
Reported by Erik: "Seems like you can't drag and drop files into a chat." Root cause: `readFileAsChatFile()` in `chatFiles.ts` silently returned `null` for any extension outside its `IMAGE`/`TEXT`/`BINARY` allow-lists.

## Changes
- `dashboard/src/lib/chatFiles.ts` — `readFileAsChatFile` now falls back to a binary attachment for any non-image/non-text file instead of rejecting it (removes the allow-list gate). Added `filesFromClipboard()` (extracts every pasted file, not just images; ignores non-file clipboard items so plain-text paste is untouched).
- `dashboard/src/components/composer/useFileDrop.ts` — **new** shared drag-and-drop hook (`isDragOver` + drag handlers), so drop behaviour is identical everywhere.
- `dashboard/src/components/ChatPanel.tsx` — use the shared `useFileDrop` hook (removes duplicated inline drag handlers/state) and broaden paste to any file type via `filesFromClipboard`.
- `dashboard/src/components/tasks/QuickAddTask.tsx` — adopt the shared `useFileDrop` hook (this composer had **no** drag-and-drop before) and use `filesFromClipboard` for paste.

## Testing
Verified in a real browser (local Loma stack, throwaway DB) with Playwright-driven drag-and-drop:

| Surface | File dropped | Result |
|---|---|---|
| `/chat` (ChatPanel) | `chatpanel-report.xyz` | attached |
| Tasks board (QuickAddTask) | `erik-report.xyz` | attached |
| Tasks board (QuickAddTask) | `photo.heic` | attached |
| Tasks board (QuickAddTask) | `pic.png` | attached (thumbnail) |
| `/tasks` (QuickAddTask) | `tasks-file.dat` | attached |

All previously-rejected extensions now attach. `npx tsc --noEmit` passes (0 errors); `eslint` on the changed files reports 0 errors (only pre-existing warnings).

## Notes
- This PR was generated by the Plotline IE Bot based on the request above.
- Please review carefully before merging.
