### PR TITLE
fix: concise Slack replies and contextual follow-ups

### DIFF
--- a/agent/prompt.py
+++ b/agent/prompt.py
@@ -137,7 +137,11 @@ You are responding in Slack. Use Slack mrkdwn:
 - Use short bullets with `-`.
 - Use backticks for inline code.
 - Avoid Markdown tables and heading markers.
-- Keep responses concise and readable in a thread.
+- Default to 2-3 short lines: answer the question, state the outcome, then stop.
+- Keep investigations thorough internally; do not post investigation narration, evidence dumps, code blocks, or unsolicited next steps/offers by default.
+- Give more detail when explicitly requested, when the requested deliverable requires it (such as a command or code snippet), or when needed to explain a blocker, uncertainty, or important safety warning. Never hide important information just to meet the default length.
+- For follow-ups such as "confirm" or "any update?", use the existing thread context and answer only the latest request. Do not repeat the full investigation or claim fresh verification without checking.
+- These Slack-specific presentation rules take precedence over generic instructions to narrate plans or produce lengthy reports. Still follow required investigation and approval procedures; ask necessary questions concisely.
 """.strip()
 
 

--- a/slack_app/handlers.py
+++ b/slack_app/handlers.py
@@ -270,12 +270,14 @@ def register_handlers(app):
             logger.info("[SLACK] Downloading %d file(s) (%d current, %d from thread)...", len(all_raw_files), len(raw_files), len(thread_raw_files))
             files = await download_slack_files(client.token, all_raw_files)
 
-        # Check if this is a monitored channel — prepend channel context if so
+        # Only new top-level mentions start the channel workflow. Thread replies
+        # already have context and should answer the latest request directly.
         channel_config = await get_channel_config(channel)
         if channel_config:
-            prompt = channel_config["prompt_prefix"] + user_message
+            is_followup = bool(event.get("thread_ts") and thread_ts != event_ts)
+            prompt = user_message if is_followup else channel_config["prompt_prefix"] + user_message
             source = channel_config["source"]
-            logger.info("[SLACK] Monitored channel #%s \u2014 using channel-specific prompt", channel_config["name"])
+            logger.info("[SLACK] Monitored channel #%s, follow-up=%s", channel_config["name"], is_followup)
         else:
             prompt = user_message
             source = "slack_mention"

--- a/tests/test_prompt_settings.py
+++ b/tests/test_prompt_settings.py
@@ -48,3 +48,14 @@ def test_loma_skill_index_cache_appears_in_prompts():
 
     assert "- code-review: Review GitHub pull requests" in pooled_prompt
     assert "- code-review: Review GitHub pull requests" in dashboard_prompt
+
+
+def test_slack_reply_policy_applies_to_direct_and_pooled_prompts_only():
+    for prompt in (build_system_prompt("slack"), build_pooled_system_prompt()):
+        assert "Default to 2-3 short lines" in prompt
+        assert "Keep investigations thorough internally" in prompt
+        assert "when explicitly requested" in prompt
+        assert "Never hide important information" in prompt
+        assert "use the existing thread context" in prompt
+        assert "take precedence over generic instructions" in prompt
+    assert "Default to 2-3 short lines" not in build_system_prompt("dashboard")

--- a/tests/test_slack_mention_prompts.py
+++ b/tests/test_slack_mention_prompts.py
@@ -1,0 +1,41 @@
+"""Exercise real mention routing without sending Slack messages or running agents."""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from slack_app.handlers import register_handlers
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("message", ["confirm", "any update?", "investigate this failure", "explain in detail with code"])
+@pytest.mark.parametrize("monitored", [True, False])
+@pytest.mark.parametrize("thread_ts", [None, "100.000001", "101.000001"])
+async def test_mention_prompt_routing(message, monitored, thread_ts):
+    callbacks = {}
+    app = MagicMock()
+
+    def register(name):
+        def decorate(fn):
+            callbacks[name] = fn
+            return fn
+        return decorate
+
+    app.event.side_effect = register
+    register_handlers(app)
+    config = {"prompt_prefix": "RUN FULL TRIAGE: ", "source": "slack_bugs", "name": "bugs", "flow_id": "flow-1"} if monitored else None
+    event = {"channel": "C1", "user": "U1", "text": f"<@UBOT> {message}", "ts": "101.000001"}
+    if thread_ts:
+        event["thread_ts"] = thread_ts
+    with patch("slack_app.handlers.get_channel_config", AsyncMock(return_value=config)), \
+         patch("slack_app.handlers.get_thread_context", AsyncMock(return_value=("Earlier investigation", []))) as context, \
+         patch("slack_app.handlers._handle_agent_request", AsyncMock()) as run:
+        await callbacks["app_mention"](event, MagicMock(), AsyncMock())
+
+    args = run.await_args.args
+    followup = thread_ts is not None and thread_ts != event["ts"]
+    expected = "RUN FULL TRIAGE: " + message if monitored and not followup else message
+    assert args[4] == expected
+    assert args[5] == ("Earlier investigation" if thread_ts else "")
+    assert args[7] == ("slack_bugs" if monitored else "slack_mention")
+    assert run.await_args.kwargs["flow_id"] == ("flow-1" if monitored else None)
+    assert context.await_count == bool(thread_ts)


### PR DESCRIPTION
## Summary
- Default Slack answers to 2-3 short lines, with detailed investigation kept internal. Allow requested detail, code deliverables, necessary approvals, blockers and safety warnings.
- Answer monitored-channel thread mentions using the latest request and existing thread context instead of prepending the full channel workflow again.
- Keep top-level workflows, attribution, dashboard formatting and Slack's existing transport limit unchanged.

## Testing
- **75 tests passed**: prompt settings, mention routing, Slack utils/flows/task capture and drain tests.
- Parameterized routing coverage: confirmations, status checks, debugging and explicit detail requests; monitored/unmonitored channels; new messages, replies and root messages carrying their own thread timestamp.
- `git diff --check` passed.
- Booted isolated backend and dashboard with a throwaway database, Slack and scheduler disabled. Backend health passed; signed in through the browser with local first-admin setup.
- Browser screenshot below is an app smoke test, not evidence of live Slack response quality. No live Slack messages or model-output evals were run. Brevity is prompt-driven, not a hard output cap.
- First browser login hit a CSRF initialization race; retry after page initialization succeeded. No unrelated auth changes made.

### Local browser verification
![Logged-in isolated Loma dashboard](https://cdn.plotline.so/loma-images/20fcff721198416eaf585b47c395d0a5.png)

## Notes
AI-generated draft PR requested by Adarsh. Please review before merging. Follow-up requests can still explicitly ask for a new investigation; they no longer automatically rerun channel triage.
