### PR TITLE
feat: refresh chat titles every five user messages

### DIFF
--- a/observability/observer.py
+++ b/observability/observer.py
@@ -446,22 +446,40 @@ class ConversationObserver:
             prompt = self.metadata.get("prompt", "")
             response_snippet = (final_response or "")[:300]
 
-            title, topic = await asyncio.gather(
-                _generate_title_llm(prompt, response_snippet),
-                _classify_topic_llm(prompt, response_snippet),
-            )
-
-            # Never clobber a user-provided title (rename PATCH / task drafts
-            # set title_edited) — only enrich the topic in that case.
             existing = await self.db.conversations.find_one(
-                {"conversation_id": self.conversation_id}, {"title_edited": 1})
-            update_fields = {"topic": topic}
-            if not (existing or {}).get("title_edited"):
-                update_fields["title"] = title
+                {"conversation_id": self.conversation_id},
+                {"title_edited": 1, "messages.role": 1},
+            )
+            user_message_count = sum(
+                message.get("role") == "user"
+                for message in (existing or {}).get("messages", [])
+            )
+            # Refresh after user messages 1, 6, 11, ...; agent/tool turns don't count.
+            refresh_title = (
+                not (existing or {}).get("title_edited")
+                and user_message_count > 0
+                and (user_message_count - 1) % 5 == 0
+            )
+            title = None
+            if refresh_title:
+                title, topic = await asyncio.gather(
+                    _generate_title_llm(prompt, response_snippet),
+                    _classify_topic_llm(prompt, response_snippet),
+                )
+            else:
+                topic = await _classify_topic_llm(prompt, response_snippet)
+
             await self.db.conversations.update_one(
                 {"conversation_id": self.conversation_id},
-                {"$set": update_fields},
+                {"$set": {"topic": topic}},
             )
+            if refresh_title:
+                # Check at write time too: a rename may happen during the LLM call.
+                await self.db.conversations.update_one(
+                    {"conversation_id": self.conversation_id,
+                     "title_edited": {"$ne": True}},
+                    {"$set": {"title": title}},
+                )
             logger.info("Observability: enrichment complete for %s: title=%r topic=%s",
                          self.conversation_id, title, topic)
         except Exception as e:

--- a/tests/test_title_cadence.py
+++ b/tests/test_title_cadence.py
@@ -1,0 +1,83 @@
+"""Title cadence counts user messages, not agent turns, and preserves renames."""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from observability.observer import ConversationObserver
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("count", range(17))
+async def test_title_refreshes_every_five_user_messages(count):
+    db = MagicMock()
+    db.conversations.find_one = AsyncMock(return_value={
+        "messages": [{"role": role} for _ in range(count)
+                     for role in ("user", "assistant", "tool")],
+    })
+    db.conversations.update_one = AsyncMock()
+    observer = ConversationObserver(db, {"prompt": "latest prompt"}, "chat")
+    observer.turn_offset = 37
+    observer.turn_count = 12
+    with patch("api.routes._generate_title_llm", new_callable=AsyncMock,
+               return_value="Updated title") as generate, patch(
+        "api.routes._classify_topic_llm", new_callable=AsyncMock,
+        return_value="engineering",
+    ) as classify:
+        await observer._run_title_topic_enrichment("reply")
+
+    classify.assert_awaited_once_with("latest prompt", "reply")
+    db.conversations.update_one.assert_any_await(
+        {"conversation_id": "chat"}, {"$set": {"topic": "engineering"}})
+    if count in (1, 6, 11, 16):
+        generate.assert_awaited_once_with("latest prompt", "reply")
+        db.conversations.update_one.assert_any_await(
+            {"conversation_id": "chat", "title_edited": {"$ne": True}},
+            {"$set": {"title": "Updated title"}},
+        )
+    else:
+        generate.assert_not_awaited()
+        assert db.conversations.update_one.await_count == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("existing", [None, {}, {
+    "title_edited": True, "messages": [{"role": "user"}],
+}])
+async def test_manual_titles_and_missing_history_are_not_replaced(existing):
+    db = MagicMock()
+    db.conversations.find_one = AsyncMock(return_value=existing)
+    db.conversations.update_one = AsyncMock()
+    observer = ConversationObserver(db, {"prompt": "prompt"}, "chat")
+    with patch("api.routes._generate_title_llm", new_callable=AsyncMock) as generate, patch(
+        "api.routes._classify_topic_llm", new_callable=AsyncMock,
+        return_value="general",
+    ):
+        await observer._run_title_topic_enrichment("reply")
+    generate.assert_not_awaited()
+    db.conversations.update_one.assert_awaited_once_with(
+        {"conversation_id": "chat"}, {"$set": {"topic": "general"}})
+
+
+@pytest.mark.asyncio
+async def test_rename_during_generation_is_guarded_at_write_time():
+    db = MagicMock()
+    document = {"title": "Auto title", "messages": [{"role": "user"}]}
+    db.conversations.find_one = AsyncMock(side_effect=lambda *args: dict(document))
+
+    async def rename_during_generation(*args):
+        document.update(title="My manual title", title_edited=True)
+        return "Generated title"
+
+    async def update(query, operation):
+        if query.get("title_edited") == {"$ne": True} and document.get("title_edited"):
+            return
+        document.update(operation["$set"])
+
+    db.conversations.update_one = AsyncMock(side_effect=update)
+    observer = ConversationObserver(db, {"prompt": "prompt"}, "chat")
+    with patch("api.routes._generate_title_llm", side_effect=rename_during_generation), patch(
+        "api.routes._classify_topic_llm", new_callable=AsyncMock, return_value="general",
+    ):
+        await observer._run_title_topic_enrichment("reply")
+    assert document["title"] == "My manual title"
+    assert document["topic"] == "general"


### PR DESCRIPTION
## Summary
- Refresh auto-generated chat titles after replies to user messages **1, 6, 11, 16, ...**, keeping them stable between those messages.
- Count stored user messages, not assistant/tool turns. Skip unnecessary title LLM calls; topic classification still runs after every completed response.
- Preserve manually renamed titles, including a rename made while title generation is in progress.

## Testing
- `python -m pytest tests/test_title_cadence.py tests/test_drain.py tests/test_conversation_sharing.py -q`: **44 passed**.
- New cadence tests cover counts 0 through 16, mixed assistant/tool messages, resumed agent turn offsets, missing history, manual titles, and a rename during generation.
- Booted the actual backend and Next.js dashboard on isolated ports against a fresh throwaway MongoDB, with Slack and the scheduler disabled.
- Logged in through the browser's first-admin setup flow. A fixture harness invoked the real observer enrichment method against the test database with deterministic mocked title/topic LLM responses (no live agent conversations). Browser assertions checked the rendered title at user-message counts 1, 2, 5, 6, 10, 11, 16, 17, and 21 (manual rename).
- `git diff --check` passed.

## Browser screenshots
After message 5, the title from message 1 remains:
![Message 5: unchanged title](https://cdn.plotline.so/loma-images/0eef194117964e228a8e6d9e7a13b34e.png)

After message 6, the title refreshes:
![Message 6: refreshed title](https://cdn.plotline.so/loma-images/7c73c1daab0449d8a356024bee21f029.png)

A manual title remains at message 21:
![Manual title preserved](https://cdn.plotline.so/loma-images/5449e5d5864445c38bf4a7c366d504a5.png)

## Notes
- Requested and approved by Shubham in Loma chat.
- Generated by Loma. Draft for human review; not deployed or merged.