### PR TITLE
fix: prevent chat freezes on incomplete streamed Markdown headings

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --port 3001",
     "build": "next build",
     "start": "next start --port 3001",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test:markdown": "node --test tests/markdown-blocks.test.cjs"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/dashboard/src/components/MarkdownContent.tsx
+++ b/dashboard/src/components/MarkdownContent.tsx
@@ -277,6 +277,8 @@ interface Block {
   rows?: string[][];
 }
 
+const HEADING_PATTERN = /^(#{1,6})\s+(.+)/;
+
 function parseBlocks(md: string): Block[] {
   const lines = md.split("\n");
   const blocks: Block[] = [];
@@ -301,7 +303,7 @@ function parseBlocks(md: string): Block[] {
     }
 
     // Heading
-    const headingMatch = line.match(/^(#{1,6})\s+(.+)/);
+    const headingMatch = line.match(HEADING_PATTERN);
     if (headingMatch) {
       blocks.push({
         type: "heading",
@@ -365,7 +367,7 @@ function parseBlocks(md: string): Block[] {
       i < lines.length &&
       lines[i].trim() !== "" &&
       !lines[i].match(/^```/) &&
-      !lines[i].match(/^#{1,6}\s/) &&
+      !HEADING_PATTERN.test(lines[i]) &&
       !lines[i].match(/^[\-•]\s+/) &&
       !lines[i].match(/^\d+\.\s+/) &&
       // Don't swallow table rows into paragraphs
@@ -376,6 +378,10 @@ function parseBlocks(md: string): Block[] {
     }
     if (paraLines.length > 0) {
       blocks.push({ type: "paragraph", text: paraLines.join("\n") });
+    } else {
+      // Always advance if block detection and paragraph boundaries disagree.
+      blocks.push({ type: "paragraph", text: line });
+      i++;
     }
   }
 

--- a/dashboard/tests/markdown-blocks.test.cjs
+++ b/dashboard/tests/markdown-blocks.test.cjs
@@ -1,0 +1,71 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+const ts = require('typescript');
+
+// Exercise the real parser without exporting an internal implementation detail.
+const source = fs.readFileSync(
+  path.join(__dirname, '../src/components/MarkdownContent.tsx'), 'utf8',
+);
+const { outputText } = ts.transpileModule(source + '\nexport { parseBlocks };', {
+  compilerOptions: { module: ts.ModuleKind.CommonJS, jsx: ts.JsxEmit.ReactJSX },
+});
+const context = vm.createContext({ exports: {}, require });
+vm.runInContext(outputText, context);
+const parseScript = new vm.Script('exports.parseBlocks(input)');
+function parse(input) {
+  context.input = input;
+  // A synchronous infinite loop cannot be stopped by a test-runner timer.
+  return JSON.parse(JSON.stringify(parseScript.runInContext(context, { timeout: 500 })));
+}
+
+test('incomplete headings remain text and never stall the parser', () => {
+  for (let level = 1; level <= 6; level++) {
+    for (const suffix of ['', ' ', '\t']) {
+      const line = '#'.repeat(level) + suffix;
+      assert.deepEqual(parse(line), [{ type: 'paragraph', text: line }]);
+      assert.deepEqual(parse('Before\n\n' + line + '\n\nAfter'), [
+        { type: 'paragraph', text: 'Before' },
+        { type: 'paragraph', text: line },
+        { type: 'paragraph', text: 'After' },
+      ]);
+    }
+  }
+  assert.deepEqual(parse('Before\n## '), [{ type: 'paragraph', text: 'Before\n## ' }]);
+});
+
+test('complete headings retain all six levels', () => {
+  for (let level = 1; level <= 6; level++) {
+    assert.deepEqual(parse('#'.repeat(level) + ' Title'), [
+      { type: 'heading', level, text: 'Title' },
+    ]);
+  }
+  assert.deepEqual(parse('####### Title'), [{ type: 'paragraph', text: '####### Title' }]);
+});
+
+test('ordinary block formatting is preserved', () => {
+  assert.deepEqual(parse('Hello\nworld\n\n## Title\n- One\n- Two\n1. First\n```js\nx\n```'), [
+    { type: 'paragraph', text: 'Hello\nworld' },
+    { type: 'heading', level: 2, text: 'Title' },
+    { type: 'ul', items: ['One', 'Two'] },
+    { type: 'ol', items: ['First'] },
+    { type: 'code', lang: 'js', code: 'x' },
+  ]);
+  assert.deepEqual(parse('| A | B |\n| :--- | ---: |\n| a | b |'), [
+    { type: 'table', headers: ['A', 'B'], alignments: ['left', 'right'], rows: [['a', 'b']] },
+  ]);
+  assert.deepEqual(parse(''), []);
+  assert.deepEqual(parse('```js\nx'), [{ type: 'code', lang: 'js', code: 'x' }]);
+});
+
+test('every streaming prefix of mixed Markdown terminates', () => {
+  const message = [
+    '# Summary', 'Paragraph with **bold**, `code`, and [link](https://example.com).',
+    '', '## 2. Agents', '- First', '• Second', '1. Ordered', '',
+    '### Details', '| A | B |', '| :--- | ---: |', '| a | b |', '',
+    '```js', 'const x = 1;', '```', '#### Four', '##### Five', '###### Six',
+  ].join('\n');
+  for (let i = 0; i <= message.length; i++) parse(message.slice(0, i));
+});


### PR DESCRIPTION
## Summary
- Use the same heading pattern for heading detection and paragraph boundaries.
- Preserve incomplete streamed headings as plain text until their content arrives.
- Add a defensive fallback that consumes a line if block detection and paragraph boundaries ever disagree.

## Cause
For `## `, heading detection requires content (`(.+)`) but the old paragraph boundary only required whitespace. Neither branch consumed the line, so `parseBlocks` looped forever on the browser's main thread.

This fixes a reproduced browser-freezing defect that strongly matches the reported incident. Stored conversation logs do not include the exact SSE chunks or a browser trace, so this does not claim every reported freeze had this cause.

## Testing
- `cd dashboard && npm run test:markdown`: all 4 tests pass. Covers incomplete headings at all 6 levels, complete headings, paragraphs, lists, tables, unfinished code fences, and every prefix of mixed Markdown.
- The same tests against the original implementation fail with a bounded VM timeout on incomplete headings and streaming prefixes. A VM timeout ensures the regression test itself cannot hang indefinitely.
- Replayed all **4,307 prefixes** of the affected response: pass. The private conversation content is not committed.
- TypeScript `tsc --noEmit --incremental false`: pass.
- Targeted ESLint: no errors; one pre-existing `no-img-element` warning.
- Booted the backend and dashboard locally against a fresh throwaway DB, with Slack and scheduler disabled. Logged in via local setup-token auth.
- In Chromium, a temporary harness using the actual `MarkdownContent` component remained interactive at `## ` and through **164 successive React prefix renders**. Verified completed headings, lists, code, and tables. Harness and DB removed after verification.
- Local browser validation reused installed dependencies (Next 16.3.4) and disabled webpack's disk cache due host disk pressure; a clean lockfile install/build was not completed. No dependency changes are included.

## Browser screenshots
Synthetic test content only. These show the temporary local harness, not a production conversation.

### Incomplete heading stays responsive
![Incomplete streamed heading and successful responsiveness click](https://cdn.plotline.so/loma-images/5afaf62f825b4010b59dd57d0bb81898.png)

### Completed Markdown renders normally
![Completed heading, list, code, table, and second responsiveness click](https://cdn.plotline.so/loma-images/b5a6db11447b486db634455cac9c81a9.png)

## Notes
Generated by Loma at Shubham's request. Draft for human review; not merged or deployed.
